### PR TITLE
chore: add helm chart releaser workflow

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -1,0 +1,39 @@
+name: Release - Helm Charts
+
+on:
+  push:
+    paths:
+      - 'charts/**'
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+
+    steps:
+      # fetch-depth: 0 is required to determine differences in chart(s)
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.1
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
add workflow to release Helm Charts. 

Due to Helm Chart releaser limitation we might need to touch `Chart.yaml` file for each chart, as the chart releaser action reacts on git history. Currently there is only a singe commit for each `Chart.yaml` file. A good starting point could be adjusting [`home`](https://github.com/eclipse-tractusx/tractusx-edc/blob/9690c0c0aa39b6707b9d62dba2e51c1d97050afa/charts/edc-controlplane/Chart.yaml#L6).