### PR TITLE
docs: create decision record about the release process

### DIFF
--- a/docs/development/decision-records/2023-02-09-release-process/README.md
+++ b/docs/development/decision-records/2023-02-09-release-process/README.md
@@ -9,7 +9,7 @@ To improve stability, reproducibility and maintainability of releases, tractusx-
   is a clear and concise reason to do so.
 - slightly update branching model
 - if possible, bugs/defects should be fixed on `develop` and be backported to the respective `hotfix/` branch
-- Catena-X/Tractus-X will only provide hotfixes for critical security bugs as defined by the committers for the
+- only hotfixes for critical security bugs will be provided as defined by the committers for the
   currently released version. Nothing else.
 - feature development happens _in developers' forks only_ to keep the Git reflog of the `origin` clean.
 
@@ -52,6 +52,7 @@ part of the release process. For reference_:
 - Creating tags using GitHub's
   API: https://github.com/eclipse-edc/Connector/blob/b24a5cacbc9fcabdfd8020d779399b3e56856661/.github/workflows/release-edc.yml#L21 (
   example)
+- Create GitHub Release: https://github.com/eclipse-edc/Connector/blob/b24a5cacbc9fcabdfd8020d779399b3e56856661/.github/workflows/release-edc.yml#L56 (example)
 
 Once a release is created, the EDC upstream version must not change anymore, unless there is good reason to do so, for
 example, a defect, that needs to be fixed upstream. At that point a decision can also be made to employ a cherry-pick model, in case the
@@ -91,8 +92,7 @@ readability and make a release's history readily apparent.
 
 ### Nightly builds
 
-Nightly builds are generated according to a fixed schedule (as suggested
-in [this Jira issue](https://jira.catena-x.net/browse/A1IDSC-408)). Upstream EDC will soon begin to publish nightly
+Nightly builds are generated according to a fixed schedule. Upstream EDC will soon begin to publish nightly
 builds as actual releases (as opposed to: snapshots) to a separate OSSRH-operated repository (see
 [this EDC decision record](https://github.com/eclipse-edc/Connector/tree/main/docs/developer/decision-records/2023-02-10-nightly-builds)).
 
@@ -111,7 +111,7 @@ current date, we can start the nightly. If the EDC nightly doesn't appear within
 - All artifacts (docker images, helm charts, Maven artifacts) should be published to well-known and publicly accessible
   locations such as MavenCentral, DockerHub, etc. The GitHub Packages repository is only accessible to authenticated
   users.
-- When and if Tractus-X becomes an Eclipse project, we'll have to adopt the Eclipse Foundation's publishing guidelines,
+- When the project was migrated to be an Eclipse project, we'll have to adopt the Eclipse Foundation's publishing guidelines,
   which prescribes the use of Jenkins for publishing to MavenCentral and OSSRH.
 - Typically, GitHub Actions should perform all verification tasks, running tests, etc. and Jenkins' only purpose is to
   publish.

--- a/docs/development/decision-records/2023-02-09-release-process/README.md
+++ b/docs/development/decision-records/2023-02-09-release-process/README.md
@@ -97,7 +97,8 @@ builds as actual releases (as opposed to: snapshots) to a separate OSSRH-operate
 [this EDC decision record](https://github.com/eclipse-edc/Connector/tree/main/docs/developer/decision-records/2023-02-10-nightly-builds)).
 
 Unfortunately there is no way to automatically trigger the tractusx-edc build whenever a new EDC nightly is
-created. The most reliable method is to periodically query for the latest EDC nightly, e.g. leveraging GitHub's `dependabot` feature, or using the method highlighted in the aforementioned Jira issue:
+created. The most reliable method is to periodically query for the latest EDC nightly, e.g. leveraging GitHub's
+`dependabot` feature, or using the following `curl` command:
 
 ```shell
 curl <OSSHR_RELEASES_REPO_URL>/org/eclipse/edc/connector-core/maven-metadata.xml | xmllint --xpath "//metadata/versioning/versions/version[last()]" -

--- a/docs/development/decision-records/2023-02-09-release-process/README.md
+++ b/docs/development/decision-records/2023-02-09-release-process/README.md
@@ -1,0 +1,117 @@
+# Release process of tractusx-edc
+
+## Decision
+
+To improve stability, reproducibility and maintainability of releases, tractusx-edc will undergo the following changes:
+
+- use EDC `SNAPSHOT` builds during development
+- use release versions of EDC in releases. Release branches must not change upstream dependency versions, unless there
+  is a clear and concise reason to do so.
+- slightly update branching model
+- if possible, bugs/defects should be fixed on `develop` and be backported to the respective `hotfix/` branch
+- Catena-X/Tractus-X will only provide hotfixes for critical security bugs as defined by the committers for the
+  currently released version. Nothing else.
+- feature development happens _in developers' forks only_ to keep the Git reflog of the `origin` clean.
+
+## Rationale
+
+Having releases depend on snapshot versions of upstream projects, such as EDC, is inherently dangerous, particularly
+when that dependency has not yet reached a final state and breaking changes are to be expected. Most problems will stem
+from breaking changes, such as Java SPIs, APIs and changes in service contracts.
+
+Up until now, the only way out was cherry-picking, which is extremely cumbersome and error-prone, and requires a
+parallel build pipeline to publish the cherry-picked artifacts of EDC (and potentially others). With the approach
+presented here, cherry-picking is still an option, but there are easier alternatives to it. 
+
+Every release version published by tractusx-edc must be reproducible at any time.
+
+## Approach
+
+### Use EDC `SNAPSHOT` versions during development
+
+During feature development we only use `-SNAPSHOT` versions of EDC packages. It is assumed that when the build breaks
+due to changes in upstream, the fix can be done quickly and easily, much more so than working off technical
+debt that would otherwise accumulate over several months. Builds on `develop` are therefore _not repeatable_, but that
+downside is easily offset by the tighter alignment with and smaller technical debt and integration pain with the
+upstream EDC.
+
+### Use release versions of EDC in releases
+
+First, a new branch `releases/X.Y.Z` based off of `develop` is created. This can either be done
+on `HEAD`, or - if desired - on a particular ref. The latter case is relevant if there are already features
+in `develop` that are not scoped for a particular release.
+
+Second, the dependency onto EDC is updated to the most recent build. For example, if a release is
+created on March 27th 2023, the most recent nightly would be `0.0.1-20230326`.
+
+_Updating Gradle files or Maven POMs, creating branches and tags in Git should be automated through GitHub Actions as
+part of the release process. For reference_:
+
+- Modifying and committing files: https://github.com/orgs/community/discussions/26842#discussioncomment-3253612
+- Creating branches: https://github.com/marketplace/actions/create-branch
+- Creating tags using GitHub's
+  API: https://github.com/eclipse-edc/Connector/blob/b24a5cacbc9fcabdfd8020d779399b3e56856661/.github/workflows/release-edc.yml#L21 (
+  example)
+
+Once a release is created, the EDC upstream version must not change anymore, unless there is good reason to do so, for
+example, a defect, that needs to be fixed upstream. At that point a decision can also be made to employ a cherry-pick model, in case the
+upstream's development has progressed to the point of breaking changes.
+
+### Changes to the branching model
+
+Tractusx-edc's branching model is already very close to
+the [GitFlow branching model](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow#:~:text=What%20is%20Gitflow%3F,lived%20branches%20and%20larger%20commits)
+which is good. The following changes need to be made:
+
+- feature development happens in forks only. Thus, `feature/` branches don't exist in the `origin`. This is important
+  when moving to OSS.
+- adhere to GitFlow branch naming conventions, i.e. no `docu`, `tryout_something` branches. Increases readability and
+  clarity, improves tool support.
+
+_Other guidelines w.r.t. the review process, merging etc. will follow in a later DR._
+
+## Further considerations
+
+### A word on Bugfixes/Hotfixes
+
+Once a release is published, for example `0.3.0` it will receive no further development other than hotfixes. Similarly,
+hotfix branches are created based off of the release branch, here `releases/0.3.0`, thus, `hotfix/0.3.1`. From this,
+three scenarios emerge:
+
+1. The actual fix is done on `develop` and can be cherry-picked into the `hotfix/0.3.1` branch. No new commits are
+   made directly in that branch.
+2. The actual fix is done on `develop` and must be manually ported into the `hotfix/0.3.1` branch. One or several new
+   commits are made on `hotfix/0.3.1`. This is needed when cherry-picking is not available due to incompatibilities
+   between `develop` and the hotfix branch due to intermittent changes.
+3. The fix is only relevant for the `0.3.1` hotfix, it is not needed in `develop`. This can happen, when the problem is
+   not present on `develop`, because it was already implicitly fixed, or otherwise doesn't exist.
+
+This might produce many branches, and the first `hotfix` makes the release obsolete, but it will greatly help
+readability and make a release's history readily apparent.
+
+### Nightly builds
+
+Nightly builds are generated according to a fixed schedule (as suggested
+in [this Jira issue](https://jira.catena-x.net/browse/A1IDSC-408)). Upstream EDC will soon begin to publish nightly
+builds as actual releases (as opposed to: snapshots) to a separate OSSRH-operated repository (see
+[this EDC decision record](https://github.com/eclipse-edc/Connector/tree/main/docs/developer/decision-records/2023-02-10-nightly-builds)).
+
+Unfortunately there is no way to automatically trigger the tractusx-edc build whenever a new EDC nightly is
+created. The most reliable method is to periodically query for the latest EDC nightly, e.g. leveraging GitHub's `dependabot` feature, or using the method highlighted in the aforementioned Jira issue:
+
+```shell
+curl <OSSHR_RELEASES_REPO_URL>/org/eclipse/edc/connector-core/maven-metadata.xml | xmllint --xpath "//metadata/versioning/versions/version[last()]" -
+```
+
+That would return something like to `0.0.1-20230213`. As soon as the version string (here: Feb 13th, 2023) matches the
+current date, we can start the nightly. If the EDC nightly doesn't appear within a set timeframe, we throw an error.
+
+## Notes for becoming OpenSource
+
+- All artifacts (docker images, helm charts, Maven artifacts) should be published to well-known and publicly accessible
+  locations such as MavenCentral, DockerHub, etc. The GitHub Packages repository is only accessible to authenticated
+  users.
+- When and if Tractus-X becomes an Eclipse project, we'll have to adopt the Eclipse Foundation's publishing guidelines,
+  which prescribes the use of Jenkins for publishing to MavenCentral and OSSRH.
+- Typically, GitHub Actions should perform all verification tasks, running tests, etc. and Jenkins' only purpose is to
+  publish.


### PR DESCRIPTION
This PR contains a decision record about the adaptations needed to make the tractusx-edc build more repeatable and in line with established practices.

_this is a clone of https://github.com/catenax-ng/product-edc/pull/782_