### PR TITLE
chore: update project metadata

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,9 +13,9 @@ plugins {
 }
 
 val javaVersion: String by project
-val scmConnection: String by project
-val websiteUrl: String by project
-val scmUrl: String by project
+val txScmConnection: String by project
+val txWebsiteUrl: String by project
+val txScmUrl: String by project
 val groupId: String by project
 val defaultVersion: String by project
 val annotationProcessorVersion: String by project
@@ -80,9 +80,9 @@ allprojects {
             groupId = gid
             projectName.set(project.name)
             description.set("edc :: ${project.name}")
-            projectUrl.set(websiteUrl)
-            scmConnection.set(scmConnection)
-            scmUrl.set(scmUrl)
+            projectUrl.set(txWebsiteUrl)
+            scmConnection.set(txScmConnection)
+            scmUrl.set(txScmUrl)
         }
         swagger {
             title.set((project.findProperty("apiTitle") ?: "Tractus-X REST API") as String)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-groupId=org.eclipse.edc
+groupId=org.eclipse.tractusx.edc
 defaultVersion=0.3.1-SNAPSHOT
 javaVersion=11
 
@@ -7,6 +7,6 @@ javaVersion=11
 annotationProcessorVersion=0.0.1-SNAPSHOT
 edcGradlePluginsVersion=0.0.1-SNAPSHOT
 metaModelVersion=0.0.1-SNAPSHOT
-scmConnection=scm:git:git@github.com:catenax-ng/product-edc.git
-websiteUrl=https://github.com/catenax-ng/product-edc.git
-scmUrl=https://github.com/catenax-ng/product-edc.git
+txScmConnection=scm:git:git@github.com:eclipse-tractusx/tractusx-edc.git
+txWebsiteUrl=https://github.com/eclipse-tractusx/tractusx-edc.git
+txScmUrl=https://github.com/eclipse-tractusx/tractusx-edc.git

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "product-edc"
+rootProject.name = "tractusx-edc"
 
 include(":edc-extensions:business-partner-validation")
 include(":edc-extensions:control-plane-adapter")


### PR DESCRIPTION
## WHAT

updates some Gradle metadata to reflect the move to TractusX, such as `gradle.properties`, the Group ID and the project name in `settings.gradle.kts`

## WHY

Move to tractusx should be reflected throughout the code base.