### PR TITLE
feature: make business tests more resilient

### DIFF
--- a/.github/workflows/business-tests.yaml
+++ b/.github/workflows/business-tests.yaml
@@ -126,99 +126,104 @@ jobs:
           echo "SOKRATES_AWS_ACCESS_KEY_ID=sokratesqwerty123" | tee -a ${GITHUB_ENV}
       -
         name: Install infrastructure components via Helm
-        run: |-
-          # Update helm dependencies
-          helm dependency update edc-tests/src/main/resources/deployment/helm/supporting-infrastructure
-
-          # Install the all-in-one supporting infrastructure environment (daps, vault, pgsql, minio)
-          helm install infrastructure edc-tests/src/main/resources/deployment/helm/supporting-infrastructure \
-            --wait-for-jobs --timeout=120s
-
-          # GH pipelines constrained by cpu, so give helm some time to register all resources \w k8s
-          sleep 5s
-
-          # Wait for supporting infrastructure to become ready (control-/data-plane, backend service)
-          kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=backend --timeout=120s || ( kubectl logs -l app.kubernetes.io/name=backend --tail 500 && exit 1 )
-          kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=idsdaps --timeout=120s || ( kubectl logs -l app.kubernetes.io/name=idsdaps --tail 500 && exit 1 )
-          kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=vault --timeout=120s || ( kubectl logs -l app.kubernetes.io/name=vault --tail 500 && exit 1 )
-          kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=sokrates-postgresql --timeout=120s || ( kubectl logs -l app.kubernetes.io/name=sokrates-postgresql --tail 500 && exit 1 )
-          kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=plato-postgresql --timeout=120s || ( kubectl logs -l app.kubernetes.io/name=plato-postgresql --tail 500 && exit 1 )
-          kubectl wait --for=condition=ready pod -l app=minio --timeout=120s || ( kubectl logs -l app=minio --tail 500 && exit 1 )
-
-          # Install Plato
-          helm install plato charts/tractusx-connector  \
-            --set fullnameOverride=plato \
-            --set controlplane.service.type=NodePort \
-            --set controlplane.endpoints.data.authKey=password \
-            --set controlplane.image.tag=business-test \
-            --set controlplane.image.pullPolicy=Never \
-            --set controlplane.image.repository=docker.io/library/edc-controlplane-postgresql-hashicorp-vault \
-            --set dataplane.image.tag=business-test \
-            --set dataplane.image.pullPolicy=Never \
-            --set dataplane.image.repository=docker.io/library/edc-dataplane-hashicorp-vault \
-            --set controlplane.debug.enabled=true \
-            --set controlplane.suspendOnStart=false \
-            --set postgresql.enabled=true \
-            --set postgresql.username=user \
-            --set postgresql.password=password \
-            --set postgresql.jdbcUrl=jdbc:postgresql://plato-postgresql:5432/edc \
-            --set vault.hashicorp.enabled=true \
-            --set vault.hashicorp.url=http://vault:8200 \
-            --set vault.hashicorp.token=root \
-            --set vault.secretNames.transferProxyTokenSignerPublicKey=plato/daps/my-plato-daps-crt \
-            --set vault.secretNames.transferProxyTokenSignerPrivateKey=plato/daps/my-plato-daps-key \
-            --set vault.secretNames.transferProxyTokenEncryptionAesKey=plato/data-encryption-aes-keys \
-            --set vault.secretNames.dapsPrivateKey=plato/daps/my-plato-daps-key \
-            --set vault.secretNames.dapsPublicKey=plato/daps/my-plato-daps-crt \
-            --set daps.url=http://ids-daps:4567 \
-            --set daps.clientId=99:83:A7:17:86:FF:98:93:CE:A0:DD:A1:F1:36:FA:F6:0F:75:0A:23:keyid:99:83:A7:17:86:FF:98:93:CE:A0:DD:A1:F1:36:FA:F6:0F:75:0A:23 \
-            --set dataplane.aws.endpointOverride=http://minio:9000 \
-            --set dataplane.aws.secretAccessKey=platoqwerty123 \
-            --set dataplane.aws.accessKeyId=platoqwerty123 \
-            --set backendService.httpProxyTokenReceiverUrl=http://backend:8080 \
-            --wait-for-jobs --timeout=120s
-          
-          # Install Sokrates
-          helm install sokrates charts/tractusx-connector  \
-            --set fullnameOverride=sokrates \
-            --set controlplane.service.type=NodePort \
-            --set controlplane.endpoints.data.authKey=password \
-            --set controlplane.image.tag=business-test \
-            --set controlplane.image.pullPolicy=Never \
-            --set controlplane.image.repository=docker.io/library/edc-controlplane-postgresql-hashicorp-vault \
-            --set dataplane.image.tag=business-test \
-            --set dataplane.image.pullPolicy=Never \
-            --set dataplane.image.repository=docker.io/library/edc-dataplane-hashicorp-vault \
-            --set controlplane.debug.enabled=true \
-            --set controlplane.suspendOnStart=false \
-            --set postgresql.enabled=true \
-            --set postgresql.username=user \
-            --set postgresql.password=password \
-            --set postgresql.jdbcUrl=jdbc:postgresql://sokrates-postgresql:5432/edc \
-            --set vault.hashicorp.enabled=true \
-            --set vault.hashicorp.url=http://vault:8200 \
-            --set vault.hashicorp.token=root \
-            --set vault.secretNames.transferProxyTokenSignerPublicKey=sokrates/daps/my-sokrates-daps-crt \
-            --set vault.secretNames.transferProxyTokenSignerPrivateKey=sokrates/daps/my-sokrates-daps-key \
-            --set vault.secretNames.transferProxyTokenEncryptionAesKey=sokrates/data-encryption-aes-keys \
-            --set vault.secretNames.dapsPrivateKey=sokrates/daps/my-sokrates-daps-key \
-            --set vault.secretNames.dapsPublicKey=sokrates/daps/my-sokrates-daps-crt \
-            --set daps.url=http://ids-daps:4567 \
-            --set daps.clientId=E7:07:2D:74:56:66:31:F0:7B:10:EA:B6:03:06:4C:23:7F:ED:A6:65:keyid:E7:07:2D:74:56:66:31:F0:7B:10:EA:B6:03:06:4C:23:7F:ED:A6:65 \
-            --set dataplane.aws.endpointOverride=http://minio:9000 \
-            --set dataplane.aws.secretAccessKey=sokratesqwerty123 \
-            --set dataplane.aws.accessKeyId=sokratesqwerty123 \
-            --set backendService.httpProxyTokenReceiverUrl=http://backend:8080 \
-            --wait-for-jobs --timeout=120s
-
-          # GH pipelines constrained by cpu, so give helm some time to register all resources \w k8s
-          sleep 5s
-
-          # Wait for Control-/DataPlane and backend-service to become ready
-          kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=sokrates-controlplane --timeout=600s || ( kubectl logs -l app.kubernetes.io/instance=sokrates-controlplane --tail 500 && exit 1 )
-          kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=sokrates-dataplane --timeout=600s || ( kubectl logs -l app.kubernetes.io/instance=sokrates-dataplane --tail 500 && exit 1 )
-          kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=plato-controlplane --timeout=600s || ( kubectl logs -l app.kubernetes.io/instance=plato-controlplane --tail 500 && exit 1 )
-          kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=plato-dataplane --timeout=600s || ( kubectl logs -l app.kubernetes.io/instance=plato-dataplane --tail 500 && exit 1 )
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: |-
+            # Update helm dependencies
+            helm dependency update edc-tests/src/main/resources/deployment/helm/supporting-infrastructure
+  
+            # Install the all-in-one supporting infrastructure environment (daps, vault, pgsql, minio)
+            helm install infrastructure edc-tests/src/main/resources/deployment/helm/supporting-infrastructure \
+              --wait-for-jobs --timeout=120s
+  
+            # GH pipelines constrained by cpu, so give helm some time to register all resources \w k8s
+            sleep 5s
+  
+            # Wait for supporting infrastructure to become ready (control-/data-plane, backend service)
+            kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=backend --timeout=120s || ( kubectl logs -l app.kubernetes.io/name=backend --tail 500 && exit 1 )
+            kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=idsdaps --timeout=120s || ( kubectl logs -l app.kubernetes.io/name=idsdaps --tail 500 && exit 1 )
+            kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=vault --timeout=120s || ( kubectl logs -l app.kubernetes.io/name=vault --tail 500 && exit 1 )
+            kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=sokrates-postgresql --timeout=120s || ( kubectl logs -l app.kubernetes.io/name=sokrates-postgresql --tail 500 && exit 1 )
+            kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=plato-postgresql --timeout=120s || ( kubectl logs -l app.kubernetes.io/name=plato-postgresql --tail 500 && exit 1 )
+            kubectl wait --for=condition=ready pod -l app=minio --timeout=120s || ( kubectl logs -l app=minio --tail 500 && exit 1 )
+  
+            # Install Plato
+            helm install plato charts/tractusx-connector  \
+              --set fullnameOverride=plato \
+              --set controlplane.service.type=NodePort \
+              --set controlplane.endpoints.data.authKey=password \
+              --set controlplane.image.tag=business-test \
+              --set controlplane.image.pullPolicy=Never \
+              --set controlplane.image.repository=docker.io/library/edc-controlplane-postgresql-hashicorp-vault \
+              --set dataplane.image.tag=business-test \
+              --set dataplane.image.pullPolicy=Never \
+              --set dataplane.image.repository=docker.io/library/edc-dataplane-hashicorp-vault \
+              --set controlplane.debug.enabled=true \
+              --set controlplane.suspendOnStart=false \
+              --set postgresql.enabled=true \
+              --set postgresql.username=user \
+              --set postgresql.password=password \
+              --set postgresql.jdbcUrl=jdbc:postgresql://plato-postgresql:5432/edc \
+              --set vault.hashicorp.enabled=true \
+              --set vault.hashicorp.url=http://vault:8200 \
+              --set vault.hashicorp.token=root \
+              --set vault.secretNames.transferProxyTokenSignerPublicKey=plato/daps/my-plato-daps-crt \
+              --set vault.secretNames.transferProxyTokenSignerPrivateKey=plato/daps/my-plato-daps-key \
+              --set vault.secretNames.transferProxyTokenEncryptionAesKey=plato/data-encryption-aes-keys \
+              --set vault.secretNames.dapsPrivateKey=plato/daps/my-plato-daps-key \
+              --set vault.secretNames.dapsPublicKey=plato/daps/my-plato-daps-crt \
+              --set daps.url=http://ids-daps:4567 \
+              --set daps.clientId=99:83:A7:17:86:FF:98:93:CE:A0:DD:A1:F1:36:FA:F6:0F:75:0A:23:keyid:99:83:A7:17:86:FF:98:93:CE:A0:DD:A1:F1:36:FA:F6:0F:75:0A:23 \
+              --set dataplane.aws.endpointOverride=http://minio:9000 \
+              --set dataplane.aws.secretAccessKey=platoqwerty123 \
+              --set dataplane.aws.accessKeyId=platoqwerty123 \
+              --set backendService.httpProxyTokenReceiverUrl=http://backend:8080 \
+              --wait-for-jobs --timeout=120s
+            
+            # Install Sokrates
+            helm install sokrates charts/tractusx-connector  \
+              --set fullnameOverride=sokrates \
+              --set controlplane.service.type=NodePort \
+              --set controlplane.endpoints.data.authKey=password \
+              --set controlplane.image.tag=business-test \
+              --set controlplane.image.pullPolicy=Never \
+              --set controlplane.image.repository=docker.io/library/edc-controlplane-postgresql-hashicorp-vault \
+              --set dataplane.image.tag=business-test \
+              --set dataplane.image.pullPolicy=Never \
+              --set dataplane.image.repository=docker.io/library/edc-dataplane-hashicorp-vault \
+              --set controlplane.debug.enabled=true \
+              --set controlplane.suspendOnStart=false \
+              --set postgresql.enabled=true \
+              --set postgresql.username=user \
+              --set postgresql.password=password \
+              --set postgresql.jdbcUrl=jdbc:postgresql://sokrates-postgresql:5432/edc \
+              --set vault.hashicorp.enabled=true \
+              --set vault.hashicorp.url=http://vault:8200 \
+              --set vault.hashicorp.token=root \
+              --set vault.secretNames.transferProxyTokenSignerPublicKey=sokrates/daps/my-sokrates-daps-crt \
+              --set vault.secretNames.transferProxyTokenSignerPrivateKey=sokrates/daps/my-sokrates-daps-key \
+              --set vault.secretNames.transferProxyTokenEncryptionAesKey=sokrates/data-encryption-aes-keys \
+              --set vault.secretNames.dapsPrivateKey=sokrates/daps/my-sokrates-daps-key \
+              --set vault.secretNames.dapsPublicKey=sokrates/daps/my-sokrates-daps-crt \
+              --set daps.url=http://ids-daps:4567 \
+              --set daps.clientId=E7:07:2D:74:56:66:31:F0:7B:10:EA:B6:03:06:4C:23:7F:ED:A6:65:keyid:E7:07:2D:74:56:66:31:F0:7B:10:EA:B6:03:06:4C:23:7F:ED:A6:65 \
+              --set dataplane.aws.endpointOverride=http://minio:9000 \
+              --set dataplane.aws.secretAccessKey=sokratesqwerty123 \
+              --set dataplane.aws.accessKeyId=sokratesqwerty123 \
+              --set backendService.httpProxyTokenReceiverUrl=http://backend:8080 \
+              --wait-for-jobs --timeout=120s
+  
+            # GH pipelines constrained by cpu, so give helm some time to register all resources \w k8s
+            sleep 5s
+  
+            # Wait for Control-/DataPlane and backend-service to become ready
+            kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=sokrates-controlplane --timeout=600s || ( kubectl logs -l app.kubernetes.io/instance=sokrates-controlplane --tail 500 && exit 1 )
+            kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=sokrates-dataplane --timeout=600s || ( kubectl logs -l app.kubernetes.io/instance=sokrates-dataplane --tail 500 && exit 1 )
+            kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=plato-controlplane --timeout=600s || ( kubectl logs -l app.kubernetes.io/instance=plato-controlplane --tail 500 && exit 1 )
+            kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=plato-dataplane --timeout=600s || ( kubectl logs -l app.kubernetes.io/instance=plato-dataplane --tail 500 && exit 1 )
 
       ##############################################
       ### Run Business Tests inside kind cluster ###


### PR DESCRIPTION
## WHAT
This PR executes the `helm install` portion of the business tests in a retryable action, to guard agains transient failures and timeouts.

## WHY
they are flaky

## FURTHER NOTES
supersedes #129 