### PR TITLE
feat(baseImage): replace alpine with temurin as base image for running java applications

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       # Build
       -
@@ -121,7 +121,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       # Build
       -
@@ -188,7 +188,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       # Build
       -
@@ -243,7 +243,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       - name: Import GPG Key
         uses: crazy-max/ghaction-import-gpg@v1

--- a/.github/workflows/business-tests.yaml
+++ b/.github/workflows/business-tests.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       -
         name: Cache ContainerD Image Layers

--- a/.github/workflows/draft-new-release.yaml
+++ b/.github/workflows/draft-new-release.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       -
         name: Bump version in gradle.properties

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
 
       - name: Import GPG Key
@@ -181,7 +181,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       -
         name: Merge main back into develop and set new snapshot version

--- a/.github/workflows/veracode.yaml
+++ b/.github/workflows/veracode.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       -
         name: Verify proper formatting
@@ -63,7 +63,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       # Build
       -
@@ -112,7 +112,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       # Build
       -

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       -
         name: Verify proper formatting
@@ -91,7 +91,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
 
       - name: Run Unit tests
@@ -108,7 +108,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
 
       - name: Run Integration tests
@@ -125,7 +125,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
 
       - name: Run API tests
@@ -142,7 +142,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
 
       - name: Run E2E tests
@@ -165,7 +165,7 @@ jobs:
         uses: actions/setup-java@v3.10.0
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       -
         name: Cache SonarCloud packages

--- a/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
@@ -26,16 +26,11 @@ HEALTHCHECK NONE
 
 RUN wget ${OTEL_AGENT_LOCATION} -O /tmp/opentelemetry-javaagent.jar
 
-FROM alpine:3.17.1
-
+FROM eclipse-temurin:11.0.18_10-jre-alpine
 ARG JAR
 
 ARG APP_USER=docker
 ARG APP_UID=10100
-
-RUN apk update && \
-     apk add openjdk11-jre-headless=11.0.18_p10-r0 --no-cache && \
-     rm -rf /var/cache/apk/*
 
 RUN addgroup --system "$APP_USER"
 

--- a/edc-controlplane/edc-controlplane-memory/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-memory/src/main/docker/Dockerfile
@@ -26,16 +26,11 @@ HEALTHCHECK NONE
 
 RUN wget ${OTEL_AGENT_LOCATION} -O /tmp/opentelemetry-javaagent.jar
 
-FROM alpine:3.17.2
-
+FROM eclipse-temurin:11.0.18_10-jre-alpine
 ARG JAR
 
 ARG APP_USER=docker
 ARG APP_UID=10100
-
-RUN apk update && \
-     apk add openjdk11-jre-headless=11.0.18_p10-r0 --no-cache && \
-     rm -rf /var/cache/apk/*
 
 RUN addgroup --system "$APP_USER"
 

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
@@ -26,16 +26,11 @@ HEALTHCHECK NONE
 
 RUN wget ${OTEL_AGENT_LOCATION} -O /tmp/opentelemetry-javaagent.jar
 
-FROM alpine:3.17.2
-
+FROM eclipse-temurin:11.0.18_10-jre-alpine
 ARG JAR
 
 ARG APP_USER=docker
 ARG APP_UID=10100
-
-RUN apk update && \
-     apk add openjdk11-jre-headless=11.0.18_p10-r0 --no-cache && \
-     rm -rf /var/cache/apk/*
 
 RUN addgroup --system "$APP_USER"
 

--- a/edc-controlplane/edc-controlplane-postgresql/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql/src/main/docker/Dockerfile
@@ -26,16 +26,11 @@ HEALTHCHECK NONE
 
 RUN wget ${OTEL_AGENT_LOCATION} -O /tmp/opentelemetry-javaagent.jar
 
-FROM alpine:3.17.2
-
+FROM eclipse-temurin:11.0.18_10-jre-alpine
 ARG JAR
 
 ARG APP_USER=docker
 ARG APP_UID=10100
-
-RUN apk update && \
-     apk add openjdk11-jre-headless=11.0.18_p10-r0 --no-cache && \
-     rm -rf /var/cache/apk/*
 
 RUN addgroup --system "$APP_USER"
 

--- a/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
@@ -26,16 +26,11 @@ HEALTHCHECK NONE
 
 RUN wget ${OTEL_AGENT_LOCATION} -O /tmp/opentelemetry-javaagent.jar
 
-FROM alpine:3.17.2
-
+FROM eclipse-temurin:11.0.18_10-jre-alpine
 ARG JAR
 
 ARG APP_USER=docker
 ARG APP_UID=10100
-
-RUN apk update && \
-     apk add openjdk11-jre-headless=11.0.18_p10-r0 --no-cache && \
-     rm -rf /var/cache/apk/*
 
 RUN addgroup --system "$APP_USER"
 

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
@@ -26,16 +26,11 @@ HEALTHCHECK NONE
 
 RUN wget ${OTEL_AGENT_LOCATION} -O /tmp/opentelemetry-javaagent.jar
 
-FROM alpine:3.17.2
-
+FROM eclipse-temurin:11.0.18_10-jre-alpine
 ARG JAR
 
 ARG APP_USER=docker
 ARG APP_UID=10100
-
-RUN apk update && \
-     apk add openjdk11-jre-headless=11.0.18_p10-r0 --no-cache && \
-     rm -rf /var/cache/apk/*
 
 RUN addgroup --system "$APP_USER"
 


### PR DESCRIPTION
This PR changes the base image from `alpine` to `eclipse-temurin` for running java application.

It also changes the `distribution` in `temurin` when running CI jobs with the `setup-java` actions


Closes #130 