### PR TITLE
Fix: `vault.azure.clientsecret` and `vault.azure.certificate` should be null if not configured

### DIFF
--- a/charts/tractusx-connector/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-controlplane.yaml
@@ -1,24 +1,24 @@
 #
-  #  Copyright (c) 2023 ZF Friedrichshafen AG
-  #  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
-  #  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-  #  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
-  #
-  #  See the NOTICE file(s) distributed with this work for additional
-  #  information regarding copyright ownership.
-  #
-  #  This program and the accompanying materials are made available under the
-  #  terms of the Apache License, Version 2.0 which is available at
-  #  https://www.apache.org/licenses/LICENSE-2.0
-  #
-  #  Unless required by applicable law or agreed to in writing, software
-  #  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-  #  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-  #  License for the specific language governing permissions and limitations
-  #  under the License.
-  #
-  #  SPDX-License-Identifier: Apache-2.0
-  #
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
 
 ---
 apiVersion: apps/v1

--- a/charts/tractusx-connector/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-controlplane.yaml
@@ -1,24 +1,24 @@
 #
-#  Copyright (c) 2023 ZF Friedrichshafen AG
-#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
-#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
-#
-#  See the NOTICE file(s) distributed with this work for additional
-#  information regarding copyright ownership.
-#
-#  This program and the accompanying materials are made available under the
-#  terms of the Apache License, Version 2.0 which is available at
-#  https://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-#  License for the specific language governing permissions and limitations
-#  under the License.
-#
-#  SPDX-License-Identifier: Apache-2.0
-#
+  #  Copyright (c) 2023 ZF Friedrichshafen AG
+  #  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+  #  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+  #  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+  #
+  #  See the NOTICE file(s) distributed with this work for additional
+  #  information regarding copyright ownership.
+  #
+  #  This program and the accompanying materials are made available under the
+  #  terms of the Apache License, Version 2.0 which is available at
+  #  https://www.apache.org/licenses/LICENSE-2.0
+  #
+  #  Unless required by applicable law or agreed to in writing, software
+  #  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  #  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  #  License for the specific language governing permissions and limitations
+  #  under the License.
+  #
+  #  SPDX-License-Identifier: Apache-2.0
+  #
 
 ---
 apiVersion: apps/v1
@@ -315,10 +315,16 @@ spec:
               value: {{ .Values.vault.azure.tenant | required ".Values.vault.azure.tenant is required" | quote }}
             - name: "EDC_VAULT_NAME"
               value: {{ .Values.vault.azure.name | required ".Values.vault.azure.name is required" | quote }}
+            # only set the env var if config value not null
+            {{- if .Values.vault.azure.secret }}
             - name: "EDC_VAULT_CLIENTSECRET"
               value: {{ .Values.vault.azure.secret | quote }}
+            {{- end }}
+            # only set the env var if config value not null
+            {{- if .Values.vault.azure.certificate }}
             - name: "EDC_VAULT_CERTIFICATE"
               value: {{ .Values.vault.azure.certificate | quote }}
+            {{- end }}
           {{- end }}
 
             #####################

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -509,8 +509,8 @@ vault:
     name: ""
     client: ""
     tenant: ""
-    secret: ""
-    certificate: ""
+    secret:
+    certificate:
   secretNames:
     transferProxyTokenSignerPrivateKey: transfer-proxy-token-signer-private-key
     transferProxyTokenSignerPublicKey: transfer-proxy-token-signer-public-key


### PR DESCRIPTION
This PR fixes a bug where `vault.azure.clientsecret` and `vault.azure.certificate` were not `null`, even if they aren't configured.

Closes #168 