### PR TITLE
Chore: use old repo URL for maven releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -257,6 +257,7 @@ jobs:
           echo "Publishing Version $(grep -e "version" gradle.properties | cut -f2 -d"=") to Github Packages"
           ./gradlew publishAllPublicationsToGitHubPackagesRepository
         env:
-          REPO: ${{ github.repository }}
+          #REPO: ${{ github.repository }}
+          REPO: "catenax-ng/product-edc"
           GITHUB_PACKAGE_USERNAME: ${{ github.actor }}
           GITHUB_PACKAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -75,7 +75,8 @@ jobs:
           echo "Publishing Version $(grep -e "version" gradle.properties | cut -f2 -d"=") to Github Packages"
           ./gradlew publishAllPublicationsToGithubPackagesRepository
         env:
-          REPO: ${{ github.repository }}
+          #REPO: ${{ github.repository }}
+          REPO: "catenax-ng/product-edc"
           GITHUB_PACKAGE_USERNAME: ${{ github.actor }}
           GITHUB_PACKAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## WHAT

This PR sets a hard-coded repo URL for publishing Maven artifacts, and sets it to the "old" `catenax-ng/product-edc` repository. 

## WHY
Until we can publish to OSSRH/MavenCentral (#166) we still need to publish to GitHub Packages.
GH requires that Maven coordinates be unique in the same org.  
Since both the old Product-EDC repo and our fork of Tractusx-EDC are in the `catenax-ng` org, we can only publish packages from _either one_, not both.

So for the time being we publish "into" the old repo.

## FURTHER NOTES

Consumers of the packages **must also use the old repo url**:
```kotlin
repositories {
    maven {
        url = uri("https://maven.pkg.github.com/catenax-ng/product-edc")
        credentials {
            username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
            password = project.findProperty("gpr.key") as String? ?: System.getenv("TOKEN")
        }
    }
}
```

this **will go away** once we have implemented the OSSRH/MavenCentral release process (#166)