### PR TITLE
feature: publish Docker images to DockerHub

### DIFF
--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -1,0 +1,72 @@
+name: "Publish Docker Image"
+description: "Build and publish a Docker Image to DockerHub"
+inputs:
+  rootDir:
+    required: true
+    description: "The directory where the notice.md file and the src/main/docker directory are located"
+  namespace:
+    required: false
+    default: "tractusx"
+    description: "The Docker image namespace"
+  imagename:
+    required: true
+    description: "the name of the image"
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    #####################
+    # Login to DockerHub
+    #####################
+    - name: DockerHub login
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+    ###############################
+    # Set metadata of docker image
+    ###############################
+    # Create SemVer or ref tags dependent of trigger event
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: |
+          ${{ inputs.namespace }}/${{ inputs.imagename }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}
+          type=semver,pattern={{major}}.{{minor}}
+
+    ###############################
+    # Build and push the image
+    ###############################
+    - name: Build and push
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: ${{ inputs.rootDir }}/src/main/docker/Dockerfile
+        build-args: |
+          JAR=${{ inputs.rootDir }}/build/libs/${{ inputs.imagename }}.jar
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+
+    ###############################
+    # Update the description
+    # https://github.com/peter-evans/dockerhub-description
+    ###############################
+    - name: Update Docker Hub description
+      if: github.event_name != 'pull_request' && ${{ secrets.DOCKER_HUB_USER }} && ${{ secrets.DOCKER_HUB_TOKEN }}
+      uses: peter-evans/dockerhub-description@v3
+      with:
+        readme-filepath: ${{ inputs.rootDir }}/notice.md
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+        repository: ${{ inputs.namespace }}/${{ inputs.imagename }}

--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -104,7 +104,7 @@ runs:
     # https://github.com/peter-evans/dockerhub-description
     ###############################
     - name: Update Docker Hub description
-      if: github.event_name != 'pull_request' && ${{ inputs.docker_user }} && ${{ inputs.docker_token }}
+      if: github.event_name != 'pull_request'
       uses: peter-evans/dockerhub-description@v3
       with:
         readme-filepath: ${{ inputs.rootDir }}/notice.md

--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -11,6 +11,12 @@ inputs:
   imagename:
     required: true
     description: "the name of the image"
+  docker_user:
+    required: false
+    description: "DockerHub user name. No push is done if omitted"
+  docker_token:
+    required: false
+    description: "DockerHub Token. No push is done if omitted"
 runs:
   using: "composite"
   steps:
@@ -24,8 +30,8 @@ runs:
       if: github.event_name != 'pull_request'
       uses: docker/login-action@v2
       with:
-        username: ${{ secrets.DOCKER_HUB_USER }}
-        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+        username: ${{ inputs.docker_user }}
+        password: ${{ inputs.docker_token }}
 
     ###############################
     # Set metadata of docker image
@@ -63,10 +69,10 @@ runs:
     # https://github.com/peter-evans/dockerhub-description
     ###############################
     - name: Update Docker Hub description
-      if: github.event_name != 'pull_request' && ${{ secrets.DOCKER_HUB_USER }} && ${{ secrets.DOCKER_HUB_TOKEN }}
+      if: github.event_name != 'pull_request' && ${{ inputs.docker_user }} && ${{ inputs.docker_token }}
       uses: peter-evans/dockerhub-description@v3
       with:
         readme-filepath: ${{ inputs.rootDir }}/notice.md
-        username: ${{ secrets.DOCKER_HUB_USER }}
-        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+        username: ${{ inputs.docker_user }}
+        password: ${{ inputs.docker_token }}
         repository: ${{ inputs.namespace }}/${{ inputs.imagename }}

--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -1,3 +1,24 @@
+#
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
+---
 name: "Publish Docker Image"
 description: "Build and publish a Docker Image to DockerHub"
 inputs:

--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -33,6 +33,20 @@ runs:
         username: ${{ inputs.docker_user }}
         password: ${{ inputs.docker_token }}
 
+    #####################
+    # Build JAR file
+    #####################
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3.11.0
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: 'gradle'
+    - name: Build Controlplane
+      shell: bash
+      run: |-
+        ./gradlew -p ${{ inputs.rootDir }} shadowJar
+
     ###############################
     # Set metadata of docker image
     ###############################

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,8 +55,7 @@ jobs:
       GPG_PRIVATE_KEY: ${{ steps.secret-presence.outputs.GPG_PRIVATE_KEY }}
       GPG_PASSPHRASE: ${{ steps.secret-presence.outputs.GPG_PASSPHRASE }}
     steps:
-      -
-        name: Check whether secrets exist
+      - name: Check whether secrets exist
         id: secret-presence
         run: |
           [ ! -z "${{ secrets.SONAR_TOKEN }}" ] && echo "::set-output name=SONAR_TOKEN::true"
@@ -66,22 +65,19 @@ jobs:
 
   build-extensions:
     runs-on: ubuntu-latest
-    needs: [ secret-presence]
+    needs: [ secret-presence ]
     steps:
       # Set-Up
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3.3.0
-      -
-        name: Set up JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v3.11.0
         with:
           java-version: '11'
           distribution: 'temurin'
           cache: 'gradle'
       # Build
-      -
-        name: Build Extensions
+      - name: Build Extensions
         run: |-
           ./gradlew -p edc-extensions build
         env:
@@ -89,11 +85,9 @@ jobs:
           GITHUB_PACKAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
   build-controlplane:
+    name: "Create Docker Images for the ControlPlane"
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    needs: [ secret-presence]
+    needs: [ secrets-presence ]
     strategy:
       fail-fast: false
       matrix:
@@ -102,134 +96,49 @@ jobs:
           - edc-controlplane-memory-hashicorp-vault
           - edc-controlplane-postgresql
           - edc-controlplane-postgresql-hashicorp-vault
+    permissions:
+      contents: write
+      packages: write
     steps:
-      # Set-Up
-      -
-        name: Checkout
-        uses: actions/checkout@v3.3.0
-      -
-        name: Login to GitHub Container Registry
-        if: |
-          github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/publish-docker-image
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-          cache: 'gradle'
-      # Build
-      -
-        name: Build Controlplane
-        run: |-
-          ./gradlew -p edc-controlplane/${{ matrix.name }} shadowJar
-        env:
-          GITHUB_PACKAGE_USERNAME: ${{ github.actor }}
-          GITHUB_PACKAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: edc-controlplane Docker Metadata
-        id: edc_controlplane_meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}/${{ matrix.name }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{raw}}
-            type=match,pattern=\d.\d.\d
-            type=sha
-      -
-        name: Build Docker Image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: edc-controlplane/${{ matrix.name }}/src/main/docker/Dockerfile
-          build-args: |
-            JAR=edc-controlplane/${{ matrix.name }}/build/libs/${{ matrix.name }}.jar
-          push: |
-            ${{ (github.event_name != 'pull_request' && 'true') || 'false' }}
-          tags: ${{ steps.edc_controlplane_meta.outputs.tags }}
-          labels: ${{ steps.edc_controlplane_meta.outputs.labels }}
+          rootDir: edc-controlplane/${{ matrix.name }}
+          imagename: ${{ matrix.name }}
+          namespace: ${{ inputs.namespace }}
+          docker_user: ${{ secrets.DOCKER_HUB_USER }}
+          docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}
 
   build-dataplane:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    needs: [ secret-presence]
+    needs: [ secret-presence ]
     strategy:
       fail-fast: false
       matrix:
         name:
           - edc-dataplane-azure-vault
           - edc-dataplane-hashicorp-vault
+    permissions:
+      contents: write
+      packages: write
     steps:
-      # Set-Up
-      -
-        name: Checkout
-        uses: actions/checkout@v3.3.0
-      -
-        name: Login to GitHub Container Registry
-        if: |
-          github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/publish-docker-image
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-          cache: 'gradle'
-      # Build
-      -
-        name: Build Dataplane
-        run: |-
-          ./gradlew -p edc-dataplane/${{ matrix.name }} shadowJar
-        env:
-          GITHUB_PACKAGE_USERNAME: ${{ github.actor }}
-          GITHUB_PACKAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: edc-dataplane Docker Metadata
-        id: edc_dataplane_meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}/${{ matrix.name }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{raw}}
-            type=match,pattern=\d.\d.\d
-            type=sha
-      -
-        name: Build Docker Image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: edc-dataplane/${{ matrix.name }}/src/main/docker/Dockerfile
-          build-args: |
-            JAR=edc-dataplane/${{ matrix.name }}/build/libs/${{ matrix.name }}.jar
-          push: |
-            ${{ (github.event_name != 'pull_request' && 'true') || 'false' }}
-          tags: ${{ steps.edc_dataplane_meta.outputs.tags }}
-          labels: ${{ steps.edc_dataplane_meta.outputs.labels }}
+          rootDir: edc-dataplane/${{ matrix.name }}
+          imagename: ${{ matrix.name }}
+          namespace: ${{ inputs.namespace }}
+          docker_user: ${{ secrets.DOCKER_HUB_USER }}
+          docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}
 
   publish-to-github-packages:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-    needs: [secret-presence, build-controlplane, build-dataplane, build-extensions]
+    needs: [ secret-presence, build-controlplane, build-dataplane, build-extensions ]
 
     # do not run on PR branches, do not run on main
     if: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,7 +105,6 @@ jobs:
         with:
           rootDir: edc-controlplane/${{ matrix.name }}
           imagename: ${{ matrix.name }}
-          namespace: ${{ inputs.namespace }}
           docker_user: ${{ secrets.DOCKER_HUB_USER }}
           docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}
 
@@ -127,7 +126,6 @@ jobs:
         with:
           rootDir: edc-dataplane/${{ matrix.name }}
           imagename: ${{ matrix.name }}
-          namespace: ${{ inputs.namespace }}
           docker_user: ${{ secrets.DOCKER_HUB_USER }}
           docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,7 @@ jobs:
   build-controlplane:
     name: "Create Docker Images for the ControlPlane"
     runs-on: ubuntu-latest
-    needs: [ secrets-presence ]
+    needs: [ secret-presence ]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,7 +98,6 @@ jobs:
           - edc-controlplane-postgresql-hashicorp-vault
     permissions:
       contents: write
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -121,7 +120,6 @@ jobs:
           - edc-dataplane-hashicorp-vault
     permissions:
       contents: write
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -23,17 +23,10 @@ name: "Create Docker images"
 
 on:
   workflow_dispatch:
-    inputs:
-      rootDir:
-        required: true
-        description: "The directory where the notice.md file and the src/main/docker directory are located"
-      namespace:
-        required: false
-        default: "tractusx"
-        description: "The Docker image namespace"
-      imagename:
-        required: true
-        description: "the name of the image"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   create-docker-image-controlplane:

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -1,0 +1,76 @@
+#
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
+---
+name: "Create Docker images"
+
+on:
+  workflow_dispatch:
+    inputs:
+      rootDir:
+        required: true
+        description: "The directory where the notice.md file and the src/main/docker directory are located"
+      namespace:
+        required: false
+        default: "tractusx"
+        description: "The Docker image namespace"
+      imagename:
+        required: true
+        description: "the name of the image"
+
+jobs:
+  create-docker-image-controlplane:
+    name: "Create Docker Images for the ControlPlane"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        name:
+          - edc-controlplane-memory
+          - edc-controlplane-memory-hashicorp-vault
+          - edc-controlplane-postgresql
+          - edc-controlplane-postgresql-hashicorp-vault
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: ./.github/actions/publish-docker-image
+        with:
+          rootDir: edc-controlplane/${{ matrix.name }}
+          imagename: ${{ matrix.name }}
+
+
+  create-docker-image-dataplane:
+    name: "Create Docker Images for the DataPlane"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        name:
+          - edc-dataplane-azure-vault
+          - edc-dataplane-hashicorp-vault
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: ./.github/actions/publish-docker-image
+        with:
+          rootDir: edc-dataplane/${{ matrix.name }}
+          imagename: ${{ matrix.name }}

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -50,6 +50,8 @@ jobs:
         with:
           rootDir: edc-controlplane/${{ matrix.name }}
           imagename: ${{ matrix.name }}
+          docker_user: ${{ secrets.DOCKER_HUB_USER }}
+          docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}
 
 
   create-docker-image-dataplane:
@@ -71,3 +73,5 @@ jobs:
         with:
           rootDir: edc-dataplane/${{ matrix.name }}
           imagename: ${{ matrix.name }}
+          docker_user: ${{ secrets.DOCKER_HUB_USER }}
+          docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -44,6 +44,8 @@ jobs:
       contents: write
       packages: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - uses: ./.github/actions/publish-docker-image
         with:
           rootDir: edc-controlplane/${{ matrix.name }}
@@ -63,6 +65,8 @@ jobs:
       contents: write
       packages: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - uses: ./.github/actions/publish-docker-image
         with:
           rootDir: edc-dataplane/${{ matrix.name }}

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -23,6 +23,11 @@ name: "Create Docker images"
 
 on:
   workflow_dispatch:
+    inputs:
+      namespace:
+        description: 'The namespace (=repo) in DockerHub'
+        required: false
+        default: "tractusx"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -50,6 +55,7 @@ jobs:
         with:
           rootDir: edc-controlplane/${{ matrix.name }}
           imagename: ${{ matrix.name }}
+          namespace: ${{ inputs.namespace }}
           docker_user: ${{ secrets.DOCKER_HUB_USER }}
           docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}
 
@@ -73,5 +79,6 @@ jobs:
         with:
           rootDir: edc-dataplane/${{ matrix.name }}
           imagename: ${{ matrix.name }}
+          namespace: ${{ inputs.namespace }}
           docker_user: ${{ secrets.DOCKER_HUB_USER }}
           docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -19,6 +19,7 @@
 "default": true
 # Do not restrict line length: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#MD013
 "MD013": false
+"MD034":
 # Allow same content on headlines on siblings: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#MD024
 "MD024":
   "siblings_only": true

--- a/charts/tractusx-connector/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-controlplane.yaml
@@ -62,13 +62,13 @@ spec:
           {{- if .Values.controlplane.image.repository }}
           image: "{{ .Values.controlplane.image.repository }}:{{ .Values.controlplane.image.tag | default .Chart.AppVersion }}"
           {{- else if and .Values.postgresql.enabled .Values.vault.hashicorp.enabled }}
-          image: "ghcr.io/catenax-ng/tx-tractusx-edc/edc-controlplane-postgresql-hashicorp-vault:{{ .Values.controlplane.image.tag | default .Chart.AppVersion }}"
+          image: "tractusx/edc-controlplane-postgresql-hashicorp-vault:{{ .Values.controlplane.image.tag | default .Chart.AppVersion }}"
           {{- else if and .Values.postgresql.enabled .Values.vault.azure.enabled }}
-          image: "ghcr.io/catenax-ng/tx-tractusx-edc/edc-controlplane-postgresql:{{ .Values.controlplane.image.tag | default .Chart.AppVersion }}"
+          image: "tractusx/edc-controlplane-postgresql:{{ .Values.controlplane.image.tag | default .Chart.AppVersion }}"
           {{- else if .Values.vault.hashicorp.enabled }}
-          image: "ghcr.io/catenax-ng/tx-tractusx-edc/edc-controlplane-memory-hashicorp-vault:{{ .Values.controlplane.image.tag | default .Chart.AppVersion }}"
+          image: "tractusx/edc-controlplane-memory-hashicorp-vault:{{ .Values.controlplane.image.tag | default .Chart.AppVersion }}"
           {{- else if .Values.vault.azure.enabled }}
-          image: "ghcr.io/catenax-ng/tx-tractusx-edc/edc-controlplane-memory:{{ .Values.controlplane.image.tag | default .Chart.AppVersion }}"
+          image: "tractusx/edc-controlplane-memory:{{ .Values.controlplane.image.tag | default .Chart.AppVersion }}"
           {{- else }}
           {{- fail "cannot choose control-plane image automatically based on configuration" }}
           {{- end }}

--- a/charts/tractusx-connector/templates/deployment-dataplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-dataplane.yaml
@@ -1,3 +1,25 @@
+#
+#  Copyright (c) 2023 ZF Friedrichshafen AG
+#  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -40,9 +62,9 @@ spec:
           {{- if .Values.dataplane.image.repository }}
           image: "{{ .Values.dataplane.image.repository }}:{{ .Values.dataplane.image.tag | default .Chart.AppVersion }}"
           {{- else if and .Values.vault.hashicorp }}
-          image: "ghcr.io/catenax-ng/tx-tractusx-edc/edc-dataplane-hashicorp-vault:{{ .Values.dataplane.image.tag | default .Chart.AppVersion }}"
+          image: "tractusx/edc-dataplane-hashicorp-vault:{{ .Values.dataplane.image.tag | default .Chart.AppVersion }}"
           {{- else if .Values.vault.azure }}
-          image: "ghcr.io/catenax-ng/tx-tractusx-edc/edc-dataplane-azure-vault:{{ .Values.dataplane.image.tag | default .Chart.AppVersion }}"
+          image: "tractusx/edc-dataplane-azure-vault:{{ .Values.dataplane.image.tag | default .Chart.AppVersion }}"
           {{- else }}
           {{- fail "cannot choose data-plane image automatically based on configuration" }}
           {{- end }}
@@ -109,7 +131,7 @@ spec:
             - name: "WEB_HTTP_PUBLIC_PATH"
               value: {{ .Values.dataplane.endpoints.public.path | quote }}
             - name: "EDC_DATAPLANE_TOKEN_VALIDATION_ENDPOINT"
-              value:  {{ include "txdc.controlplane.url.validation" .}}
+              value: {{ include "txdc.controlplane.url.validation" .}}
 
             #######
             # AWS #
@@ -162,9 +184,9 @@ spec:
               value: {{ .Values.vault.azure.certificate | quote }}
           {{- end }}
 
-          ######################################
-          ## Additional environment variables ##
-          ######################################
+            ######################################
+            ## Additional environment variables ##
+            ######################################
           {{- range $key, $value := .Values.dataplane.envValueFrom }}
             - name: {{ $key | quote }}
               valueFrom:

--- a/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md
@@ -1,4 +1,4 @@
-## Notice for Docker image
+# Notice for Docker image
 
 An EDC Control Plane using memory-based storage, and HashiCorp Vault as secret store.
 
@@ -6,14 +6,14 @@ DockerHub: https://hub.docker.com/r/tractusx/edc-controlplane-memory-hashicorp-v
 
 Eclipse Tractus-X product(s) installed within the image:
 
-### TractusX-EDC Control Plane
+## TractusX-EDC Control Plane
 
 - GitHub: https://github.com/eclipse-tractusx/tractusx-edc
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
 - Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
 - Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
 
-**Used base image**
+## Used base image
 
 - [eclipse-temurin:11.0.18_10-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
@@ -26,4 +26,3 @@ from the base distribution, along with any direct or indirect dependencies of th
 
 As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
 with any relevant licenses for all software contained within.
-

--- a/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md
@@ -1,6 +1,6 @@
 ## Notice for Docker image
 
-This application provides container images for demonstration purposes.
+An EDC Control Plane using memory-based storage, and HashiCorp Vault as secret store.
 
 DockerHub: https://hub.docker.com/r/tractusx/edc-controlplane-memory-hashicorp-vault
 

--- a/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md
@@ -6,10 +6,11 @@ DockerHub: https://hub.docker.com/r/tractusx/edc-controlplane-memory-hashicorp-v
 
 Eclipse Tractus-X product(s) installed within the image:
 
+### TractusX-EDC Control Plane
+
 - GitHub: https://github.com/eclipse-tractusx/tractusx-edc
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
--
-Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
+- Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
 - Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
 
 **Used base image**

--- a/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md
@@ -1,0 +1,28 @@
+## Notice for Docker image
+
+This application provides container images for demonstration purposes.
+
+DockerHub: https://hub.docker.com/r/tractusx/edc-controlplane-memory-hashicorp-vault
+
+Eclipse Tractus-X product(s) installed within the image:
+
+- GitHub: https://github.com/eclipse-tractusx/tractusx-edc
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+-
+Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
+
+**Used base image**
+
+- [eclipse-temurin:11.0.18_10-jre-alpine](https://github.com/adoptium/containers)
+- Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
+- Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
+- Additional information about the Eclipse Temurin
+  images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
+
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
+from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
+with any relevant licenses for all software contained within.
+

--- a/edc-controlplane/edc-controlplane-memory/notice.md
+++ b/edc-controlplane/edc-controlplane-memory/notice.md
@@ -1,15 +1,16 @@
 ## Notice for Docker image
 
-This application provides container images for demonstration purposes.
+An EDC Control Plane using memory-based storage, and Azure KeyVault as secret store.
 
 DockerHub: https://hub.docker.com/r/tractusx/edc-controlplane-memory
 
 Eclipse Tractus-X product(s) installed within the image:
 
+### TractusX-EDC Control Plane
+
 - GitHub: https://github.com/eclipse-tractusx/tractusx-edc
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
--
-Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-memory/src/main/docker/Dockerfile
+- Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-memory/src/main/docker/Dockerfile
 - Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
 
 **Used base image**

--- a/edc-controlplane/edc-controlplane-memory/notice.md
+++ b/edc-controlplane/edc-controlplane-memory/notice.md
@@ -1,0 +1,28 @@
+## Notice for Docker image
+
+This application provides container images for demonstration purposes.
+
+DockerHub: https://hub.docker.com/r/tractusx/edc-controlplane-memory
+
+Eclipse Tractus-X product(s) installed within the image:
+
+- GitHub: https://github.com/eclipse-tractusx/tractusx-edc
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+-
+Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-memory/src/main/docker/Dockerfile
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
+
+**Used base image**
+
+- [eclipse-temurin:11.0.18_10-jre-alpine](https://github.com/adoptium/containers)
+- Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
+- Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
+- Additional information about the Eclipse Temurin
+  images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
+
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
+from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
+with any relevant licenses for all software contained within.
+

--- a/edc-controlplane/edc-controlplane-memory/notice.md
+++ b/edc-controlplane/edc-controlplane-memory/notice.md
@@ -1,4 +1,4 @@
-## Notice for Docker image
+# Notice for Docker image
 
 An EDC Control Plane using memory-based storage, and Azure KeyVault as secret store.
 
@@ -6,14 +6,14 @@ DockerHub: https://hub.docker.com/r/tractusx/edc-controlplane-memory
 
 Eclipse Tractus-X product(s) installed within the image:
 
-### TractusX-EDC Control Plane
+## TractusX-EDC Control Plane
 
 - GitHub: https://github.com/eclipse-tractusx/tractusx-edc
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
 - Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-memory/src/main/docker/Dockerfile
 - Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
 
-**Used base image**
+## Used base image
 
 - [eclipse-temurin:11.0.18_10-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
@@ -26,4 +26,3 @@ from the base distribution, along with any direct or indirect dependencies of th
 
 As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
 with any relevant licenses for all software contained within.
-

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/notice.md
@@ -6,14 +6,12 @@ DockerHub: https://hub.docker.com/r/tractusx/edc-controlplane-postgresql-hashico
 
 Eclipse Tractus-X product(s) installed within the image:
 
+### TractusX-EDC Control Plane
+
 - GitHub: https://github.com/eclipse-tractusx/tractusx-edc
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
--
-
-Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
-
-- Project
-  license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
+- Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
 
 **Used base image**
 

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/notice.md
@@ -1,4 +1,4 @@
-## Notice for Docker image
+# Notice for Docker image
 
 An EDC Control Plane using PostgreSQL as persistence backend, and HashiCorp Vault as secret store.
 
@@ -6,14 +6,14 @@ DockerHub: https://hub.docker.com/r/tractusx/edc-controlplane-postgresql-hashico
 
 Eclipse Tractus-X product(s) installed within the image:
 
-### TractusX-EDC Control Plane
+## TractusX-EDC Control Plane
 
 - GitHub: https://github.com/eclipse-tractusx/tractusx-edc
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
 - Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
 - Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
 
-**Used base image**
+## Used base image
 
 - [eclipse-temurin:11.0.18_10-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
@@ -26,4 +26,3 @@ from the base distribution, along with any direct or indirect dependencies of th
 
 As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
 with any relevant licenses for all software contained within.
-

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/notice.md
@@ -1,0 +1,31 @@
+## Notice for Docker image
+
+This application provides container images for demonstration purposes.
+
+DockerHub: https://hub.docker.com/r/tractusx/edc-controlplane-postgresql-hashicorp-vault
+
+Eclipse Tractus-X product(s) installed within the image:
+
+- GitHub: https://github.com/eclipse-tractusx/tractusx-edc
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+-
+
+Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
+
+- Project
+  license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
+
+**Used base image**
+
+- [eclipse-temurin:11.0.18_10-jre-alpine](https://github.com/adoptium/containers)
+- Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
+- Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
+- Additional information about the Eclipse Temurin
+  images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
+
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
+from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
+with any relevant licenses for all software contained within.
+

--- a/edc-controlplane/edc-controlplane-postgresql/notice.md
+++ b/edc-controlplane/edc-controlplane-postgresql/notice.md
@@ -1,6 +1,6 @@
 ## Notice for Docker image
 
-This application provides container images for demonstration purposes.
+An EDC Control Plane using PostgreSQL as persistence backend, and Azure KeyVault as secret store.
 
 DockerHub: https://hub.docker.com/r/tractusx/edc-controlplane-postgresql
 

--- a/edc-controlplane/edc-controlplane-postgresql/notice.md
+++ b/edc-controlplane/edc-controlplane-postgresql/notice.md
@@ -6,10 +6,11 @@ DockerHub: https://hub.docker.com/r/tractusx/edc-controlplane-postgresql
 
 Eclipse Tractus-X product(s) installed within the image:
 
+### TractusX-EDC Control Plane
+
 - GitHub: https://github.com/eclipse-tractusx/tractusx-edc
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
--
-Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-postgresql/src/main/docker/Dockerfile
+- Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-postgresql/src/main/docker/Dockerfile
 - Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
 
 **Used base image**

--- a/edc-controlplane/edc-controlplane-postgresql/notice.md
+++ b/edc-controlplane/edc-controlplane-postgresql/notice.md
@@ -1,4 +1,4 @@
-## Notice for Docker image
+# Notice for Docker image
 
 An EDC Control Plane using PostgreSQL as persistence backend, and Azure KeyVault as secret store.
 
@@ -6,14 +6,14 @@ DockerHub: https://hub.docker.com/r/tractusx/edc-controlplane-postgresql
 
 Eclipse Tractus-X product(s) installed within the image:
 
-### TractusX-EDC Control Plane
+## TractusX-EDC Control Plane
 
 - GitHub: https://github.com/eclipse-tractusx/tractusx-edc
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
 - Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-postgresql/src/main/docker/Dockerfile
 - Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
 
-**Used base image**
+## Used base image
 
 - [eclipse-temurin:11.0.18_10-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
@@ -26,4 +26,3 @@ from the base distribution, along with any direct or indirect dependencies of th
 
 As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
 with any relevant licenses for all software contained within.
-

--- a/edc-controlplane/edc-controlplane-postgresql/notice.md
+++ b/edc-controlplane/edc-controlplane-postgresql/notice.md
@@ -1,0 +1,28 @@
+## Notice for Docker image
+
+This application provides container images for demonstration purposes.
+
+DockerHub: https://hub.docker.com/r/tractusx/edc-controlplane-postgresql
+
+Eclipse Tractus-X product(s) installed within the image:
+
+- GitHub: https://github.com/eclipse-tractusx/tractusx-edc
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+-
+Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-postgresql/src/main/docker/Dockerfile
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
+
+**Used base image**
+
+- [eclipse-temurin:11.0.18_10-jre-alpine](https://github.com/adoptium/containers)
+- Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
+- Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
+- Additional information about the Eclipse Temurin
+  images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
+
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
+from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
+with any relevant licenses for all software contained within.
+

--- a/edc-dataplane/edc-dataplane-azure-vault/notice.md
+++ b/edc-dataplane/edc-dataplane-azure-vault/notice.md
@@ -1,19 +1,15 @@
 ## Notice for Docker image
 
-An EDC Control Plane using PostgreSQL as persistence backend, and HashiCorp Vault as secret store.
+An EDC Data Plane using the Azure KeyVault.
 
-DockerHub: https://hub.docker.com/r/tractusx/edc-controlplane-postgresql-hashicorp-vault
+DockerHub: https://hub.docker.com/r/tractusx/edc-dataplane-azure-vault
 
 Eclipse Tractus-X product(s) installed within the image:
 
 - GitHub: https://github.com/eclipse-tractusx/tractusx-edc
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
--
-
-Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
-
-- Project
-  license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
+- Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
 
 **Used base image**
 

--- a/edc-dataplane/edc-dataplane-azure-vault/notice.md
+++ b/edc-dataplane/edc-dataplane-azure-vault/notice.md
@@ -6,6 +6,8 @@ DockerHub: https://hub.docker.com/r/tractusx/edc-dataplane-azure-vault
 
 Eclipse Tractus-X product(s) installed within the image:
 
+### TractusX-EDC Data Plane
+
 - GitHub: https://github.com/eclipse-tractusx/tractusx-edc
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
 - Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile

--- a/edc-dataplane/edc-dataplane-azure-vault/notice.md
+++ b/edc-dataplane/edc-dataplane-azure-vault/notice.md
@@ -1,4 +1,4 @@
-## Notice for Docker image
+# Notice for Docker image
 
 An EDC Data Plane using the Azure KeyVault.
 
@@ -6,14 +6,14 @@ DockerHub: https://hub.docker.com/r/tractusx/edc-dataplane-azure-vault
 
 Eclipse Tractus-X product(s) installed within the image:
 
-### TractusX-EDC Data Plane
+## TractusX-EDC Data Plane
 
 - GitHub: https://github.com/eclipse-tractusx/tractusx-edc
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
 - Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
 - Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
 
-**Used base image**
+## Used base image
 
 - [eclipse-temurin:11.0.18_10-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
@@ -26,4 +26,3 @@ from the base distribution, along with any direct or indirect dependencies of th
 
 As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
 with any relevant licenses for all software contained within.
-

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/notice.md
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/notice.md
@@ -1,19 +1,16 @@
 ## Notice for Docker image
 
-An EDC Control Plane using PostgreSQL as persistence backend, and HashiCorp Vault as secret store.
+An EDC Data Plane using the HashiCorp Vault
 
-DockerHub: https://hub.docker.com/r/tractusx/edc-controlplane-postgresql-hashicorp-vault
+DockerHub: https://hub.docker.com/r/tractusx/edc-dataplane-hashicorp-vault
 
 Eclipse Tractus-X product(s) installed within the image:
 
 - GitHub: https://github.com/eclipse-tractusx/tractusx-edc
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
 -
-
-Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
-
-- Project
-  license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
+Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
 
 **Used base image**
 

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/notice.md
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/notice.md
@@ -1,4 +1,4 @@
-## Notice for Docker image
+# Notice for Docker image
 
 An EDC Data Plane using the HashiCorp Vault
 
@@ -6,14 +6,14 @@ DockerHub: https://hub.docker.com/r/tractusx/edc-dataplane-hashicorp-vault
 
 Eclipse Tractus-X product(s) installed within the image:
 
-### TractusX-EDC Data Plane
+## TractusX-EDC Data Plane
 
 - GitHub: https://github.com/eclipse-tractusx/tractusx-edc
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
 - Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
 - Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
 
-**Used base image**
+## Used base image
 
 - [eclipse-temurin:11.0.18_10-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
@@ -26,4 +26,3 @@ from the base distribution, along with any direct or indirect dependencies of th
 
 As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
 with any relevant licenses for all software contained within.
-

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/notice.md
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/notice.md
@@ -6,10 +6,11 @@ DockerHub: https://hub.docker.com/r/tractusx/edc-dataplane-hashicorp-vault
 
 Eclipse Tractus-X product(s) installed within the image:
 
+### TractusX-EDC Data Plane
+
 - GitHub: https://github.com/eclipse-tractusx/tractusx-edc
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
--
-Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
+- Dockerfile: https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
 - Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/develop/LICENSE)
 
 **Used base image**


### PR DESCRIPTION
## WHAT

This PR targets DockerHub when publishing Docker images instead of the GitHub Packages registry.

## WHY

Eclipse projects cannot have public packages in their GH Packages registry.

## FURTHER NOTES
- updates the deployment specs of our helm charts
- since we publish several docker images, several `notice.md` files (as required by Eclipse) were created
- 