### PR TITLE
docs(control-plane-adapter): improve documentation on how to use the control-plane adapter extension

### DIFF
--- a/edc-extensions/control-plane-adapter/README.md
+++ b/edc-extensions/control-plane-adapter/README.md
@@ -41,7 +41,7 @@ To run CP-Adapter in "PERSISTENT" mode, You need to create a proper tables with 
    ```plain
    {controlplaneUrl}:{web.http.management.port}/{web.http.management.path}/adapter/asset/sync/{assetId}?providerUrl={providerUrl}
    ```
-   
+
    | Name                       | Description                                                                      |
    |----------------------------|----------------------------------------------------------------------------------|
    | `controlplaneUrl`          | The URL where the control plane of the consumer connector is available           |

--- a/edc-extensions/control-plane-adapter/README.md
+++ b/edc-extensions/control-plane-adapter/README.md
@@ -39,8 +39,15 @@ To run CP-Adapter in "PERSISTENT" mode, You need to create a proper tables with 
 1. Client sends a GET request with two parameters: assetId and the url of the provider controlplane:
 
    ```plain
-   /adapter/asset/sync/{assetId}?providerUrl={providerUrl}
+   {controlplaneUrl}:{web.http.management.port}/{web.http.management.path}/adapter/asset/sync/{assetId}?providerUrl={providerUrl}
    ```
+   | Name                       | Description                                                         |
+   |----------------------------|---------------------------------------------------------------------|
+   | `controlplaneUrl`          | The URL where the control plane of the consumer connector is hosted |
+   | `web.http.management.port` | Port of the management API provided by the control plane            |
+   | `web.http.management.path` | Path of the management API provided by the control plane            |
+   | `assetId`                  | ID of the wanted asset                                              |
+   | `providerUrl`              | URL leading to the provider connector                               |
 
    The example ULR could be:
 

--- a/edc-extensions/control-plane-adapter/README.md
+++ b/edc-extensions/control-plane-adapter/README.md
@@ -41,13 +41,14 @@ To run CP-Adapter in "PERSISTENT" mode, You need to create a proper tables with 
    ```plain
    {controlplaneUrl}:{web.http.management.port}/{web.http.management.path}/adapter/asset/sync/{assetId}?providerUrl={providerUrl}
    ```
-   | Name                       | Description                                                         |
-   |----------------------------|---------------------------------------------------------------------|
-   | `controlplaneUrl`          | The URL where the control plane of the consumer connector is hosted |
-   | `web.http.management.port` | Port of the management API provided by the control plane            |
-   | `web.http.management.path` | Path of the management API provided by the control plane            |
-   | `assetId`                  | ID of the wanted asset                                              |
-   | `providerUrl`              | URL leading to the provider connector                               |
+   
+   | Name                       | Description                                                                      |
+   |----------------------------|----------------------------------------------------------------------------------|
+   | `controlplaneUrl`          | The URL where the control plane of the consumer connector is available           |
+   | `web.http.management.port` | Port of the management API provided by the control plane                         |
+   | `web.http.management.path` | Path of the management API provided by the control plane                         |
+   | `assetId`                  | ID of the wanted asset                                                           |
+   | `providerUrl`              | URL pointing to the `data` endpoint of the IDS context of the provider connector |
 
    The example ULR could be:
 


### PR DESCRIPTION
### What needs to be changed?
The documentation of the Control-Plane-Adapter extension on how to request an asset.

### Why does it need to be changed?
The current documentation may lead to misunderstandings and is not clear enough.