### PR TITLE
chore: update to temurin 17

### DIFF
--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -60,7 +60,7 @@ runs:
     - name: Set up JDK 11
       uses: actions/setup-java@v3.11.0
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: 'gradle'
     - name: Build Controlplane

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3.11.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       # Build
@@ -147,7 +147,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3.11.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       - name: Import GPG Key

--- a/.github/workflows/business-tests.yaml
+++ b/.github/workflows/business-tests.yaml
@@ -55,7 +55,7 @@ jobs:
         name: Set-Up JDK 11
         uses: actions/setup-java@v3.11.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       -

--- a/.github/workflows/draft-new-release.yaml
+++ b/.github/workflows/draft-new-release.yaml
@@ -36,7 +36,7 @@ jobs:
         name: Set up JDK 11
         uses: actions/setup-java@v3.11.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       -

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -60,7 +60,7 @@ jobs:
         name: Set up JDK 11
         uses: actions/setup-java@v3.11.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
 
@@ -181,7 +181,7 @@ jobs:
         name: Set up JDK 11
         uses: actions/setup-java@v3.11.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       -

--- a/.github/workflows/veracode.yaml
+++ b/.github/workflows/veracode.yaml
@@ -33,7 +33,7 @@ jobs:
         name: Set up JDK 11
         uses: actions/setup-java@v3.11.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       -
@@ -62,7 +62,7 @@ jobs:
         name: Set up JDK 11
         uses: actions/setup-java@v3.11.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       # Build
@@ -111,7 +111,7 @@ jobs:
         name: Set up JDK 11
         uses: actions/setup-java@v3.11.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       # Build

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3.11.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       - name: Verify proper formatting
@@ -96,7 +96,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3.11.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
 
@@ -113,7 +113,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3.11.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
 
@@ -130,7 +130,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3.11.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
 
@@ -147,7 +147,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3.11.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
 
@@ -168,7 +168,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3.11.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       - name: Cache SonarCloud packages

--- a/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:11.0.18_10-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin

--- a/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
@@ -26,7 +26,7 @@ HEALTHCHECK NONE
 
 RUN wget ${OTEL_AGENT_LOCATION} -O /tmp/opentelemetry-javaagent.jar
 
-FROM eclipse-temurin:11.0.18_10-jre-alpine
+FROM eclipse-temurin:17-jre-alpine
 ARG JAR
 
 ARG APP_USER=docker

--- a/edc-controlplane/edc-controlplane-memory/notice.md
+++ b/edc-controlplane/edc-controlplane-memory/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:11.0.18_10-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin

--- a/edc-controlplane/edc-controlplane-memory/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-memory/src/main/docker/Dockerfile
@@ -26,7 +26,7 @@ HEALTHCHECK NONE
 
 RUN wget ${OTEL_AGENT_LOCATION} -O /tmp/opentelemetry-javaagent.jar
 
-FROM eclipse-temurin:11.0.18_10-jre-alpine
+FROM eclipse-temurin:17-jre-alpine
 ARG JAR
 
 ARG APP_USER=docker

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:11.0.18_10-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
@@ -26,7 +26,7 @@ HEALTHCHECK NONE
 
 RUN wget ${OTEL_AGENT_LOCATION} -O /tmp/opentelemetry-javaagent.jar
 
-FROM eclipse-temurin:11.0.18_10-jre-alpine
+FROM eclipse-temurin:17-jre-alpine
 ARG JAR
 
 ARG APP_USER=docker

--- a/edc-controlplane/edc-controlplane-postgresql/notice.md
+++ b/edc-controlplane/edc-controlplane-postgresql/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:11.0.18_10-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin

--- a/edc-controlplane/edc-controlplane-postgresql/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql/src/main/docker/Dockerfile
@@ -26,7 +26,7 @@ HEALTHCHECK NONE
 
 RUN wget ${OTEL_AGENT_LOCATION} -O /tmp/opentelemetry-javaagent.jar
 
-FROM eclipse-temurin:11.0.18_10-jre-alpine
+FROM eclipse-temurin:17-jre-alpine
 ARG JAR
 
 ARG APP_USER=docker

--- a/edc-dataplane/edc-dataplane-azure-vault/notice.md
+++ b/edc-dataplane/edc-dataplane-azure-vault/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:11.0.18_10-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin

--- a/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
@@ -26,7 +26,7 @@ HEALTHCHECK NONE
 
 RUN wget ${OTEL_AGENT_LOCATION} -O /tmp/opentelemetry-javaagent.jar
 
-FROM eclipse-temurin:11.0.18_10-jre-alpine
+FROM eclipse-temurin:17-jre-alpine
 ARG JAR
 
 ARG APP_USER=docker

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/notice.md
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:11.0.18_10-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
@@ -26,7 +26,7 @@ HEALTHCHECK NONE
 
 RUN wget ${OTEL_AGENT_LOCATION} -O /tmp/opentelemetry-javaagent.jar
 
-FROM eclipse-temurin:11.0.18_10-jre-alpine
+FROM eclipse-temurin:17-jre-alpine
 ARG JAR
 
 ARG APP_USER=docker


### PR DESCRIPTION
## WHAT
updates all Dockerfiles and CI jobs to use `temurin-17`

## WHY
it is the latest LTS version