### PR TITLE
fix: only run trivy when docker images were actually built

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -74,13 +74,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3.3.0
+
+        ## This step will fail if the docker images is not found
       - name: "Check if image exists"
+        id: imageCheck
         run: |
           docker manifest inspect tractusx/${{ matrix.image }}:sha-${{ needs.git-sha7.outputs.value }}
         continue-on-error: true
-        
+
+        ## the next two steps will only execute if the image exists check was successful
       - name: Run Trivy vulnerability scanner
-        if: success()
+        if: success() && steps.imageCheck.outcome != 'failure'
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: "tractusx/${{ matrix.image }}:sha-${{ needs.git-sha7.outputs.value }}"
@@ -90,7 +94,7 @@ jobs:
           severity: "CRITICAL,HIGH"
           timeout: "10m0s"
       - name: Upload Trivy scan results to GitHub Security tab
-        if: always()
+        if: success() && steps.imageCheck.outcome != 'failure'
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: "trivy-results-${{ matrix.image }}.sarif"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -74,8 +74,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3.3.0
+      - name: "Check if image exists"
+        run: |
+          docker manifest inspect tractusx/${{ matrix.image }}:sha-${{ needs.git-sha7.outputs.value }}
+        continue-on-error: true
+        
       - name: Run Trivy vulnerability scanner
-        if: always()
+        if: success()
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: "tractusx/${{ matrix.image }}:sha-${{ needs.git-sha7.outputs.value }}"


### PR DESCRIPTION
## WHAT

This job configures the `trivy.yaml` workflow to check if an image exists, and only then does it run the scanner.

## WHY

Since the `trivy` flow is executed by the `Build` flow, and because there is no way to check if docker images were actually published, the trivy flow would fail "by design" on pull requests and on forks.

## FURTHER NOTES

Even though the issue suggests a different approach, I discovered that it is much easier to simply check for the existence of a docker image with `docker manifest inspect`, which fails if the image was not found.

Closes #239 
