### PR TITLE
refactor: Extract the checkout and setup-java action into a re-usable action

### DIFF
--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -41,8 +41,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+    - uses: ./.github/actions/checkout
 
     #####################
     # Login to DockerHub
@@ -56,12 +55,7 @@ runs:
     #####################
     # Build JAR file
     #####################
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3.11.0
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: 'gradle'
+    - uses: ./.github/actions/setup-java
     - name: Build Controlplane
       shell: bash
       run: |-

--- a/.github/actions/run-deployment-test/action.yml
+++ b/.github/actions/run-deployment-test/action.yml
@@ -42,8 +42,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@v3.3.0
+    - uses: ./.github/actions/checkout
 
     - name: Cache ContainerD Image Layers
       uses: actions/cache@v3
@@ -51,12 +50,7 @@ runs:
         path: /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs
         key: ${{ runner.os }}-io.containerd.snapshotter.v1.overlayfs
 
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3.11.0
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: 'gradle'
+    - uses: ./.github/actions/setup-java
 
     - name: Build docker images
       shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,14 +71,8 @@ jobs:
     needs: [ secret-presence ]
     steps:
       # Set-Up
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/checkout
+      - uses: ./.github/actions/setup-java
       # Build
       - name: Build Extensions
         run: |-
@@ -104,8 +98,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: ./.github/actions/checkout
       - uses: ./.github/actions/publish-docker-image
         with:
           rootDir: edc-controlplane/${{ matrix.name }}
@@ -128,8 +121,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: ./.github/actions/checkout
       - uses: ./.github/actions/publish-docker-image
         with:
           rootDir: edc-dataplane/${{ matrix.name }}
@@ -149,15 +141,9 @@ jobs:
       needs.secret-presence.outputs.GPG_PASSPHRASE && needs.secret-presence.outputs.GPG_PRIVATE_KEY && github.event_name != 'pull_request' && github.ref != 'refs/heads/releases'
     steps:
       # Set-Up
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
+      - uses: ./.github/actions/checkout
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-java
       - name: Import GPG Key
         uses: crazy-max/ghaction-import-gpg@v5
         with:

--- a/.github/workflows/business-tests.yaml
+++ b/.github/workflows/business-tests.yaml
@@ -50,15 +50,9 @@ jobs:
       ### Set-Up ###
       ##############
       -
-        name: Checkout
-        uses: actions/checkout@v3.3.0
+        uses: ./.github/actions/checkout
       -
-        name: Set-Up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+        uses: ./.github/actions/setup-java
       -
         name: Cache ContainerD Image Layers
         uses: actions/cache@v3

--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -47,8 +47,7 @@ jobs:
   deployment-test-memory:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
+      - uses: ./.github/actions/checkout
       - uses: ./.github/actions/run-deployment-test
         name: "Run deployment test using KinD and Helm"
         with:

--- a/.github/workflows/draft-new-release.yaml
+++ b/.github/workflows/draft-new-release.yaml
@@ -18,7 +18,7 @@ jobs:
       pages: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: ./.github/actions/checkout
       -
         name: Create release branch
         run: git checkout -b release/${{ github.event.inputs.version }}
@@ -33,12 +33,7 @@ jobs:
           git config user.name "GitHub actions"
           git config user.email noreply@github.com
       -
-        name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+        uses: ./.github/actions/setup-java
       -
         name: Bump version in gradle.properties
         run: |-

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -38,8 +38,7 @@ jobs:
 
     steps:
       # fetch-depth: 0 is required to determine differences in chart(s)
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: ./.github/actions/checkout
         with:
           fetch-depth: 0
 

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -26,8 +26,7 @@ jobs:
     ### Set-Up ###
     ##############
     -
-      name: Checkout
-      uses: actions/checkout@v3.3.0
+      uses: ./.github/actions/checkout
       with:
         fetch-depth: 0
     -

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -20,7 +20,7 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: ./.github/actions/checkout
 
       - name: KICS scan
         uses: checkmarx/kics-github-action@v1.5

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -50,8 +50,7 @@ jobs:
       contents: write
       packages: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: ./.github/actions/checkout
       - uses: ./.github/actions/publish-docker-image
         with:
           rootDir: edc-controlplane/${{ matrix.name }}
@@ -74,8 +73,7 @@ jobs:
       contents: write
       packages: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: ./.github/actions/checkout
       - uses: ./.github/actions/publish-docker-image
         with:
           rootDir: edc-dataplane/${{ matrix.name }}

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -54,15 +54,9 @@ jobs:
         run: |
           echo "RELEASE_VERSION=${{ needs.release-version.outputs.RELEASE_VERSION }}" >> $GITHUB_ENV
       -
-        name: Checkout
-        uses: actions/checkout@v3.3.0
+        uses: ./.github/actions/checkout
       -
-        name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+        uses: ./.github/actions/setup-java
 
       - name: Import GPG Key
         uses: crazy-max/ghaction-import-gpg@v5
@@ -96,8 +90,7 @@ jobs:
         run: |
           echo "RELEASE_VERSION=${{ needs.release-version.outputs.RELEASE_VERSION }}" >> $GITHUB_ENV
       -
-        name: Checkout
-        uses: actions/checkout@v3.3.0
+        uses: ./.github/actions/checkout
         with:
           fetch-depth: 0
       -
@@ -144,8 +137,7 @@ jobs:
         run: |
           echo "RELEASE_VERSION=${{ needs.release-version.outputs.RELEASE_VERSION }}" >> $GITHUB_ENV
       -
-        name: Checkout
-        uses: actions/checkout@v3.3.0
+        uses: ./.github/actions/checkout
         with:
           # 0 to fetch the full history due to upcoming merge of releases into main branch
           fetch-depth: 0
@@ -177,12 +169,7 @@ jobs:
           draft: false
           prerelease: false
       -
-        name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+        uses: ./.github/actions/setup-java
       -
         name: Merge releases back into main and set new snapshot version
         if: github.event.pull_request.base.ref == 'releases'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -36,8 +36,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3.3.0
+      - uses: ./.github/actions/checkout
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@master
         with:
@@ -72,8 +71,7 @@ jobs:
           - edc-dataplane-azure-vault
           - edc-dataplane-hashicorp-vault
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
+      - uses: ./.github/actions/checkout
       - name: Run Trivy vulnerability scanner
         if: always()
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/veracode.yaml
+++ b/.github/workflows/veracode.yaml
@@ -23,16 +23,10 @@ jobs:
   verify-formatting:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
+      - uses: ./.github/actions/checkout
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-java
       - name: Verify proper formatting
         run: ./gradlew spotlessCheck
 
@@ -51,14 +45,8 @@ jobs:
           - edc-controlplane-postgresql-hashicorp-vault
     steps:
       # Set-Up
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/checkout
+      - uses: ./.github/actions/setup-java
       # Build
       - name: Build Controlplane
         run: |-
@@ -95,14 +83,8 @@ jobs:
           - edc-dataplane-hashicorp-vault
     steps:
       # Set-Up
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/checkout
+      - uses: ./.github/actions/setup-java
       # Build
       - name: Build Dataplane
         run: |-

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -58,15 +58,9 @@ jobs:
   verify-formatting:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
+      - uses: ./.github/actions/checkout
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-java
       - name: Verify proper formatting
         run: ./gradlew spotlessCheck
 
@@ -78,7 +72,7 @@ jobs:
   markdown-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ./.github/actions/checkout
 
       - name: Install mardkdownlint
         run: npm install -g markdownlint-cli2
@@ -91,15 +85,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ verify-formatting ]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
+      - uses: ./.github/actions/checkout
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-java
 
       - name: Run Unit tests
         run: ./gradlew test
@@ -108,15 +96,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ verify-formatting ]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
+      - uses: ./.github/actions/checkout
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-java
 
       - name: Run Integration tests
         run: ./gradlew test -DincludeTags="ComponentTest"
@@ -125,15 +107,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ verify-formatting ]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
+      - uses: ./.github/actions/checkout
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-java
 
       - name: Run API tests
         run: ./gradlew test -DincludeTags="ApiTest"
@@ -142,15 +118,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ verify-formatting ]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
+      - uses: ./.github/actions/checkout
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-java
 
       - name: Run E2E tests
         run: ./gradlew :edc-tests:runtime:build test -DincludeTags="EndToEndTest"
@@ -162,16 +132,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Set-Up
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
+      - uses: ./.github/actions/checkout
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-java
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
## WHAT

Extract the checkout and setup-java action into a re-usable action

## WHY

Avoid duplication, create consistency, one place to maintain the code, e.g. for version upgrades

## FURTHER NOTES

Closes #231 
