### PR TITLE
build(deps): add constraints to avoid vulnerable transitive dependencies

### DIFF
--- a/edc-controlplane/edc-controlplane-postgresql/build.gradle.kts
+++ b/edc-controlplane/edc-controlplane-postgresql/build.gradle.kts
@@ -11,6 +11,11 @@ dependencies {
     runtimeOnly(project(":edc-controlplane:edc-controlplane-base"))
     runtimeOnly(project(":edc-extensions:postgresql-migration"))
     runtimeOnly(edc.azure.vault)
+    constraints {
+        implementation("net.minidev:json-smart:2.4.10") {
+            because("version 2.4.8 has vulnerabilities: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1370.")
+        }
+    }
     runtimeOnly(edc.bundles.sqlstores)
     runtimeOnly(edc.transaction.local)
     runtimeOnly(edc.sql.pool)

--- a/edc-dataplane/edc-dataplane-azure-vault/build.gradle.kts
+++ b/edc-dataplane/edc-dataplane-azure-vault/build.gradle.kts
@@ -8,6 +8,11 @@ plugins {
 dependencies {
     implementation(project(":edc-dataplane:edc-dataplane-base"))
     implementation(edc.azure.vault)
+    constraints {
+        implementation("net.minidev:json-smart:2.4.10") {
+            because("version 2.4.8 has vulnerabilities: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1370.")
+        }
+    }
     implementation(edc.azure.identity)
     implementation("com.azure:azure-security-keyvault-secrets:4.6.0")
 }

--- a/edc-extensions/control-plane-adapter/build.gradle.kts
+++ b/edc-extensions/control-plane-adapter/build.gradle.kts
@@ -8,7 +8,14 @@ plugins {
 dependencies {
     implementation(edc.spi.core)
     implementation(edc.spi.policy)
+
     implementation(edc.api.management)
+    constraints {
+        implementation("org.yaml:snakeyaml:2.0") {
+            because("version 1.33 has vulnerabilities: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1471.")
+        }
+    }
+
     implementation(edc.spi.catalog)
     implementation(edc.spi.transactionspi)
     implementation(edc.spi.transaction.datasource)


### PR DESCRIPTION
## WHAT

constraints: 
- `net.minidev:json-smart` to version `2.4.10`
- `org.yaml:snakeyaml` to version `2.0`

## WHY

to avoid hi-level vulnerabilities detected by veracode

## FURTHER NOTES


Closes #258 
