### PR TITLE
Fix wrong helm install command

### DIFF
--- a/charts/tractusx-connector-memory/README.md.gotmpl
+++ b/charts/tractusx-connector-memory/README.md.gotmpl
@@ -12,7 +12,7 @@
 
 ```shell
 helm repo add tractusx-edc https://eclipse-tractusx.github.io/charts/dev
-helm install my-release tractusx-edc/tractusx-connector --version {{ .Version }}
+helm install my-release tractusx-edc/tractusx-connector-memory --version {{ .Version }}
 ```
 
 {{ template "chart.maintainersSection" . }}


### PR DESCRIPTION
## WHAT

In the README.md of the memory helm chart is the wrong chart referenced.
