### PR TITLE
feat: add GitHub workflow to automaticly add features to project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,17 @@
+name: Add to Project
+
+on:
+  issues:
+    types: [ opened ]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue to project
+        uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/eclipse-tractusx/projects/5
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          labeled: bug
+          label-operator: NOT


### PR DESCRIPTION
Workflow to add created issues (not bugs) to the Feature board

## WHAT

With this workflow, new features are automatically added to the related project/board.

## WHY

Since more and more work is being done in GitHub and issues are also being created, it is currently difficult to keep track of everything. Priorities can also not be seen immediately.

## FURTHER NOTES

This PR just adds the functionality to add issues to the board. Handling bugs is done after issues works well and is approved by the PO.

Closes #263 
