### PR TITLE
chore(build): add GHA variables for sonar project and org

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -151,8 +151,8 @@ jobs:
         run: |-
           ./gradlew sonar \
             -Pcoverage,failsafe \
-            -Dsonar.projectKey=${GITHUB_REPOSITORY_OWNER}_product-edc \
-            -Dsonar.organization=${GITHUB_REPOSITORY_OWNER} \
+            -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }} \
+            -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }} \
             -Dsonar.host.url=https://sonarcloud.io \
             -Dsonar.coverage.jacoco.xmlReportPaths=${GITHUB_WORKSPACE}/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml \
             -Dsonar.verbose=true


### PR DESCRIPTION
## WHAT

Reads the SonarCloud organization and project from GH Actions vars. Also, the `SONAR_TOKEN` secret was [added to our repo by the Eclipse Helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3047)

## WHY

Have Sonar runs available upstream -> QGate requirement (?)

## FURTHER NOTES

.

Closes # <-- _insert Issue number if one exists_
