### PR TITLE
chore(build): remove CI-triggered sonar job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,6 @@ jobs:
   secret-presence:
     runs-on: ubuntu-latest
     outputs:
-      SONAR_TOKEN: ${{ steps.secret-presence.outputs.SONAR_TOKEN }}
       GPG_PRIVATE_KEY: ${{ steps.secret-presence.outputs.GPG_PRIVATE_KEY }}
       GPG_PASSPHRASE: ${{ steps.secret-presence.outputs.GPG_PASSPHRASE }}
       DOCKER_HUB_TOKEN: ${{ steps.secret-presence.outputs.DOCKER_HUB_TOKEN }}
@@ -60,7 +59,6 @@ jobs:
       - name: Check whether secrets exist
         id: secret-presence
         run: |
-          [ ! -z "${{ secrets.SONAR_TOKEN }}" ] && echo "SONAR_TOKEN=true" >> $GITHUB_OUTPUT
           [ ! -z "${{ secrets.GPG_PRIVATE_KEY }}" ] && echo "GPG_PRIVATE_KEY=true" >> $GITHUB_OUTPUT
           [ ! -z "${{ secrets.GPG_PASSPHRASE }}" ] && echo "GPG_PASSPHRASE=true" >> $GITHUB_OUTPUT
           [ ! -z "${{ secrets.DOCKER_HUB_TOKEN }}" ] && echo "DOCKER_HUB_TOKEN=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -44,16 +44,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  secret-presence:
-    runs-on: ubuntu-latest
-    outputs:
-      SONAR_TOKEN: ${{ steps.secret-presence.outputs.SONAR_TOKEN }}
-    steps:
-      - name: Check whether secrets exist
-        id: secret-presence
-        run: |
-          [ ! -z "${{ secrets.SONAR_TOKEN }}" ] && echo "SONAR_TOKEN=true" >> $GITHUB_OUTPUT
-          exit 0
 
   verify-formatting:
     runs-on: ubuntu-latest
@@ -124,37 +114,3 @@ jobs:
 
       - name: Run E2E tests
         run: ./gradlew :edc-tests:runtime:build test -DincludeTags="EndToEndTest"
-
-  sonar:
-    needs: [ secret-presence, verify-formatting ]
-    if: |
-      needs.secret-presence.outputs.SONAR_TOKEN
-    runs-on: ubuntu-latest
-    steps:
-      # Set-Up
-      - uses: actions/checkout@v3.5.2
-        with:
-          fetch-depth: 0
-      - uses: ./.github/actions/setup-java
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-      # Analyse
-      - name: Build with Maven and analyze with Sonar
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          JACOCO: true
-        run: |-
-          ./gradlew sonar \
-            -Pcoverage,failsafe \
-            -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }} \
-            -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }} \
-            -Dsonar.host.url=https://sonarcloud.io \
-            -Dsonar.coverage.jacoco.xmlReportPaths=${GITHUB_WORKSPACE}/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml \
-            -Dsonar.verbose=true
-
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     id("com.diffplug.spotless") version "6.18.0"
     id("com.github.johnrengelman.shadow") version "8.1.1"
     id("com.bmuschko.docker-remote-api") version "9.3.1"
-    id("org.sonarqube") version "4.0.0.2929"
 }
 
 val javaVersion: String by project
@@ -37,15 +36,9 @@ project.subprojects.forEach {
     }
 }
 
-// make sure the test report aggregation is done before reporting to sonar
-tasks.sonar {
-    dependsOn(tasks.named<JacocoReport>("testCodeCoverageReport"))
-}
-
 allprojects {
     apply(plugin = "org.eclipse.edc.edc-build")
     apply(plugin = "io.freefair.lombok")
-    apply(plugin = "org.sonarqube")
 
     repositories {
         mavenCentral()
@@ -159,12 +152,6 @@ subprojects {
 
             // make sure "shadowJar" always runs before "dockerize"
             dockerTask.dependsOn(tasks.findByName(ShadowJavaPlugin.SHADOW_JAR_TASK_NAME))
-        }
-    }
-
-    sonarqube {
-        properties {
-            property("sonar.moduleKey", "${project.group}-${project.name}")
         }
     }
 }


### PR DESCRIPTION
## WHAT

Removes the Sonar job from our CI workflows, and all related configuration, such as build scripts and secrets.

## WHY

According to the [documentation](https://community.sonarsource.com/t/sonarcloud-task-fails-because-of-ci-analysis-and-auto-analysis-running/22937/4) we can either have the automatic scan, _or_ a CI-triggered scan, not both.

## FURTHER NOTES

While there is little technical difference whether we perform a manual (=CI-triggered) or automatic scan, having this done automatically seems to be the more streamlined approach to me personally.

Closes # <-- _insert Issue number if one exists_
