### PR TITLE
chore: remove all printstacktrace statements

### DIFF
--- a/edc-extensions/control-plane-adapter/src/main/java/org/eclipse/tractusx/edc/cp/adapter/service/objectstore/ObjectStoreServiceInMemory.java
+++ b/edc-extensions/control-plane-adapter/src/main/java/org/eclipse/tractusx/edc/cp/adapter/service/objectstore/ObjectStoreServiceInMemory.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
+import org.eclipse.edc.spi.EdcException;
 
 @AllArgsConstructor
 public class ObjectStoreServiceInMemory implements ObjectStoreService {
@@ -33,7 +34,7 @@ public class ObjectStoreServiceInMemory implements ObjectStoreService {
     try {
       map.put(getKey(key, objectType), mapper.writeValueAsString(object));
     } catch (JsonProcessingException e) {
-      e.printStackTrace();
+
       throw new IllegalArgumentException();
     }
   }
@@ -67,7 +68,7 @@ public class ObjectStoreServiceInMemory implements ObjectStoreService {
     try {
       object = mapper.readValue(json, type);
     } catch (JsonProcessingException e) {
-      e.printStackTrace();
+      throw new EdcException(e);
     }
     return object;
   }

--- a/edc-extensions/control-plane-adapter/src/main/java/org/eclipse/tractusx/edc/cp/adapter/service/objectstore/ObjectStoreServiceSql.java
+++ b/edc-extensions/control-plane-adapter/src/main/java/org/eclipse/tractusx/edc/cp/adapter/service/objectstore/ObjectStoreServiceSql.java
@@ -70,7 +70,7 @@ public class ObjectStoreServiceSql implements ObjectStoreService {
     try {
       return mapper.writeValueAsString(object);
     } catch (JsonProcessingException e) {
-      e.printStackTrace();
+
       throw new IllegalArgumentException(String.format("Can not parse object of type %s", type));
     }
   }
@@ -79,7 +79,7 @@ public class ObjectStoreServiceSql implements ObjectStoreService {
     try {
       return mapper.readValue(entity.getObject(), type);
     } catch (JsonProcessingException e) {
-      e.printStackTrace();
+
       throw new IllegalArgumentException(String.format("Can not parse object of type %s", type));
     }
   }

--- a/edc-extensions/control-plane-adapter/src/main/java/org/eclipse/tractusx/edc/cp/adapter/store/SqlObjectStore.java
+++ b/edc-extensions/control-plane-adapter/src/main/java/org/eclipse/tractusx/edc/cp/adapter/store/SqlObjectStore.java
@@ -58,7 +58,7 @@ public class SqlObjectStore extends AbstractSqlStore {
                 objectEntity.getType(),
                 objectEntity.getObject());
           } catch (SQLException e) {
-            e.printStackTrace();
+
             throw new EdcPersistenceException(e);
           }
         });
@@ -71,7 +71,7 @@ public class SqlObjectStore extends AbstractSqlStore {
             var sql = statements.getFindByIdAndTypeTemplate();
             return executeQuerySingle(connection, false, this::mapObjectEntity, sql, id, type);
           } catch (SQLException e) {
-            e.printStackTrace();
+
             throw new EdcPersistenceException(e);
           }
         });
@@ -88,7 +88,7 @@ public class SqlObjectStore extends AbstractSqlStore {
             stream.close();
             return result;
           } catch (SQLException e) {
-            e.printStackTrace();
+
             throw new EdcPersistenceException(e);
           }
         });
@@ -101,7 +101,7 @@ public class SqlObjectStore extends AbstractSqlStore {
             var stmt = statements.getDeleteTemplate();
             executeQuery(connection, stmt, id, type);
           } catch (SQLException | IllegalStateException e) {
-            e.printStackTrace();
+
             throw new EdcPersistenceException(e);
           }
         });

--- a/edc-extensions/control-plane-adapter/src/main/java/org/eclipse/tractusx/edc/cp/adapter/store/SqlQueueStore.java
+++ b/edc-extensions/control-plane-adapter/src/main/java/org/eclipse/tractusx/edc/cp/adapter/store/SqlQueueStore.java
@@ -69,7 +69,7 @@ public class SqlQueueStore extends AbstractSqlStore {
                 toJson(queueMessage.getMessage()),
                 queueMessage.getInvokeAfter());
           } catch (SQLException e) {
-            e.printStackTrace();
+
             throw new EdcPersistenceException(e);
           }
         });
@@ -82,7 +82,7 @@ public class SqlQueueStore extends AbstractSqlStore {
             var sql = statements.getFindByIdTemplate();
             return executeQuerySingle(connection, false, this::mapQueueMessage, sql, id);
           } catch (SQLException e) {
-            e.printStackTrace();
+
             throw new EdcPersistenceException(e);
           }
         });
@@ -99,7 +99,7 @@ public class SqlQueueStore extends AbstractSqlStore {
               var stmt = statements.getDeleteTemplate();
               executeQuery(connection, stmt, id);
             } catch (SQLException | IllegalStateException e) {
-              e.printStackTrace();
+
               throw new EdcPersistenceException(e);
             }
           }
@@ -123,7 +123,7 @@ public class SqlQueueStore extends AbstractSqlStore {
                   queueMessage.getInvokeAfter(),
                   queueMessage.getId());
             } catch (SQLException | IllegalStateException e) {
-              e.printStackTrace();
+
               throw new EdcPersistenceException(e);
             }
           }
@@ -146,7 +146,7 @@ public class SqlQueueStore extends AbstractSqlStore {
             stream.close();
             return result;
           } catch (SQLException e) {
-            e.printStackTrace();
+
             throw new EdcPersistenceException(e);
           }
         });

--- a/edc-extensions/control-plane-adapter/src/test/java/org/eclipse/tractusx/edc/cp/adapter/service/ResultServiceTest.java
+++ b/edc-extensions/control-plane-adapter/src/test/java/org/eclipse/tractusx/edc/cp/adapter/service/ResultServiceTest.java
@@ -119,7 +119,7 @@ public class ResultServiceTest {
     try {
       Thread.sleep(milisec);
     } catch (InterruptedException e) {
-      e.printStackTrace();
+      throw new RuntimeException(e);
     }
   }
 


### PR DESCRIPTION
## WHAT

Deletes all `e.printStackTrace()` statements in the code base. Some were replaced with throwing a runtime exception.

## WHY

Sonar [complains](https://sonarcloud.io/project/security_hotspots?id=eclipse-tractusx_tractusx-edc&sinceLeakPeriod=true). And we don't print stacktraces. Ever.

## FURTHER NOTES

this module will go away anyways, so I didn't invest any time in coming up with an elaborate exception chain.

Closes # <-- _insert Issue number if one exists_
