### PR TITLE
docs: fix misspelled gradlew commands in the documents

### DIFF
--- a/docs/kit/operation-view/page03_local_setup_controlplane.md
+++ b/docs/kit/operation-view/page03_local_setup_controlplane.md
@@ -18,7 +18,7 @@ The following is a short overview of the necessary steps to start up the default
 TractusX EDC is build with Gradle. The following command creates the default control plane as a docker container:
 
 ```shell
-./gardlew :edc-controlplane:edc-controlplane-postgresql-hashicorp-vault:dockerize
+./gradlew :edc-controlplane:edc-controlplane-postgresql-hashicorp-vault:dockerize
 ```
 
 ## Example Configuration

--- a/docs/kit/operation-view/page04_local_setup_dataplane.md
+++ b/docs/kit/operation-view/page04_local_setup_dataplane.md
@@ -18,7 +18,7 @@ The following is a short overview of the necessary steps to start up the default
 TractusX EDC is build with Gradle. The following command creates the default data plane as a docker container:
 
 ```shell
-./gardlew :edc-dataplane:edc-dataplane-hashicorp-vault:dockerize
+./gradlew :edc-dataplane:edc-dataplane-hashicorp-vault:dockerize
 ```
 
 ## Example Configuration

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/README.md
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/README.md
@@ -3,7 +3,7 @@
 ## Building
 
 ```shell
-./gardlew :edc-controlplane:edc-controlplane-postgresql-hashicorp-vault:dockerize
+./gradlew :edc-controlplane:edc-controlplane-postgresql-hashicorp-vault:dockerize
 ```
 
 ## Configuration

--- a/edc-controlplane/edc-controlplane-postgresql/README.md
+++ b/edc-controlplane/edc-controlplane-postgresql/README.md
@@ -3,7 +3,7 @@
 ## Building
 
 ```shell
-./gardlew :edc-controlplane:edc-controlplane-postgresql:dockerize
+./gradlew :edc-controlplane:edc-controlplane-postgresql:dockerize
 ```
 
 ## Configuration

--- a/edc-dataplane/edc-dataplane-azure-vault/README.md
+++ b/edc-dataplane/edc-dataplane-azure-vault/README.md
@@ -3,7 +3,7 @@
 ## Building
 
 ```shell
-./gardlew :edc-dataplane:edc-dataplane-azure-vault:dockerize
+./gradlew :edc-dataplane:edc-dataplane-azure-vault:dockerize
 ```
 
 ## Configuration

--- a/edc-dataplane/edc-dataplane-base/README.md
+++ b/edc-dataplane/edc-dataplane-base/README.md
@@ -3,5 +3,5 @@
 ## Building
 
 ```shell
-./gardlew :edc-dataplane:edc-dataplane-base:build
+./gradlew :edc-dataplane:edc-dataplane-base:build
 ```

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/README.md
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/README.md
@@ -3,7 +3,7 @@
 ## Building
 
 ```shell
-./gardlew :edc-dataplane:edc-dataplane-hashicorp-vault:dockerize
+./gradlew :edc-dataplane:edc-dataplane-hashicorp-vault:dockerize
 ```
 
 ## Configuration


### PR DESCRIPTION
## WHAT

This PR fixes misspelled `gradlew` commands in some documents.

## WHY

Fixing misspelled commands enables users to copy-and-paste them.

## FURTHER NOTES

Closes #302 