### PR TITLE
feat(ControlPlaneAdapter): edr cache integration on TransferProcessStarted event

### DIFF
--- a/core/edr-cache-core/build.gradle.kts
+++ b/core/edr-cache-core/build.gradle.kts
@@ -14,17 +14,13 @@
 
 plugins {
     `java-library`
-    `maven-publish`
 }
 
 dependencies {
-    implementation(project(":spi:control-plane-adapter-spi"))
-    implementation(project(":spi:edr-cache-spi"))
     implementation(libs.edc.spi.core)
-    implementation(libs.edc.spi.transfer)
-    implementation(libs.edc.spi.contract)
-    implementation(libs.edc.spi.controlplane)
-    implementation(libs.edc.spi.aggregateservices)
+    implementation(libs.edc.config.filesystem)
+    implementation(libs.edc.util)
 
-    testImplementation(libs.edc.junit)
+    implementation(project(":spi:edr-cache-spi"))
 }
+

--- a/core/edr-cache-core/src/main/java/org/eclipse/tractusx/edc/edr/core/EdrCacheCoreExtension.java
+++ b/core/edr-cache-core/src/main/java/org/eclipse/tractusx/edc/edr/core/EdrCacheCoreExtension.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.edr.core;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.tractusx.edc.edr.core.defaults.InMemoryEndpointDataReferenceCache;
+import org.eclipse.tractusx.edc.edr.core.defaults.PersistentCacheEntry;
+import org.eclipse.tractusx.edc.edr.spi.EndpointDataReferenceCache;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+
+/**
+ * Registers default services for the EDR cache.
+ */
+@Extension(value = EdrCacheCoreExtension.NAME)
+public class EdrCacheCoreExtension implements ServiceExtension {
+    static final String NAME = "EDR Cache Core";
+
+    @Setting("File location of an in-memory EDR cache seed file for testing")
+    private static final String CACHE_TEST_SEED_FILE = "tx.edr.cache.memory.file";
+
+    private static final TypeReference<List<PersistentCacheEntry>> TYPE_REFERENCE = new TypeReference<>() {
+    };
+
+    @Inject
+    private Monitor monitor;
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider(isDefault = true)
+    public EndpointDataReferenceCache edrCache(ServiceExtensionContext context) {
+        var location = context.getSetting(CACHE_TEST_SEED_FILE, null);
+        var cache = new InMemoryEndpointDataReferenceCache();
+        if (location != null) {
+            var entries = loadSeedFile(location);
+            entries.forEach(entry -> cache.save(entry.getEdrEntry(), entry.getEdr()));
+            monitor.info(format("Seeded test EDR cache with %s entries", entries.size()));
+        }
+        return cache;
+    }
+
+    private List<PersistentCacheEntry> loadSeedFile(String configLocation) {
+        var path = new File(configLocation);
+        if (!path.exists()) {
+            monitor.warning(format("Configuration file does not exist: %s. Ignoring.", configLocation));
+            return emptyList();
+        }
+
+        try {
+            return typeManager.getMapper().readValue(path, TYPE_REFERENCE);
+        } catch (IOException e) {
+            throw new EdcException(e);
+        }
+
+    }
+
+}

--- a/core/edr-cache-core/src/main/java/org/eclipse/tractusx/edc/edr/core/EdrCacheCoreExtension.java
+++ b/core/edr-cache-core/src/main/java/org/eclipse/tractusx/edc/edr/core/EdrCacheCoreExtension.java
@@ -14,26 +14,14 @@
 
 package org.eclipse.tractusx.edc.edr.core;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
-import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.tractusx.edc.edr.core.defaults.InMemoryEndpointDataReferenceCache;
-import org.eclipse.tractusx.edc.edr.core.defaults.PersistentCacheEntry;
 import org.eclipse.tractusx.edc.edr.spi.EndpointDataReferenceCache;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-
-import static java.lang.String.format;
-import static java.util.Collections.emptyList;
 
 /**
  * Registers default services for the EDR cache.
@@ -42,17 +30,8 @@ import static java.util.Collections.emptyList;
 public class EdrCacheCoreExtension implements ServiceExtension {
     static final String NAME = "EDR Cache Core";
 
-    @Setting("File location of an in-memory EDR cache seed file for testing")
-    private static final String CACHE_TEST_SEED_FILE = "tx.edr.cache.memory.file";
-
-    private static final TypeReference<List<PersistentCacheEntry>> TYPE_REFERENCE = new TypeReference<>() {
-    };
-
     @Inject
     private Monitor monitor;
-
-    @Inject
-    private TypeManager typeManager;
 
     @Override
     public String name() {
@@ -61,29 +40,7 @@ public class EdrCacheCoreExtension implements ServiceExtension {
 
     @Provider(isDefault = true)
     public EndpointDataReferenceCache edrCache(ServiceExtensionContext context) {
-        var location = context.getSetting(CACHE_TEST_SEED_FILE, null);
-        var cache = new InMemoryEndpointDataReferenceCache();
-        if (location != null) {
-            var entries = loadSeedFile(location);
-            entries.forEach(entry -> cache.save(entry.getEdrEntry(), entry.getEdr()));
-            monitor.info(format("Seeded test EDR cache with %s entries", entries.size()));
-        }
-        return cache;
-    }
-
-    private List<PersistentCacheEntry> loadSeedFile(String configLocation) {
-        var path = new File(configLocation);
-        if (!path.exists()) {
-            monitor.warning(format("Configuration file does not exist: %s. Ignoring.", configLocation));
-            return emptyList();
-        }
-
-        try {
-            return typeManager.getMapper().readValue(path, TYPE_REFERENCE);
-        } catch (IOException e) {
-            throw new EdcException(e);
-        }
-
+        return new InMemoryEndpointDataReferenceCache();
     }
 
 }

--- a/core/edr-cache-core/src/main/java/org/eclipse/tractusx/edc/edr/core/defaults/InMemoryEndpointDataReferenceCache.java
+++ b/core/edr-cache-core/src/main/java/org/eclipse/tractusx/edc/edr/core/defaults/InMemoryEndpointDataReferenceCache.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.edr.core.defaults;
+
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
+import org.eclipse.edc.util.concurrency.LockManager;
+import org.eclipse.tractusx.edc.edr.spi.EndpointDataReferenceCache;
+import org.eclipse.tractusx.edc.edr.spi.EndpointDataReferenceEntry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static org.eclipse.edc.spi.result.StoreResult.notFound;
+import static org.eclipse.edc.spi.result.StoreResult.success;
+
+/**
+ * An in-memory, threadsafe implementation of the cache.
+ */
+public class InMemoryEndpointDataReferenceCache implements EndpointDataReferenceCache {
+    private final LockManager lockManager;
+
+    private final Map<String, List<EndpointDataReferenceEntry>> entriesByAssetId;
+    private final Map<String, EndpointDataReferenceEntry> entriesByEdrId;
+    private final Map<String, EndpointDataReference> edrsByTransferProcessId;
+
+    public InMemoryEndpointDataReferenceCache() {
+        lockManager = new LockManager(new ReentrantReadWriteLock());
+        entriesByAssetId = new HashMap<>();
+        entriesByEdrId = new HashMap<>();
+        edrsByTransferProcessId = new HashMap<>();
+    }
+
+    @Override
+    public @Nullable EndpointDataReference resolveReference(String transferProcessId) {
+        return lockManager.readLock(() -> edrsByTransferProcessId.get(transferProcessId));
+    }
+
+    @Override
+    @NotNull
+    public List<EndpointDataReference> referencesForAsset(String assetId) {
+        var entries = entriesByAssetId.get(assetId);
+        if (entries == null) {
+            return emptyList();
+        }
+        return entries.stream().map(e -> resolveReference(e.getTransferProcessId())).filter(Objects::nonNull).collect(toList());
+    }
+
+    @Override
+    @NotNull
+    public List<EndpointDataReferenceEntry> entriesForAsset(String assetId) {
+        return lockManager.readLock(() -> entriesByAssetId.getOrDefault(assetId, emptyList()));
+    }
+
+    @Override
+    public void save(EndpointDataReferenceEntry entry, EndpointDataReference edr) {
+        lockManager.writeLock(() -> {
+            entriesByEdrId.put(edr.getId(), entry);
+            var list = entriesByAssetId.computeIfAbsent(entry.getAssetId(), k -> new ArrayList<>());
+            list.add(entry);
+
+            edrsByTransferProcessId.put(entry.getTransferProcessId(), edr);
+            return null;
+        });
+    }
+
+    @Override
+    public StoreResult<EndpointDataReferenceEntry> deleteByTransferProcessId(String id) {
+        return lockManager.writeLock(() -> {
+            var edr = edrsByTransferProcessId.remove(id);
+            if (edr == null) {
+                return notFound("EDR entry not found for id: " + id);
+            }
+            var entry = entriesByEdrId.get(edr.getId());
+            var entries = entriesByAssetId.get(entry.getAssetId());
+            entries.remove(entry);
+            if (entries.isEmpty()) {
+                entriesByAssetId.remove(entry.getAssetId());
+            }
+            return success(entry);
+        });
+    }
+}

--- a/core/edr-cache-core/src/main/java/org/eclipse/tractusx/edc/edr/core/defaults/PersistentCacheEntry.java
+++ b/core/edr-cache-core/src/main/java/org/eclipse/tractusx/edc/edr/core/defaults/PersistentCacheEntry.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.edr.core.defaults;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
+import org.eclipse.tractusx.edc.edr.spi.EndpointDataReferenceEntry;
+
+/**
+ * A wrapper to persist {@link EndpointDataReferenceEntry}s and {@link EndpointDataReference}s.
+ */
+public class PersistentCacheEntry {
+    private EndpointDataReferenceEntry edrEntry;
+    private EndpointDataReference edr;
+
+    public PersistentCacheEntry(@JsonProperty("edrEntry") EndpointDataReferenceEntry edrEntry, @JsonProperty("edr") EndpointDataReference edr) {
+        this.edrEntry = edrEntry;
+        this.edr = edr;
+    }
+
+    public EndpointDataReferenceEntry getEdrEntry() {
+        return edrEntry;
+    }
+
+    public EndpointDataReference getEdr() {
+        return edr;
+    }
+}

--- a/core/edr-cache-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/core/edr-cache-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -12,5 +12,4 @@
 #
 #
 
-org.eclipse.tractusx.edc.cp.adapter.callback.InProcessCallbackRegistryExtension
-org.eclipse.tractusx.edc.cp.adapter.callback.LocalCallbackExtension
+org.eclipse.tractusx.edc.edr.core.EdrCacheCoreExtension

--- a/core/edr-cache-core/src/test/java/org/eclipse/tractusx/edc/edr/core/defaults/InMemoryEndpointDataReferenceCacheTest.java
+++ b/core/edr-cache-core/src/test/java/org/eclipse/tractusx/edc/edr/core/defaults/InMemoryEndpointDataReferenceCacheTest.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.edr.core.defaults;
+
+import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
+import org.eclipse.tractusx.edc.edr.spi.EndpointDataReferenceEntry;
+import org.junit.jupiter.api.Test;
+
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryEndpointDataReferenceCacheTest {
+    private static final String TRANSFER_PROCESS_ID = "tp1";
+    private static final String ASSET_ID = "asset1";
+    private static final String EDR_ID = "edr1";
+
+    private InMemoryEndpointDataReferenceCache cache = new InMemoryEndpointDataReferenceCache();
+
+    @Test
+    @SuppressWarnings("DataFlowIssue")
+    void verify_operations() {
+        var edr = EndpointDataReference.Builder.newInstance().
+                endpoint("http://test.com")
+                .id(EDR_ID)
+                .authCode("11111")
+                .authKey("authentication").build();
+
+        var entry = EndpointDataReferenceEntry.Builder.newInstance()
+                .assetId(ASSET_ID)
+                .agreementId(randomUUID().toString())
+                .transferProcessId(TRANSFER_PROCESS_ID)
+                .build();
+
+        cache.save(entry, edr);
+
+        assertThat(cache.resolveReference(TRANSFER_PROCESS_ID).getId()).isEqualTo(EDR_ID);
+
+        var edrs = cache.referencesForAsset(ASSET_ID);
+        assertThat(edrs.size()).isEqualTo(1);
+        assertThat(edrs.get((0)).getId()).isEqualTo(EDR_ID);
+
+        var entries = cache.entriesForAsset(ASSET_ID);
+        assertThat(entries.size()).isEqualTo(1);
+        assertThat(entries.get((0)).getAssetId()).isEqualTo(ASSET_ID);
+
+        assertThat(cache.deleteByTransferProcessId(TRANSFER_PROCESS_ID).succeeded()).isTrue();
+
+        assertThat(cache.entriesForAsset(ASSET_ID)).isEmpty();
+        assertThat(cache.resolveReference(TRANSFER_PROCESS_ID)).isNull();
+    }
+}

--- a/core/edr-cache-core/src/test/java/org/eclipse/tractusx/edc/edr/core/defaults/PersistentCacheEntryTest.java
+++ b/core/edr-cache-core/src/test/java/org/eclipse/tractusx/edc/edr/core/defaults/PersistentCacheEntryTest.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.edr.core.defaults;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
+import org.eclipse.tractusx.edc.edr.spi.EndpointDataReferenceEntry;
+import org.junit.jupiter.api.Test;
+
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PersistentCacheEntryTest {
+
+    @Test
+    void verify_serializeDeserialize() throws JsonProcessingException {
+        var mapper = new ObjectMapper();
+
+        var edr = EndpointDataReference.Builder.newInstance().
+                endpoint("http://test.com")
+                .id(randomUUID().toString())
+                .authCode("11111")
+                .authKey("authentication").build();
+
+        var edrEntry = EndpointDataReferenceEntry.Builder.newInstance()
+                .assetId(randomUUID().toString())
+                .agreementId(randomUUID().toString())
+                .transferProcessId(randomUUID().toString())
+                .build();
+
+        var serialized = mapper.writeValueAsString(new PersistentCacheEntry(edrEntry, edr));
+
+        var deserialized = mapper.readValue(serialized, PersistentCacheEntry.class);
+
+        assertThat(deserialized.getEdrEntry()).isNotNull();
+        assertThat(deserialized.getEdr()).isNotNull();
+    }
+
+
+}

--- a/edc-controlplane/edc-controlplane-base/build.gradle.kts
+++ b/edc-controlplane/edc-controlplane-base/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    runtimeOnly(project(":core:edr-cache-core"))
     runtimeOnly(project(":edc-extensions:business-partner-validation"))
     runtimeOnly(project(":edc-extensions:dataplane-selector-configuration"))
     runtimeOnly(project(":edc-extensions:data-encryption"))

--- a/edc-extensions/control-plane-adapter-callback/src/main/java/org/eclipse/tractusx/edc/cp/adapter/callback/InProcessCallbackRegistryExtension.java
+++ b/edc-extensions/control-plane-adapter-callback/src/main/java/org/eclipse/tractusx/edc/cp/adapter/callback/InProcessCallbackRegistryExtension.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.cp.adapter.callback;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.tractusx.edc.spi.cp.adapter.callback.InProcessCallbackRegistry;
+
+@Extension(InProcessCallbackRegistryExtension.NAME)
+public class InProcessCallbackRegistryExtension implements ServiceExtension {
+
+    public static final String NAME = "In process callback registry extension";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider
+    public InProcessCallbackRegistry callbackRegistry() {
+        return new InProcessCallbackRegistryImpl();
+    }
+
+}

--- a/edc-extensions/control-plane-adapter-callback/src/main/java/org/eclipse/tractusx/edc/cp/adapter/callback/TransferProcessLocalCallback.java
+++ b/edc-extensions/control-plane-adapter-callback/src/main/java/org/eclipse/tractusx/edc/cp/adapter/callback/TransferProcessLocalCallback.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.cp.adapter.callback;
+
+import org.eclipse.edc.connector.spi.callback.CallbackEventRemoteMessage;
+import org.eclipse.edc.connector.transfer.spi.event.TransferProcessStarted;
+import org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.edr.EndpointDataAddressConstants;
+import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
+import org.eclipse.tractusx.edc.edr.spi.EndpointDataReferenceCache;
+import org.eclipse.tractusx.edc.edr.spi.EndpointDataReferenceEntry;
+import org.eclipse.tractusx.edc.spi.cp.adapter.callback.InProcessCallback;
+
+import static java.lang.String.format;
+
+public class TransferProcessLocalCallback implements InProcessCallback {
+
+    private final EndpointDataReferenceCache edrCache;
+    private final TransferProcessStore transferProcessStore;
+    private final Monitor monitor;
+
+    public TransferProcessLocalCallback(EndpointDataReferenceCache edrCache, TransferProcessStore transferProcessStore, Monitor monitor) {
+        this.edrCache = edrCache;
+        this.transferProcessStore = transferProcessStore;
+        this.monitor = monitor;
+    }
+
+    @Override
+    public <T extends Event> Result<Void> invoke(CallbackEventRemoteMessage<T> message) {
+        if (message.getEventEnvelope().getPayload() instanceof TransferProcessStarted) {
+            var transferProcessStarted = (TransferProcessStarted) message.getEventEnvelope().getPayload();
+            if (transferProcessStarted.getDataAddress() != null) {
+                return EndpointDataAddressConstants.to(transferProcessStarted.getDataAddress())
+                        .compose(this::storeEdr)
+                        .mapTo();
+            }
+        }
+        return Result.success();
+    }
+
+    private Result<Void> storeEdr(EndpointDataReference edr) {
+        // TODO upstream api for getting the TP with the DataRequest#id
+        var transferProcessId = transferProcessStore.processIdForDataRequestId(edr.getId());
+        var transferProcess = transferProcessStore.findById(transferProcessId);
+        if (transferProcess != null) {
+            var cacheEntry = EndpointDataReferenceEntry.Builder.newInstance().
+                    transferProcessId(transferProcess.getId())
+                    .assetId(transferProcess.getDataRequest().getAssetId())
+                    .agreementId(transferProcess.getDataRequest().getContractId())
+                    .build();
+
+            edrCache.save(cacheEntry, edr);
+            return Result.success();
+        } else {
+            return Result.failure(format("Failed to find a transfer process with ID %s", transferProcessId));
+        }
+    }
+}

--- a/edc-extensions/control-plane-adapter-callback/src/test/java/org/eclipse/tractusx/edc/cp/adapter/callback/InProcessCallbackRegistryExtensionTest.java
+++ b/edc-extensions/control-plane-adapter-callback/src/test/java/org/eclipse/tractusx/edc/cp/adapter/callback/InProcessCallbackRegistryExtensionTest.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.cp.adapter.callback;
+
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.injection.ObjectFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(DependencyInjectionExtension.class)
+public class InProcessCallbackRegistryExtensionTest {
+
+    InProcessCallbackRegistryExtension extension;
+
+
+    @BeforeEach
+    void setUp(ObjectFactory factory, ServiceExtensionContext context) {
+        extension = factory.constructInstance(InProcessCallbackRegistryExtension.class);
+    }
+
+    @Test
+    void shouldInitializeTheExtension(ServiceExtensionContext context) {
+        assertThat(extension.callbackRegistry()).isInstanceOf(InProcessCallbackRegistryImpl.class);
+    }
+}

--- a/edc-extensions/control-plane-adapter-callback/src/test/java/org/eclipse/tractusx/edc/cp/adapter/callback/TestFunctions.java
+++ b/edc-extensions/control-plane-adapter-callback/src/test/java/org/eclipse/tractusx/edc/cp/adapter/callback/TestFunctions.java
@@ -17,10 +17,13 @@ package org.eclipse.tractusx.edc.cp.adapter.callback;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationFinalized;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.spi.callback.CallbackEventRemoteMessage;
+import org.eclipse.edc.connector.transfer.spi.event.TransferProcessStarted;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
 
 import java.util.List;
 import java.util.Set;
@@ -48,6 +51,31 @@ public class TestFunctions {
                         .events(Set.of("test"))
                         .transactional(true)
                         .build()))
+                .build();
+    }
+
+    public static TransferProcessStarted getTransferProcessStartedEvent() {
+        return getTransferProcessStartedEvent(null);
+    }
+
+    public static TransferProcessStarted getTransferProcessStartedEvent(DataAddress dataAddress) {
+        return TransferProcessStarted.Builder.newInstance()
+                .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
+                        .uri("local://test")
+                        .events(Set.of("test"))
+                        .transactional(true)
+                        .build()))
+                .dataAddress(dataAddress)
+                .transferProcessId(UUID.randomUUID().toString())
+                .build();
+    }
+
+    public static EndpointDataReference getEdr() {
+        return EndpointDataReference.Builder.newInstance()
+                .id("dataRequestId")
+                .authCode("authCode")
+                .authKey("authKey")
+                .endpoint("http://endpoint")
                 .build();
     }
 

--- a/edc-extensions/control-plane-adapter-callback/src/test/java/org/eclipse/tractusx/edc/cp/adapter/callback/TransferProcessLocalCallbackTest.java
+++ b/edc-extensions/control-plane-adapter-callback/src/test/java/org/eclipse/tractusx/edc/cp/adapter/callback/TransferProcessLocalCallbackTest.java
@@ -1,0 +1,180 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.cp.adapter.callback;
+
+import org.eclipse.edc.connector.transfer.spi.event.*;
+import org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore;
+import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.eclipse.edc.spi.types.domain.edr.EndpointDataAddressConstants;
+import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
+import org.eclipse.tractusx.edc.edr.spi.EndpointDataReferenceCache;
+import org.eclipse.tractusx.edc.edr.spi.EndpointDataReferenceEntry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.tractusx.edc.cp.adapter.callback.TestFunctions.*;
+import static org.mockito.Mockito.*;
+
+
+public class TransferProcessLocalCallbackTest {
+
+    TransferProcessStore transferProcessStore = mock(TransferProcessStore.class);
+    EndpointDataReferenceCache edrCache = mock(EndpointDataReferenceCache.class);
+
+    Monitor monitor = mock(Monitor.class);
+
+    TransferProcessLocalCallback callback;
+
+    @BeforeEach
+    void setup() {
+        callback = new TransferProcessLocalCallback(edrCache, transferProcessStore, monitor);
+    }
+
+    @Test
+    void invoke_shouldStoreTheEdrInCache_whenDataAddressIsPresent() {
+
+        var transferProcessId = "transferProcessId";
+        var assetId = "assetId";
+        var contractId = "contractId";
+
+
+        var edr = getEdr();
+
+        when(transferProcessStore.processIdForDataRequestId(edr.getId())).thenReturn(transferProcessId);
+
+        var dataRequest = DataRequest.Builder.newInstance().id(edr.getId())
+                .destinationType("HttpProxy")
+                .assetId(assetId)
+                .contractId(contractId)
+                .build();
+
+        var transferProcess = TransferProcess.Builder.newInstance()
+                .id(transferProcessId)
+                .dataRequest(dataRequest)
+                .build();
+
+        when(transferProcessStore.findById(transferProcessId)).thenReturn(transferProcess);
+
+
+        var event = getTransferProcessStartedEvent(EndpointDataAddressConstants.from(edr));
+
+        var cacheEntryCaptor = ArgumentCaptor.forClass(EndpointDataReferenceEntry.class);
+        var edrCaptor = ArgumentCaptor.forClass(EndpointDataReference.class);
+        var message = remoteMessage(event);
+
+        var result = callback.invoke(message);
+        assertThat(result.succeeded()).isTrue();
+
+        verify(edrCache).save(cacheEntryCaptor.capture(), edrCaptor.capture());
+
+        assertThat(edrCaptor.getValue()).usingRecursiveComparison().isEqualTo(edr);
+
+    }
+
+    @Test
+    void invoke_shouldNotFail_whenDataAddressIsAbsent() {
+
+        var event = getTransferProcessStartedEvent();
+        var message = remoteMessage(event);
+
+        var result = callback.invoke(message);
+        assertThat(result.succeeded()).isTrue();
+
+        verifyNoInteractions(edrCache);
+        verifyNoInteractions(transferProcessStore);
+    }
+
+    @Test
+    void invoke_shouldNotFail_whenTransferProcessNotFound() {
+
+        var transferProcessId = "transferProcessId";
+
+        var edr = getEdr();
+
+        when(transferProcessStore.processIdForDataRequestId(edr.getId())).thenReturn(transferProcessId);
+
+        when(transferProcessStore.findById(transferProcessId)).thenReturn(null);
+
+        var event = getTransferProcessStartedEvent(EndpointDataAddressConstants.from(edr));
+        var message = remoteMessage(event);
+
+        var result = callback.invoke(message);
+        assertThat(result.succeeded()).isFalse();
+
+        verifyNoInteractions(edrCache);
+    }
+
+    @Test
+    void invoke_shouldFail_withInvalidDataAddress() {
+
+        var event = getTransferProcessStartedEvent(DataAddress.Builder.newInstance().type("HttpProxy").build());
+
+        var message = remoteMessage(event);
+
+        var result = callback.invoke(message);
+        assertThat(result.failed()).isTrue();
+
+        verifyNoInteractions(edrCache);
+        verifyNoInteractions(transferProcessStore);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(EventInstances.class)
+    void invoke_shouldIgnoreOtherEvents(TransferProcessEvent event) {
+        var message = remoteMessage(event);
+        var result = callback.invoke(message);
+
+        assertThat(result.succeeded()).isTrue();
+
+        verifyNoInteractions(edrCache);
+    }
+
+    private static class EventInstances implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    baseBuilder(TransferProcessRequested.Builder.newInstance()).build(),
+                    baseBuilder(TransferProcessProvisioned.Builder.newInstance()).build(),
+                    baseBuilder(TransferProcessCompleted.Builder.newInstance()).build(),
+                    baseBuilder(TransferProcessDeprovisioned.Builder.newInstance()).build()
+            ).map(Arguments::of);
+
+        }
+
+        private <T extends TransferProcessEvent, B extends TransferProcessEvent.Builder<T, B>> B baseBuilder(B builder) {
+            var callbacks = List.of(CallbackAddress.Builder.newInstance().uri("http://local").events(Set.of("test")).build());
+            return builder
+                    .transferProcessId(UUID.randomUUID().toString())
+                    .callbackAddresses(callbacks);
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,11 @@ rootProject.name = "tractusx-edc"
 
 // spi modules
 include(":spi:control-plane-adapter-spi")
+include(":spi:edr-cache-spi")
+
+// core modules
+include(":core:edr-cache-core")
+
 
 include(":edc-extensions:business-partner-validation")
 include(":edc-extensions:control-plane-adapter")

--- a/spi/edr-cache-spi/build.gradle.kts
+++ b/spi/edr-cache-spi/build.gradle.kts
@@ -14,17 +14,9 @@
 
 plugins {
     `java-library`
-    `maven-publish`
 }
 
 dependencies {
-    implementation(project(":spi:control-plane-adapter-spi"))
-    implementation(project(":spi:edr-cache-spi"))
     implementation(libs.edc.spi.core)
-    implementation(libs.edc.spi.transfer)
-    implementation(libs.edc.spi.contract)
-    implementation(libs.edc.spi.controlplane)
-    implementation(libs.edc.spi.aggregateservices)
-
-    testImplementation(libs.edc.junit)
 }
+

--- a/spi/edr-cache-spi/src/main/java/org/eclipse/tractusx/edc/edr/spi/EndpointDataReferenceCache.java
+++ b/spi/edr-cache-spi/src/main/java/org/eclipse/tractusx/edc/edr/spi/EndpointDataReferenceCache.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.edr.spi;
+
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Caches and resolves {@link EndpointDataReference}s
+ */
+public interface EndpointDataReferenceCache {
+
+    /**
+     * Resolves an {@link EndpointDataReference} for the transfer process, returning null if one does not exist.
+     */
+    @Nullable
+    EndpointDataReference resolveReference(String transferProcessId);
+
+    /**
+     * Resolves the {@link EndpointDataReference}s for the asset.
+     */
+    @NotNull
+    List<EndpointDataReference> referencesForAsset(String assetId);
+
+    /**
+     * Returns the {@link EndpointDataReferenceEntry}s for the asset.
+     */
+    @NotNull
+    List<EndpointDataReferenceEntry> entriesForAsset(String assetId);
+
+    /**
+     * Saves an {@link EndpointDataReference} to the cache using upsert semantics.
+     */
+    void save(EndpointDataReferenceEntry entry, EndpointDataReference edr);
+
+    /**
+     * Deletes stored endpoint reference data associated with the given transfer process.
+     */
+    StoreResult<EndpointDataReferenceEntry> deleteByTransferProcessId(String id);
+
+}

--- a/spi/edr-cache-spi/src/main/java/org/eclipse/tractusx/edc/edr/spi/EndpointDataReferenceEntry.java
+++ b/spi/edr-cache-spi/src/main/java/org/eclipse/tractusx/edc/edr/spi/EndpointDataReferenceEntry.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.edr.spi;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * An entry in the cache for an {@link EndpointDataReference}.
+ */
+@JsonDeserialize(builder = EndpointDataReferenceEntry.Builder.class)
+public class EndpointDataReferenceEntry {
+    private String assetId;
+    private String agreementId;
+    private String transferProcessId;
+
+    private EndpointDataReferenceEntry() {
+    }
+
+    public String getAssetId() {
+        return assetId;
+    }
+
+    public String getAgreementId() {
+        return agreementId;
+    }
+
+    public String getTransferProcessId() {
+        return transferProcessId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        var that = (EndpointDataReferenceEntry) o;
+
+        return transferProcessId.equals(that.transferProcessId);
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder {
+        private final EndpointDataReferenceEntry entry;
+
+        private Builder() {
+            entry = new EndpointDataReferenceEntry();
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder assetId(String assetId) {
+            entry.assetId = assetId;
+            return this;
+        }
+
+        public Builder agreementId(String agreementId) {
+            entry.agreementId = agreementId;
+            return this;
+        }
+
+        public Builder transferProcessId(String transferProcessId) {
+            entry.transferProcessId = transferProcessId;
+            return this;
+        }
+
+        public EndpointDataReferenceEntry build() {
+            requireNonNull(entry.assetId, "assetId");
+            requireNonNull(entry.agreementId, "agreementId");
+            requireNonNull(entry.transferProcessId, "transferProcessId");
+            return entry;
+        }
+    }
+
+}

--- a/spi/edr-cache-spi/src/test/java/org/eclipse/tractusx/edc/edr/spi/EndpointDataReferenceEntryTest.java
+++ b/spi/edr-cache-spi/src/test/java/org/eclipse/tractusx/edc/edr/spi/EndpointDataReferenceEntryTest.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.edr.spi;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EndpointDataReferenceEntryTest {
+
+    @Test
+    void verify_serializeDeserialize() throws JsonProcessingException {
+        var mapper = new ObjectMapper();
+
+        var entry = EndpointDataReferenceEntry.Builder.newInstance()
+                .assetId(randomUUID().toString())
+                .agreementId(randomUUID().toString())
+                .transferProcessId(randomUUID().toString())
+                .build();
+
+        var serialized = mapper.writeValueAsString(entry);
+        var deserialized = mapper.readValue(serialized, EndpointDataReferenceEntry.class);
+
+        assertThat(deserialized.getTransferProcessId()).isNotEmpty();
+        assertThat(deserialized.getAssetId()).isNotEmpty();
+        assertThat(deserialized.getAgreementId()).isNotEmpty();
+    }
+}


### PR DESCRIPTION
## WHAT

Introduces the EDR cache and integrates it into the `TransferProcessStarted` event for storing the edr associating it with

- transferProcessId
- assetId
- contractId

This PR introduces two modules:
- `:spi:edr-cache-spi` : interfaces  and types for EDR store/cache
- `:core:edc-cache-core`: first implementation of the EDR in memory cache  



## WHY

Simplification for managing the EDR 


Closes #321 
