### PR TITLE
chore: Add .tractusx metafile

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,0 +1,3 @@
+product: "Tractus-X EDC"
+leadingRepository: "https://github.com/eclipse-tractusx/tractusx-edc"
+repositories: []


### PR DESCRIPTION
## WHAT

Adds the `.tractusx` metafile to the repository

## WHY

Needed for the QG in regards to the [TRG 2.05](https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-5)

## FURTHER NOTES

Closes #280 
