### PR TITLE
fix: Rename ingress endpoint from ids to protocol

### DIFF
--- a/charts/tractusx-connector-memory/templates/_helpers.tpl
+++ b/charts/tractusx-connector-memory/templates/_helpers.tpl
@@ -85,9 +85,9 @@ Create the name of the service account to use
 {{/*
 Control IDS URL
 */}}
-{{- define "txdc.runtime.url.ids" -}}
-{{- if .Values.runtime.url.ids }}{{/* if ids api url has been specified explicitly */}}
-{{- .Values.runtime.url.ids }}
+{{- define "txdc.runtime.url.protocol" -}}
+{{- if .Values.runtime.url.protocol }}{{/* if ids api url has been specified explicitly */}}
+{{- .Values.runtime.url.protocol }}
 {{- else }}{{/* else when ids api url has not been specified explicitly */}}
 {{- with (index .Values.runtime.ingresses 0) }}
 {{- if .enabled }}{{/* if ingress enabled */}}
@@ -97,10 +97,10 @@ Control IDS URL
 {{- printf "http://%s" .hostname -}}
 {{- end }}{{/* end if tls */}}
 {{- else }}{{/* else when ingress not enabled */}}
-{{- printf "http://%s-runtime:%v" ( include "txdc.fullname" $ ) $.Values.runtime.endpoints.ids.port -}}
+{{- printf "http://%s-runtime:%v" ( include "txdc.fullname" $ ) $.Values.runtime.endpoints.protocol.port -}}
 {{- end }}{{/* end if ingress */}}
 {{- end }}{{/* end with ingress */}}
-{{- end }}{{/* end if .Values.runtime.url.ids */}}
+{{- end }}{{/* end if .Values.runtime.url.protocol */}}
 {{- end }}
 
 {{/*

--- a/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
+++ b/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
@@ -158,9 +158,9 @@ spec:
             - name: "WEB_HTTP_CONTROL_PATH"
               value: {{ .Values.runtime.endpoints.control.path | quote }}
             - name: "WEB_HTTP_IDS_PORT"
-              value: {{ .Values.runtime.endpoints.ids.port | quote }}
+              value: {{ .Values.runtime.endpoints.protocol.port | quote }}
             - name: "WEB_HTTP_IDS_PATH"
-              value: {{ .Values.runtime.endpoints.ids.path | quote }}
+              value: {{ .Values.runtime.endpoints.protocol.path | quote }}
             - name: "WEB_HTTP_OBSERVABILITY_PORT"
               value: {{ .Values.runtime.endpoints.observability.port | quote}}
             - name: "WEB_HTTP_OBSERVABILITY_PATH"
@@ -178,9 +178,9 @@ spec:
             ## IDS ##
             #########
             - name: "IDS_WEBHOOK_ADDRESS"
-              value: {{ include "txdc.runtime.url.ids" . | quote }}
+              value: {{ include "txdc.runtime.url.protocol" . | quote }}
             - name: "EDC_IDS_ENDPOINT"
-              value: {{ printf "%s%s" (include "txdc.runtime.url.ids" .) .Values.runtime.endpoints.ids.path | quote }}
+              value: {{ printf "%s%s" (include "txdc.runtime.url.protocol" .) .Values.runtime.endpoints.protocol.path | quote }}
             - name: "EDC_IDS_ID"
               value: {{ printf "urn:connector:%s" (lower .Values.runtime.internationalDataSpaces.id) | quote }}
             - name: "EDC_IDS_DESCRIPTION"
@@ -196,10 +196,10 @@ spec:
             - name: "EDC_OAUTH_PROVIDER_AUDIENCE"
               value: "idsc:IDS_CONNECTORS_ALL"
             - name: "EDC_OAUTH_ENDPOINT_AUDIENCE"
-              value: {{ printf "%s%s%s" (include "txdc.runtime.url.ids" . ) .Values.runtime.endpoints.ids.path "/data" | quote }}
+              value: {{ printf "%s%s%s" (include "txdc.runtime.url.protocol" . ) .Values.runtime.endpoints.protocol.path "/data" | quote }}
             # this is the old setting name for 'EDC_OAUTH_ENDPOINT_AUDIENCE' and is mandatory for Produce EDC v0.1.2 and older
             - name: "EDC_IDS_ENDPOINT_AUDIENCE"
-              value: {{ printf "%s%s%s" (include "txdc.runtime.url.ids" . ) .Values.runtime.endpoints.ids.path "/data" | quote }}
+              value: {{ printf "%s%s%s" (include "txdc.runtime.url.protocol" . ) .Values.runtime.endpoints.protocol.path "/data" | quote }}
 
             ################
             ## DATA PLANE ##

--- a/charts/tractusx-connector-memory/templates/service-runtime.yaml
+++ b/charts/tractusx-connector-memory/templates/service-runtime.yaml
@@ -47,7 +47,7 @@ spec:
       targetPort: validation
       protocol: TCP
       name: validation
-    - port: {{ .Values.runtime.endpoints.ids.port }}
+    - port: {{ .Values.runtime.endpoints.protocol.port }}
       targetPort: ids
       protocol: TCP
       name: ids

--- a/charts/tractusx-connector-memory/values.yaml
+++ b/charts/tractusx-connector-memory/values.yaml
@@ -105,7 +105,7 @@ runtime:
       # -- path for incoming api calls
       path: /control
     # -- ids api, used for inter connector communication and must be internet facing
-    ids:
+    protocol:
       # -- port for incoming api calls
       port: 8084
       # -- path for incoming api calls
@@ -194,7 +194,7 @@ runtime:
       annotations: {}
       # -- EDC endpoints exposed by this ingress resource
       endpoints:
-        - ids
+        - protocol
       # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
       className: ""
       # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -195,7 +195,7 @@ controlplane:
       annotations: {}
       # -- EDC endpoints exposed by this ingress resource
       endpoints:
-        - ids
+        - protocol
       # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
       className: ""
       # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource


### PR DESCRIPTION
## WHAT

Rename ingress endpoint from `ids` to `protocol`

## WHY

The ingress endpoint was pointing to wrong endpoint

## FURTHER NOTES

Closes #348 
