### PR TITLE
exclude charts/ from markdown lint, as the markdowns there are generated

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Run markdownlint
         run: |
-          markdownlint-cli2-config .markdownlint.yaml "**/*.md" "#.github"
+          markdownlint-cli2-config .markdownlint.yaml "**/*.md" "#.github" "#charts"
 
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## WHAT

excludes `charts/` from the markdown linter

## WHY

All the markdowns there are generated, so we don't have control over their exact structure, and manually editing them will not only be tedious, upon release the README's are regenerated, which - when merging the release branch back into `main` - would create invalid markdowns and inherently break the build.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
