### PR TITLE
build: add license header check

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -42,7 +42,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
+  
+  verify-license-headers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.2
+      - name: "Check for files without a license header"
+        run: |-
+          # checks all java, yaml, kts and sql files for an Apache 2.0 license header
+          if grep -riL "SPDX-License-Identifier: Apache-2.0" --include=\*.{java,yaml,yml,kts,sql} --exclude-dir={.gradle,\*\openapi} . ; then
+            echo "Files without headers were found"; exit 1
+          fi
+  
   verify-formatting:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -50,11 +50,11 @@ jobs:
       - name: "Check for files without a license header"
         run: |-
           # checks all java, yaml, kts and sql files for an Apache 2.0 license header
-          result=$(grep -riL "SPDX-License-Identifier: Apache-2.0" --include=\*.{java,yaml,yml,kts,sql} --exclude-dir={.gradle,\*\openapi} .)
-          violations=$(echo $result | wc -l)
+          cmd="grep -riL \"SPDX-License-Identifier: Apache-2.0\" --include=\*.{java,yaml,yml,kts,sql} --exclude-dir={.gradle,\*\openapi} ."
+          violations=$(eval $cmd | wc -l)
           if [[ $violations -ne 0 ]] ; then
             echo "$violations files without license headers were found:";
-            echo $result;
+            eval $cmd;
             exit 1;
           fi
   

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: "Check for files without a license header"
         run: |-
           # checks all java, yaml, kts and sql files for an Apache 2.0 license header
-          if grep -riL "SPDX-License-Identifier: Apache-2.0" --include=\*.{java,yaml,yml,kts,sql} --exclude-dir={.gradle,\*\openapi} . ; then
+          if [[ $(grep -riL "SPDX-License-Identifier: Apache-2.0" --include=\*.{java,yaml,yml,kts,sql} --exclude-dir={.gradle,\*\openapi} .) -ne 0 ]] ; then
             echo "Files without headers were found"; exit 1
           fi
   

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -50,8 +50,12 @@ jobs:
       - name: "Check for files without a license header"
         run: |-
           # checks all java, yaml, kts and sql files for an Apache 2.0 license header
-          if [[ $(grep -riL "SPDX-License-Identifier: Apache-2.0" --include=\*.{java,yaml,yml,kts,sql} --exclude-dir={.gradle,\*\openapi} .) -ne 0 ]] ; then
-            echo "Files without headers were found"; exit 1
+          result=$(grep -riL "SPDX-License-Identifier: Apache-2.0" --include=\*.{java,yaml,yml,kts,sql} --exclude-dir={.gradle,\*\openapi} .)
+          violations=$(echo $result | wc -l)
+          if [[ $violations -ne 0 ]] ; then
+            echo "$violations files without license headers were found:";
+            echo $result;
+            exit 1;
           fi
   
   verify-formatting:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -86,7 +86,7 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
-    needs: [ verify-formatting ]
+    needs: [ verify-formatting, verify-license-headers ]
     steps:
       - uses: actions/checkout@v3.5.2
 
@@ -97,7 +97,7 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-latest
-    needs: [ verify-formatting ]
+    needs: [ verify-formatting, verify-license-headers ]
     steps:
       - uses: actions/checkout@v3.5.2
 
@@ -108,7 +108,7 @@ jobs:
 
   api-tests:
     runs-on: ubuntu-latest
-    needs: [ verify-formatting ]
+    needs: [ verify-formatting, verify-license-headers ]
     steps:
       - uses: actions/checkout@v3.5.2
 
@@ -119,7 +119,7 @@ jobs:
 
   end-to-end-tests:
     runs-on: ubuntu-latest
-    needs: [ verify-formatting ]
+    needs: [ verify-formatting, verify-license-headers ]
     steps:
       - uses: actions/checkout@v3.5.2
 

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/lifecycle/provider/ProviderEdcController.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/lifecycle/provider/ProviderEdcController.java
@@ -1,2 +1,0 @@
-package org.eclipse.tractusx.edc.lifecycle.provider;public class ProviderEdcController {
-}

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/lifecycle/provider/ProviderServicesExtension.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/lifecycle/provider/ProviderServicesExtension.java
@@ -1,2 +1,0 @@
-package org.eclipse.tractusx.edc.lifecycle.provider;public class ProviderServicesExtension {
-}


### PR DESCRIPTION
## WHAT

this PR adds a simple check to assert that all relevant files have a license header

## WHY

Eclipse requirements

## FURTHER NOTES

We could have done this using gradle, but doing it with `grep` is faster and can also be used for non-jave files easily. 

Closes # <-- _insert Issue number if one exists_
