### PR TITLE
fix(migrations): remove transferprocess_properties column renaming

### DIFF
--- a/edc-extensions/postgresql-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/transferprocess/V0_0_9__Alter_TransferProcess_Remove_Transfertype.sql
+++ b/edc-extensions/postgresql-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/transferprocess/V0_0_9__Alter_TransferProcess_Remove_Transfertype.sql
@@ -13,6 +13,4 @@
 
 -- add column
 ALTER TABLE edc_transfer_process
-    RENAME COLUMN transferprocess_properties TO properties;
-ALTER TABLE edc_transfer_process
     DROP COLUMN IF EXISTS transfer_type;


### PR DESCRIPTION
## WHAT

Removes the renaming of the column

## WHY

The column it's still called `transferprocess_properties` see [here](https://github.com/eclipse-edc/Connector/blob/6dcc371b67cd760e1b9f71e42917116d19a36874/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java#L120)



