### PR TITLE
fix(ci): store release version in env

### DIFF
--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -41,6 +41,10 @@ inputs:
   docker_tag:
     required: false
     description: 'additional docker tags'
+  do_push:
+    required: false
+    default: 'false'
+    description: 'whether or not to actually push the image'
 runs:
   using: "composite"
   steps:
@@ -93,7 +97,7 @@ runs:
         file: ${{ inputs.rootDir }}/src/main/docker/Dockerfile
         build-args: |
           JAR=${{ inputs.rootDir }}/build/libs/${{ inputs.imagename }}.jar
-        push: ${{ github.event_name != 'pull_request' }}
+        push: ${{ inputs.do_push == 'true' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,6 +93,7 @@ jobs:
           imagename: ${{ matrix.variant.img }}
           docker_user: ${{ secrets.DOCKER_HUB_USER }}
           docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}
+          do_push: ${{ github.event_name != 'pull_request' }}
 
   publish-to-sonatype:
     name: "Publish artefacts to OSSRH Snapshots / MavenCentral"

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -64,3 +64,4 @@ jobs:
           namespace: ${{ inputs.namespace }}
           docker_user: ${{ secrets.DOCKER_HUB_USER }}
           docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}
+          do_push: 'true'

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -111,10 +111,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.5.2
+      - name: Export RELEASE_VERSION env
+        run: |
+          echo "RELEASE_VERSION=${{ needs.release-version.outputs.RELEASE_VERSION }}" >> $GITHUB_ENV
       - uses: ./.github/actions/publish-docker-image
         name: Publish ${{ matrix.variant.img }}
         with:
-          docker_tag: ${{ needs.release-version.outputs.RELEASE_VERSION }}
+          docker_tag: ${{ env.RELEASE_VERSION }}
           rootDir: ${{ matrix.variant.dir }}/${{ matrix.variant.img }}
           imagename: ${{ matrix.variant.img }}
           docker_user: ${{ secrets.DOCKER_HUB_USER }}

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -122,6 +122,7 @@ jobs:
           imagename: ${{ matrix.variant.img }}
           docker_user: ${{ secrets.DOCKER_HUB_USER }}
           docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}
+          do_push: 'true'
 
   # Release: Helm Charts
   helm-release:


### PR DESCRIPTION
## WHAT

Store the `RELEASE_VERSION` in the env to be accessible for the Docker release job.

## WHY

keep consistency with other jobs

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
