### PR TITLE
chore: remove lombok from `transferprocess-sftp-*` modules

### DIFF
--- a/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpClientConfig.java
+++ b/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpClientConfig.java
@@ -14,33 +14,117 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.client;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collection;
-import java.util.List;
-import lombok.Builder;
-import lombok.Getter;
 import org.apache.sshd.sftp.client.SftpClient;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpLocation;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpUser;
 
-@Builder
-@Getter
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+
 public class SftpClientConfig {
-  private SftpUser sftpUser;
-  private SftpLocation sftpLocation;
-  @Builder.Default private int bufferSize = 4096;
-  @Builder.Default private boolean hostVerification = true;
+    private int bufferSize = 4096;
+    private boolean hostVerification = true;
+    private Path knownHostFile = Paths.get(System.getenv("HOME"), ".ssh/known_hosts");
+    private int connectionTimeoutSeconds = 10;
+    private Collection<SftpClient.OpenMode> writeOpenModes =
+            List.of(SftpClient.OpenMode.Create, SftpClient.OpenMode.Write);
+    private Collection<SftpClient.OpenMode> readOpenModes = List.of(SftpClient.OpenMode.Read);
+    private SftpUser sftpUser;
+    private SftpLocation sftpLocation;
 
-  @Builder.Default
-  private Path knownHostFile = Paths.get(System.getenv("HOME"), ".ssh/known_hosts");
+    public SftpUser getSftpUser() {
+        return sftpUser;
+    }
 
-  @Builder.Default private int connectionTimeoutSeconds = 10;
+    public SftpLocation getSftpLocation() {
+        return sftpLocation;
+    }
 
-  @Builder.Default
-  private Collection<SftpClient.OpenMode> writeOpenModes =
-      List.of(SftpClient.OpenMode.Create, SftpClient.OpenMode.Write);
+    public int getBufferSize() {
+        return bufferSize;
+    }
 
-  @Builder.Default
-  private Collection<SftpClient.OpenMode> readOpenModes = List.of(SftpClient.OpenMode.Read);
+    public boolean isHostVerification() {
+        return hostVerification;
+    }
+
+    public Path getKnownHostFile() {
+        return knownHostFile;
+    }
+
+    public int getConnectionTimeoutSeconds() {
+        return connectionTimeoutSeconds;
+    }
+
+    public Collection<SftpClient.OpenMode> getWriteOpenModes() {
+        return writeOpenModes;
+    }
+
+    public Collection<SftpClient.OpenMode> getReadOpenModes() {
+        return readOpenModes;
+    }
+
+
+    public static class Builder {
+
+        private final SftpClientConfig config;
+
+        private Builder() {
+            config = new SftpClientConfig();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public static Builder sftpClientConfig() {
+            return new Builder();
+        }
+
+        public Builder sftpUser(SftpUser sftpUser) {
+            this.config.sftpUser = sftpUser;
+            return this;
+        }
+
+        public Builder sftpLocation(SftpLocation sftpLocation) {
+            this.config.sftpLocation = sftpLocation;
+            return this;
+        }
+
+        public Builder bufferSize(int bufferSize) {
+            this.config.bufferSize = bufferSize;
+            return this;
+        }
+
+        public Builder hostVerification(boolean hostVerification) {
+            this.config.hostVerification = hostVerification;
+            return this;
+        }
+
+        public Builder knownHostFile(Path knownHostFile) {
+            this.config.knownHostFile = knownHostFile;
+            return this;
+        }
+
+        public Builder connectionTimeoutSeconds(int connectionTimeoutSeconds) {
+            this.config.connectionTimeoutSeconds = connectionTimeoutSeconds;
+            return this;
+        }
+
+        public Builder writeOpenModes(Collection<SftpClient.OpenMode> writeOpenModes) {
+            this.config.writeOpenModes = writeOpenModes;
+            return this;
+        }
+
+        public Builder readOpenModes(Collection<SftpClient.OpenMode> readOpenModes) {
+            this.config.readOpenModes = readOpenModes;
+            return this;
+        }
+
+        public SftpClientConfig build() {
+            return config;
+        }
+    }
 }

--- a/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpClientWrapperImpl.java
+++ b/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpClientWrapperImpl.java
@@ -14,13 +14,6 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.client;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.time.Duration;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import org.apache.sshd.client.ClientBuilder;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.auth.password.PasswordIdentityProvider;
@@ -34,127 +27,124 @@ import org.apache.sshd.sftp.client.SftpClientFactory;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.EdcSftpException;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.Duration;
+
 public class SftpClientWrapperImpl implements SftpClientWrapper {
-  @Getter private final SftpClientConfig config;
-  private final SftpClient sftpClient;
+    private final SftpClientConfig config;
+    private final SftpClient sftpClient;
 
-  public SftpClientWrapperImpl(SftpClientConfig config) {
-    this.config = config;
-    try {
-      this.sftpClient = getSftpClient(config);
-    } catch (IOException e) {
-      throw new EdcSftpException("Unable to create SftpClient.", e);
-    }
-  }
-
-  public SftpClientWrapperImpl(SftpClientConfig config, SftpClient sftpClient) {
-    this.config = config;
-    this.sftpClient = sftpClient;
-  }
-
-  @Override
-  public void uploadFile(@NonNull final InputStream inputStream) throws IOException {
-    try (final OutputStream outputStream =
-        sftpClient.write(
-            config.getSftpLocation().getPath(),
-            config.getBufferSize(),
-            config.getWriteOpenModes())) {
-      inputStream.transferTo(outputStream);
-    }
-  }
-
-  @Override
-  public InputStream downloadFile() throws IOException {
-    final InputStream delegateInputStream;
-    try {
-      delegateInputStream =
-          sftpClient.read(
-              config.getSftpLocation().getPath(),
-              config.getBufferSize(),
-              config.getReadOpenModes());
-    } catch (final IOException e) {
-      sftpClient.close();
-      throw new EdcSftpException(
-          String.format("Unable to download file at %s", config.getSftpLocation().toString()), e);
+    public SftpClientWrapperImpl(SftpClientConfig config) {
+        this.config = config;
+        try {
+            this.sftpClient = getSftpClient(config);
+        } catch (IOException e) {
+            throw new EdcSftpException("Unable to create SftpClient.", e);
+        }
     }
 
-    return new SftpInputStreamWrapper(sftpClient, delegateInputStream);
-  }
-
-  static SftpClient getSftpClient(SftpClientConfig config) throws IOException {
-    final ClientSession session = getSshClientSession(config);
-    final SftpClientFactory factory = SftpClientFactory.instance();
-    final SftpClient sftpClient = factory.createSftpClient(session);
-    return sftpClient.singleSessionInstance();
-  }
-
-  private static ClientSession getSshClientSession(SftpClientConfig config) throws IOException {
-    final SshClient sshClient = getSshClient(config);
-    sshClient.start();
-    final ClientSession session =
-        sshClient
-            .connect(
-                config.getSftpUser().getName(),
-                config.getSftpLocation().getHost(),
-                config.getSftpLocation().getPort())
-            .verify()
-            .getSession();
-    session.auth().await(Duration.ofSeconds(config.getConnectionTimeoutSeconds()));
-
-    return session;
-  }
-
-  private static SshClient getSshClient(SftpClientConfig config) {
-    final SshClient sshClient = ClientBuilder.builder().build();
-
-    if (config.getSftpUser().getKeyPair() != null) {
-      sshClient.setKeyIdentityProvider(
-          KeyIdentityProvider.wrapKeyPairs(config.getSftpUser().getKeyPair()));
-    } else if (config.getSftpUser().getPassword() != null) {
-      sshClient.setPasswordIdentityProvider(
-          PasswordIdentityProvider.wrapPasswords(config.getSftpUser().getPassword()));
-    } else {
-      sshClient.setPasswordIdentityProvider(PasswordIdentityProvider.EMPTY_PASSWORDS_PROVIDER);
+    public SftpClientWrapperImpl(SftpClientConfig config, SftpClient sftpClient) {
+        this.config = config;
+        this.sftpClient = sftpClient;
     }
 
-    if (config.isHostVerification()) {
-      final ServerKeyVerifier keyVerifier =
-          new KnownHostsServerKeyVerifier(
-              RejectAllServerKeyVerifier.INSTANCE, config.getKnownHostFile());
-      sshClient.setServerKeyVerifier(keyVerifier);
+    static SftpClient getSftpClient(SftpClientConfig config) throws IOException {
+        var session = getSshClientSession(config);
+        var factory = SftpClientFactory.instance();
+        var sftpClient = factory.createSftpClient(session);
+        return sftpClient.singleSessionInstance();
     }
 
-    return sshClient;
-  }
+    private static ClientSession getSshClientSession(SftpClientConfig config) throws IOException {
+        var sshClient = getSshClient(config);
+        sshClient.start();
+        var session = sshClient.connect(config.getSftpUser().getName(), config.getSftpLocation().getHost(), config.getSftpLocation().getPort()).verify().getSession();
+        session.auth().await(Duration.ofSeconds(config.getConnectionTimeoutSeconds()));
 
-  @RequiredArgsConstructor
-  private static class SftpInputStreamWrapper extends InputStream {
-    @NonNull private final SftpClient sftpClient;
-    @NonNull private final InputStream delegateInputStream;
+        return session;
+    }
 
-    @Override
-    public int read() throws IOException {
-      return delegateInputStream.read();
+    private static SshClient getSshClient(SftpClientConfig config) {
+        final var sshClient = ClientBuilder.builder().build();
+
+        if (config.getSftpUser().getKeyPair() != null) {
+            sshClient.setKeyIdentityProvider(KeyIdentityProvider.wrapKeyPairs(config.getSftpUser().getKeyPair()));
+        } else if (config.getSftpUser().getPassword() != null) {
+            sshClient.setPasswordIdentityProvider(PasswordIdentityProvider.wrapPasswords(config.getSftpUser().getPassword()));
+        } else {
+            sshClient.setPasswordIdentityProvider(PasswordIdentityProvider.EMPTY_PASSWORDS_PROVIDER);
+        }
+
+        if (config.isHostVerification()) {
+            final ServerKeyVerifier keyVerifier = new KnownHostsServerKeyVerifier(RejectAllServerKeyVerifier.INSTANCE, config.getKnownHostFile());
+            sshClient.setServerKeyVerifier(keyVerifier);
+        }
+
+        return sshClient;
+    }
+
+    public SftpClientConfig getConfig() {
+        return config;
+    }
+
+    public SftpClient getSftpClient() {
+        return sftpClient;
     }
 
     @Override
-    public int read(byte @NotNull [] b, int off, int len) throws IOException {
-      return delegateInputStream.read(b, off, len);
+    public void uploadFile(final InputStream inputStream) throws IOException {
+        try (final OutputStream outputStream = sftpClient.write(config.getSftpLocation().getPath(), config.getBufferSize(), config.getWriteOpenModes())) {
+            inputStream.transferTo(outputStream);
+        }
     }
 
     @Override
-    public void close() {
-      try {
-        delegateInputStream.close();
-      } catch (IOException ignored) {
-        // Ignored. The exception should only be thrown of the stream is already closed.
-      }
+    public InputStream downloadFile() throws IOException {
+        final InputStream delegateInputStream;
+        try {
+            delegateInputStream = sftpClient.read(config.getSftpLocation().getPath(), config.getBufferSize(), config.getReadOpenModes());
+        } catch (final IOException e) {
+            sftpClient.close();
+            throw new EdcSftpException(String.format("Unable to download file at %s", config.getSftpLocation().toString()), e);
+        }
 
-      try {
-        sftpClient.close();
-      } catch (IOException ignored) {
-        // Ignored. The exception should only be thrown of the client is already closed.
-      }
+        return new SftpInputStreamWrapper(sftpClient, delegateInputStream);
     }
-  }
+
+    private static class SftpInputStreamWrapper extends InputStream {
+        private final SftpClient sftpClient;
+        private final InputStream delegateInputStream;
+
+        private SftpInputStreamWrapper(SftpClient sftpClient, InputStream delegateInputStream) {
+            this.sftpClient = sftpClient;
+            this.delegateInputStream = delegateInputStream;
+        }
+
+        @Override
+        public int read() throws IOException {
+            return delegateInputStream.read();
+        }
+
+        @Override
+        public int read(byte @NotNull [] b, int off, int len) throws IOException {
+            return delegateInputStream.read(b, off, len);
+        }
+
+        @Override
+        public void close() {
+            try {
+                delegateInputStream.close();
+            } catch (IOException ignored) {
+                // Ignored. The exception should only be thrown of the stream is already closed.
+            }
+
+            try {
+                sftpClient.close();
+            } catch (IOException ignored) {
+                // Ignored. The exception should only be thrown of the client is already closed.
+            }
+        }
+    }
 }

--- a/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSink.java
+++ b/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSink.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.client;
 
-import lombok.Builder;
-import lombok.NonNull;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
 import org.eclipse.edc.connector.dataplane.util.sink.ParallelSink;
@@ -23,10 +21,13 @@ import org.eclipse.edc.connector.dataplane.util.sink.ParallelSink;
 import java.io.IOException;
 import java.util.List;
 
-@Builder
 public class SftpDataSink extends ParallelSink {
-    @NonNull
     private final SftpClientWrapper sftpClientWrapper;
+
+    public SftpDataSink(SftpClientWrapper sftpClientWrapper) {
+        this.sftpClientWrapper = sftpClientWrapper;
+    }
+
 
     @Override
     protected StreamResult<Void> transferParts(List<DataSource.Part> parts) {

--- a/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSinkFactory.java
+++ b/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSinkFactory.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.client;
 
-import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.apache.sshd.sftp.client.SftpClient;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSink;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSinkFactory;
@@ -25,45 +23,46 @@ import org.eclipse.tractusx.edc.transferprocess.sftp.common.EdcSftpException;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpDataAddress;
 import org.jetbrains.annotations.NotNull;
 
-@RequiredArgsConstructor
+import java.util.List;
+
 public class SftpDataSinkFactory implements DataSinkFactory {
-  @Override
-  public boolean canHandle(DataFlowRequest request) {
-    try {
-      SftpDataAddress.fromDataAddress(request.getDestinationDataAddress());
-      return true;
-    } catch (EdcSftpException e) {
-      return false;
-    }
-  }
-
-  @Override
-  public @NotNull Result<Boolean> validate(DataFlowRequest request) {
-    if (!canHandle(request)) {
-      return Result.failure(String.format("Invalid DataFlowRequest: %s", request.getId()));
+    @Override
+    public boolean canHandle(DataFlowRequest request) {
+        try {
+            SftpDataAddress.fromDataAddress(request.getDestinationDataAddress());
+            return true;
+        } catch (EdcSftpException e) {
+            return false;
+        }
     }
 
-    return VALID;
-  }
+    @Override
+    public @NotNull Result<Boolean> validate(DataFlowRequest request) {
+        if (!canHandle(request)) {
+            return Result.failure(String.format("Invalid DataFlowRequest: %s", request.getId()));
+        }
 
-  @Override
-  public DataSink createSink(DataFlowRequest request) {
-    if (!canHandle(request)) {
-      return null;
+        return VALID;
     }
 
-    SftpDataAddress destination =
-        SftpDataAddress.fromDataAddress(request.getDestinationDataAddress());
+    @Override
+    public DataSink createSink(DataFlowRequest request) {
+        if (!canHandle(request)) {
+            return null;
+        }
 
-    SftpClientConfig sftpClientConfig =
-        SftpClientConfig.builder()
-            .writeOpenModes(List.of(SftpClient.OpenMode.Create, SftpClient.OpenMode.Append))
-            .sftpUser(destination.getSftpUser())
-            .sftpLocation(destination.getSftpLocation())
-            .build();
+        SftpDataAddress destination =
+                SftpDataAddress.fromDataAddress(request.getDestinationDataAddress());
 
-    SftpClientWrapper sftpClientWrapper = new SftpClientWrapperImpl(sftpClientConfig);
+        SftpClientConfig sftpClientConfig =
+                SftpClientConfig.Builder.newInstance()
+                        .writeOpenModes(List.of(SftpClient.OpenMode.Create, SftpClient.OpenMode.Append))
+                        .sftpUser(destination.getSftpUser())
+                        .sftpLocation(destination.getSftpLocation())
+                        .build();
 
-    return new SftpDataSink(sftpClientWrapper);
-  }
+        SftpClientWrapper sftpClientWrapper = new SftpClientWrapperImpl(sftpClientConfig);
+
+        return new SftpDataSink(sftpClientWrapper);
+    }
 }

--- a/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSource.java
+++ b/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSource.java
@@ -14,21 +14,23 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.client;
 
-import lombok.Builder;
-import lombok.NonNull;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
 
 import java.util.stream.Stream;
 
-@Builder
 public class SftpDataSource implements DataSource {
-    @NonNull
     private final SftpClientWrapper sftpClientWrapper;
+
+    public SftpDataSource(SftpClientWrapper sftpClientWrapper) {
+        this.sftpClientWrapper = sftpClientWrapper;
+    }
+
 
     @Override
     public StreamResult<Stream<Part>> openPartStream() {
         Part sftpPart = new SftpPart(sftpClientWrapper);
         return StreamResult.success(Stream.of(sftpPart));
     }
+
 }

--- a/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSourceFactory.java
+++ b/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSourceFactory.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.client;
 
-import lombok.RequiredArgsConstructor;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSourceFactory;
 import org.eclipse.edc.spi.result.Result;
@@ -23,42 +22,41 @@ import org.eclipse.tractusx.edc.transferprocess.sftp.common.EdcSftpException;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpDataAddress;
 import org.jetbrains.annotations.NotNull;
 
-@RequiredArgsConstructor
 public class SftpDataSourceFactory implements DataSourceFactory {
-  @Override
-  public boolean canHandle(DataFlowRequest request) {
-    try {
-      SftpDataAddress.fromDataAddress(request.getSourceDataAddress());
-      return true;
-    } catch (EdcSftpException e) {
-      return false;
-    }
-  }
-
-  @Override
-  public @NotNull Result<Boolean> validate(DataFlowRequest request) {
-    if (!canHandle(request)) {
-      return Result.failure(String.format("Invalid DataFlowRequest: %s", request.getId()));
+    @Override
+    public boolean canHandle(DataFlowRequest request) {
+        try {
+            SftpDataAddress.fromDataAddress(request.getSourceDataAddress());
+            return true;
+        } catch (EdcSftpException e) {
+            return false;
+        }
     }
 
-    return VALID;
-  }
+    @Override
+    public @NotNull Result<Boolean> validate(DataFlowRequest request) {
+        if (!canHandle(request)) {
+            return Result.failure(String.format("Invalid DataFlowRequest: %s", request.getId()));
+        }
 
-  @Override
-  public DataSource createSource(DataFlowRequest request) {
-    if (!canHandle(request)) {
-      return null;
+        return VALID;
     }
 
-    SftpDataAddress source = SftpDataAddress.fromDataAddress(request.getSourceDataAddress());
+    @Override
+    public DataSource createSource(DataFlowRequest request) {
+        if (!canHandle(request)) {
+            return null;
+        }
 
-    SftpClientConfig sftpClientConfig =
-        SftpClientConfig.builder()
-            .sftpUser(source.getSftpUser())
-            .sftpLocation(source.getSftpLocation())
-            .build();
+        SftpDataAddress source = SftpDataAddress.fromDataAddress(request.getSourceDataAddress());
 
-    SftpClientWrapper sftpClientWrapper = new SftpClientWrapperImpl(sftpClientConfig);
-    return new SftpDataSource(sftpClientWrapper);
-  }
+        SftpClientConfig sftpClientConfig =
+                SftpClientConfig.Builder.newInstance()
+                        .sftpUser(source.getSftpUser())
+                        .sftpLocation(source.getSftpLocation())
+                        .build();
+
+        SftpClientWrapper sftpClientWrapper = new SftpClientWrapperImpl(sftpClientConfig);
+        return new SftpDataSource(sftpClientWrapper);
+    }
 }

--- a/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpPart.java
+++ b/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpPart.java
@@ -14,24 +14,30 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.client;
 
-import java.io.InputStream;
-import lombok.Builder;
-import lombok.NonNull;
-import lombok.SneakyThrows;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
+import org.eclipse.tractusx.edc.transferprocess.sftp.common.EdcSftpException;
 
-@Builder
+import java.io.IOException;
+import java.io.InputStream;
+
 public class SftpPart implements DataSource.Part {
-  @NonNull private final SftpClientWrapper sftpClientWrapper;
+    private final SftpClientWrapper sftpClientWrapper;
 
-  @Override
-  public String name() {
-    return ((SftpClientWrapperImpl) sftpClientWrapper).getConfig().getSftpLocation().getPath();
-  }
+    public SftpPart(SftpClientWrapper sftpClientWrapper) {
+        this.sftpClientWrapper = sftpClientWrapper;
+    }
 
-  @Override
-  @SneakyThrows
-  public InputStream openStream() {
-    return sftpClientWrapper.downloadFile();
-  }
+    @Override
+    public String name() {
+        return ((SftpClientWrapperImpl) sftpClientWrapper).getConfig().getSftpLocation().getPath();
+    }
+
+    @Override
+    public InputStream openStream() {
+        try {
+            return sftpClientWrapper.downloadFile();
+        } catch (IOException e) {
+            throw new EdcSftpException(e);
+        }
+    }
 }

--- a/edc-extensions/transferprocess-sftp-client/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpClientWrapperIT.java
+++ b/edc-extensions/transferprocess-sftp-client/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpClientWrapperIT.java
@@ -14,17 +14,7 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.client;
 
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import lombok.Cleanup;
-import lombok.SneakyThrows;
 import org.eclipse.edc.junit.extensions.EdcExtension;
-import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpLocation;
-import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpUser;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,122 +22,98 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 @Disabled("Does not work")
 @Testcontainers
 @ExtendWith(EdcExtension.class)
 class SftpClientWrapperIT extends AbstractSftpClientWrapperIT {
 
-  @ParameterizedTest
-  @SneakyThrows
-  @ArgumentsSource(FilesProvider.class)
-  void uploadFileWithPassword(File file) {
-    final SftpUser sftpUser = getPasswordUser();
-    final SftpLocation sftpLocation =
-        getSftpLocation(
-            String.format(
-                "%s/%s/%s",
-                sftpPathPrefix,
-                remotePasswordUploadDirectory.getFileName().toString(),
-                file.getName()));
+    @ParameterizedTest
+    @ArgumentsSource(FilesProvider.class)
+    void uploadFileWithPassword(File file) throws IOException {
+        var sftpUser = getPasswordUser();
+        var sftpLocation = getSftpLocation(format("%s/%s/%s", sftpPathPrefix, remotePasswordUploadDirectory.getFileName().toString(), file.getName()));
 
-    @Cleanup final InputStream fileStream = Files.newInputStream(file.toPath());
+        var fileStream = Files.newInputStream(file.toPath());
 
-    getSftpClient(sftpLocation, sftpUser).uploadFile(fileStream);
+        getSftpClient(sftpLocation, sftpUser).uploadFile(fileStream);
 
-    final Path uploadedFilePath = remotePasswordUploadDirectory.resolve(file.getName());
-    Assertions.assertTrue(Files.exists(uploadedFilePath));
+        var uploadedFilePath = remotePasswordUploadDirectory.resolve(file.getName());
+        assertTrue(Files.exists(uploadedFilePath));
 
-    @Cleanup final InputStream source = Files.newInputStream(file.toPath());
-    @Cleanup final InputStream target = Files.newInputStream(uploadedFilePath);
+        var source = Files.newInputStream(file.toPath());
+        var target = Files.newInputStream(uploadedFilePath);
 
-    Assertions.assertTrue(
-        IOUtils.contentEquals(source, target),
-        String.format(
-            "File %s should have same content as file %s", file.toPath(), uploadedFilePath));
-  }
+        assertTrue(IOUtils.contentEquals(source, target),
+                format("File %s should have same content as file %s", file.toPath(), uploadedFilePath));
+    }
 
-  @ParameterizedTest
-  @SneakyThrows
-  @ArgumentsSource(FilesProvider.class)
-  void uploadFileWithKeyPair(File file) {
-    final SftpUser sftpUser = getKeyPairUser();
-    final SftpLocation sftpLocation =
-        getSftpLocation(
-            String.format(
-                "%s/%s/%s",
-                sftpPathPrefix,
-                remoteKeypairUploadDirectory.getFileName().toString(),
-                file.getName()));
+    @ParameterizedTest
+    @ArgumentsSource(FilesProvider.class)
+    void uploadFileWithKeyPair(File file) throws IOException {
+        var sftpUser = getKeyPairUser();
+        var sftpLocation =
+                getSftpLocation(
+                        format(
+                                "%s/%s/%s",
+                                sftpPathPrefix,
+                                remoteKeypairUploadDirectory.getFileName().toString(),
+                                file.getName()));
 
-    @Cleanup final InputStream fileStream = Files.newInputStream(file.toPath());
+        var fileStream = Files.newInputStream(file.toPath());
 
-    getSftpClient(sftpLocation, sftpUser).uploadFile(fileStream);
+        getSftpClient(sftpLocation, sftpUser).uploadFile(fileStream);
 
-    final Path uploadedFilePath = remoteKeypairUploadDirectory.resolve(file.getName());
-    Assertions.assertTrue(Files.exists(uploadedFilePath));
+        var uploadedFilePath = remoteKeypairUploadDirectory.resolve(file.getName());
+        assertTrue(Files.exists(uploadedFilePath));
 
-    @Cleanup final InputStream source = Files.newInputStream(file.toPath());
-    @Cleanup final InputStream target = Files.newInputStream(uploadedFilePath);
+        var source = Files.newInputStream(file.toPath());
+        var target = Files.newInputStream(uploadedFilePath);
 
-    Assertions.assertTrue(
-        IOUtils.contentEquals(source, target),
-        String.format(
-            "File %s should have same content as file %s", file.toPath(), uploadedFilePath));
-  }
+        assertTrue(IOUtils.contentEquals(source, target),
+                format("File %s should have same content as file %s", file.toPath(), uploadedFilePath));
+    }
 
-  @ParameterizedTest
-  @SneakyThrows
-  @ArgumentsSource(FilesProvider.class)
-  void downloadFileWithPassword(File file) {
-    final SftpUser sftpUser = getPasswordUser();
-    final SftpLocation sftpLocation =
-        getSftpLocation(
-            String.format(
-                "%s/%s/%s",
-                sftpPathPrefix,
-                remotePasswordDownloadDirectory.getFileName().toString(),
-                file.getName()));
+    @ParameterizedTest
+    @ArgumentsSource(FilesProvider.class)
+    void downloadFileWithPassword(File file) throws IOException {
+        var sftpUser = getPasswordUser();
+        var sftpLocation = getSftpLocation(
+                format("%s/%s/%s", sftpPathPrefix,
+                        remotePasswordDownloadDirectory.getFileName().toString(), file.getName()));
 
-    @Cleanup final InputStream fileToUpload = Files.newInputStream(file.toPath());
-    Files.copy(
-        fileToUpload,
-        remotePasswordDownloadDirectory.resolve(file.getName()),
-        StandardCopyOption.REPLACE_EXISTING);
+        var fileToUpload = Files.newInputStream(file.toPath());
+        Files.copy(fileToUpload,
+                remotePasswordDownloadDirectory.resolve(file.getName()),
+                StandardCopyOption.REPLACE_EXISTING);
 
-    @Cleanup final InputStream source = Files.newInputStream(file.toPath());
-    @Cleanup final InputStream target = getSftpClient(sftpLocation, sftpUser).downloadFile();
+        var source = Files.newInputStream(file.toPath());
+        var target = getSftpClient(sftpLocation, sftpUser).downloadFile();
 
-    Assertions.assertTrue(
-        IOUtils.contentEquals(source, target),
-        String.format(
-            "File %s should have same content as file %s", file.toPath(), sftpLocation.getPath()));
-  }
+        assertTrue(IOUtils.contentEquals(source, target),
+                format("File %s should have same content as file %s", file.toPath(), sftpLocation.getPath()));
+    }
 
-  @ParameterizedTest
-  @SneakyThrows
-  @ArgumentsSource(FilesProvider.class)
-  void downloadFileWithKeyPair(File file) {
-    final SftpUser sftpUser = getKeyPairUser();
-    final SftpLocation sftpLocation =
-        getSftpLocation(
-            String.format(
-                "%s/%s/%s",
-                sftpPathPrefix,
-                remoteKeypairDownloadDirectory.getFileName().toString(),
-                file.getName()));
+    @ParameterizedTest
+    @ArgumentsSource(FilesProvider.class)
+    void downloadFileWithKeyPair(File file) throws IOException {
+        var sftpUser = getKeyPairUser();
+        var sftpLocation = getSftpLocation(format("%s/%s/%s", sftpPathPrefix, remoteKeypairDownloadDirectory.getFileName().toString(), file.getName()));
 
-    @Cleanup final InputStream fileToUpload = Files.newInputStream(file.toPath());
-    Files.copy(
-        fileToUpload,
-        remoteKeypairDownloadDirectory.resolve(file.getName()),
-        StandardCopyOption.REPLACE_EXISTING);
+        var fileToUpload = Files.newInputStream(file.toPath());
+        Files.copy(fileToUpload, remoteKeypairDownloadDirectory.resolve(file.getName()), StandardCopyOption.REPLACE_EXISTING);
 
-    @Cleanup final InputStream source = Files.newInputStream(file.toPath());
-    @Cleanup final InputStream target = getSftpClient(sftpLocation, sftpUser).downloadFile();
+        var source = Files.newInputStream(file.toPath());
+        var target = getSftpClient(sftpLocation, sftpUser).downloadFile();
 
-    Assertions.assertTrue(
-        IOUtils.contentEquals(source, target),
-        String.format(
-            "File %s should have same content as file %s", file.toPath(), sftpLocation.getPath()));
-  }
+        assertTrue(IOUtils.contentEquals(source, target),
+                format("File %s should have same content as file %s", file.toPath(), sftpLocation.getPath()));
+    }
 }

--- a/edc-extensions/transferprocess-sftp-client/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpClientWrapperTest.java
+++ b/edc-extensions/transferprocess-sftp-client/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpClientWrapperTest.java
@@ -20,11 +20,6 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.client;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.util.List;
-import lombok.SneakyThrows;
 import org.apache.sshd.sftp.client.SftpClient;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpLocation;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpUser;
@@ -32,54 +27,60 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
 class SftpClientWrapperTest {
-  @Test
-  @SneakyThrows
-  void uploadFile() {
-    SftpUser userMock = Mockito.mock(SftpUser.class);
-    SftpLocation locationMock = Mockito.mock(SftpLocation.class);
-    SftpClientConfig sftpClientConfig =
-        SftpClientConfig.builder().sftpUser(userMock).sftpLocation(locationMock).build();
-    SftpClient sftpClientMock = Mockito.mock(SftpClient.class);
-    SftpClientWrapperImpl sftpClientWrapper =
-        Mockito.spy(new SftpClientWrapperImpl(sftpClientConfig, sftpClientMock));
-    byte[] content = new byte[] {0, 1, 2};
-    InputStream inputStream = new ByteArrayInputStream(content);
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    @Test
+    void uploadFile() throws IOException {
+        SftpUser userMock = Mockito.mock(SftpUser.class);
+        SftpLocation locationMock = Mockito.mock(SftpLocation.class);
+        SftpClientConfig sftpClientConfig =
+                SftpClientConfig.Builder.newInstance().sftpUser(userMock).sftpLocation(locationMock).build();
+        SftpClient sftpClientMock = Mockito.mock(SftpClient.class);
+        SftpClientWrapperImpl sftpClientWrapper =
+                Mockito.spy(new SftpClientWrapperImpl(sftpClientConfig, sftpClientMock));
+        byte[] content = new byte[]{0, 1, 2};
+        InputStream inputStream = new ByteArrayInputStream(content);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-    Mockito.when(locationMock.getPath()).thenReturn("path");
-    Mockito.when(
-            sftpClientMock.write(Mockito.anyString(), Mockito.anyInt(), Mockito.anyCollection()))
-        .thenReturn(outputStream);
-    sftpClientWrapper.uploadFile(inputStream);
+        Mockito.when(locationMock.getPath()).thenReturn("path");
+        Mockito.when(
+                        sftpClientMock.write(Mockito.anyString(), Mockito.anyInt(), Mockito.anyCollection()))
+                .thenReturn(outputStream);
+        sftpClientWrapper.uploadFile(inputStream);
 
-    Assertions.assertArrayEquals(content, outputStream.toByteArray());
-    Mockito.verify(sftpClientMock, Mockito.times(1))
-        .write("path", 4096, List.of(SftpClient.OpenMode.Create, SftpClient.OpenMode.Write));
-  }
-
-  @Test
-  @SneakyThrows
-  void downloadFile() {
-    SftpUser userMock = Mockito.mock(SftpUser.class);
-    SftpLocation locationMock = Mockito.mock(SftpLocation.class);
-    SftpClientConfig sftpClientConfig =
-        SftpClientConfig.builder().sftpUser(userMock).sftpLocation(locationMock).build();
-    SftpClient sftpClientMock = Mockito.mock(SftpClient.class);
-    SftpClientWrapperImpl sftpClientWrapper =
-        Mockito.spy(new SftpClientWrapperImpl(sftpClientConfig, sftpClientMock));
-    byte[] content = new byte[] {0, 1, 2};
-    InputStream inputStream = new ByteArrayInputStream(content);
-
-    Mockito.when(locationMock.getPath()).thenReturn("path");
-    Mockito.when(
-            sftpClientMock.read(Mockito.anyString(), Mockito.anyInt(), Mockito.anyCollection()))
-        .thenReturn(inputStream);
-
-    try (InputStream resultStream = sftpClientWrapper.downloadFile()) {
-      Assertions.assertArrayEquals(content, resultStream.readAllBytes());
-      Mockito.verify(sftpClientMock, Mockito.times(1))
-          .read("path", 4096, List.of(SftpClient.OpenMode.Read));
+        Assertions.assertArrayEquals(content, outputStream.toByteArray());
+        Mockito.verify(sftpClientMock, Mockito.times(1))
+                .write("path", 4096, List.of(SftpClient.OpenMode.Create, SftpClient.OpenMode.Write));
     }
-  }
+
+    @Test
+    void downloadFile() throws IOException {
+        SftpUser userMock = Mockito.mock(SftpUser.class);
+        SftpLocation locationMock = Mockito.mock(SftpLocation.class);
+        SftpClientConfig sftpClientConfig =
+                SftpClientConfig.Builder.newInstance().sftpUser(userMock).sftpLocation(locationMock).build();
+        SftpClient sftpClientMock = Mockito.mock(SftpClient.class);
+        SftpClientWrapperImpl sftpClientWrapper =
+                Mockito.spy(new SftpClientWrapperImpl(sftpClientConfig, sftpClientMock));
+        byte[] content = new byte[]{0, 1, 2};
+        InputStream inputStream = new ByteArrayInputStream(content);
+
+        Mockito.when(locationMock.getPath()).thenReturn("path");
+        Mockito.when(
+                        sftpClientMock.read(Mockito.anyString(), Mockito.anyInt(), Mockito.anyCollection()))
+                .thenReturn(inputStream);
+
+        try (InputStream resultStream = sftpClientWrapper.downloadFile()) {
+            Assertions.assertArrayEquals(content, resultStream.readAllBytes());
+            Mockito.verify(sftpClientMock, Mockito.times(1))
+                    .read("path", 4096, List.of(SftpClient.OpenMode.Read));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/edc-extensions/transferprocess-sftp-client/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSinkFactoryTest.java
+++ b/edc-extensions/transferprocess-sftp-client/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSinkFactoryTest.java
@@ -20,9 +20,6 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.client;
 
-import java.util.List;
-import java.util.Map;
-import lombok.SneakyThrows;
 import org.apache.sshd.sftp.client.SftpClient;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
@@ -34,91 +31,92 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.util.List;
+import java.util.Map;
+
 class SftpDataSinkFactoryTest {
 
-  @Test
-  void validate__valid() {
-    SftpDataSinkFactory dataSinkFactory = new SftpDataSinkFactory();
-    SftpUser sftpUser = SftpUser.builder().name("name").build();
-    SftpLocation sftpLocation = SftpLocation.builder().host("host").port(22).path("path").build();
+    @Test
+    void validate_valid() {
+        SftpDataSinkFactory dataSinkFactory = new SftpDataSinkFactory();
+        SftpUser sftpUser = SftpUser.Builder.newInstance().name("name").build();
+        SftpLocation sftpLocation = SftpLocation.Builder.newInstance().host("host").port(22).path("path").build();
 
-    SftpDataAddress sftpDataAddress =
-        SftpDataAddress.builder().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
-    DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
-    Mockito.when(request.getDestinationDataAddress()).thenReturn(sftpDataAddress);
+        SftpDataAddress sftpDataAddress =
+                SftpDataAddress.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
+        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
+        Mockito.when(request.getDestinationDataAddress()).thenReturn(sftpDataAddress);
 
-    Assertions.assertTrue(dataSinkFactory.validate(request).succeeded());
-  }
-
-  @Test
-  void validate__invalidDataAddressType() {
-    SftpDataSinkFactory dataSinkFactory = new SftpDataSinkFactory();
-    DataAddress dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
-    DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
-    Mockito.when(request.getDestinationDataAddress()).thenReturn(dataAddress);
-
-    Assertions.assertTrue(dataSinkFactory.validate(request).failed());
-  }
-
-  @Test
-  void validate__invalidDataAddressParameters() {
-    SftpDataSinkFactory dataSinkFactory = new SftpDataSinkFactory();
-    final Map<String, String> properties =
-        Map.of(
-            "type", "sftp",
-            "locationHost", "localhost",
-            "locationPort", "notANumber",
-            "locationPath", "path",
-            "userName", "name",
-            "userPassword", "password");
-
-    final DataAddress dataAddress =
-        DataAddress.Builder.newInstance().properties(properties).build();
-    DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
-    Mockito.when(request.getDestinationDataAddress()).thenReturn(dataAddress);
-
-    Assertions.assertTrue(dataSinkFactory.validate(request).failed());
-  }
-
-  @Test
-  @SneakyThrows
-  void createSink__successful() {
-    SftpDataSinkFactory dataSinkFactory = new SftpDataSinkFactory();
-    SftpUser sftpUser = SftpUser.builder().name("name").build();
-    SftpLocation sftpLocation =
-        SftpLocation.builder().host("127.0.0.1").port(22).path("path").build();
-    SftpClientConfig sftpClientConfig =
-        SftpClientConfig.builder()
-            .writeOpenModes(List.of(SftpClient.OpenMode.Create, SftpClient.OpenMode.Append))
-            .sftpUser(sftpUser)
-            .sftpLocation(sftpLocation)
-            .build();
-
-    SftpDataAddress sftpDataAddress =
-        SftpDataAddress.builder().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
-    DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
-    Mockito.when(request.getDestinationDataAddress()).thenReturn(sftpDataAddress);
-
-    try (MockedStatic<SftpClientWrapperImpl> staticWrapper =
-        Mockito.mockStatic(SftpClientWrapperImpl.class)) {
-      staticWrapper
-          .when(() -> SftpClientWrapperImpl.getSftpClient(sftpClientConfig))
-          .thenReturn(Mockito.mock(SftpClient.class));
-      Assertions.assertNotNull(dataSinkFactory.createSink(request));
-
-      staticWrapper.verify(
-          () -> SftpClientWrapperImpl.getSftpClient(Mockito.any()), Mockito.times(1));
+        Assertions.assertTrue(dataSinkFactory.validate(request).succeeded());
     }
-  }
 
-  @Test
-  @SneakyThrows
-  void createSink__invalidDataAddressType() {
-    SftpDataSinkFactory dataSinkFactory = new SftpDataSinkFactory();
-    DataAddress dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
-    DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
-    Mockito.when(request.getDestinationDataAddress()).thenReturn(dataAddress);
+    @Test
+    void validate_invalidDataAddressType() {
+        SftpDataSinkFactory dataSinkFactory = new SftpDataSinkFactory();
+        DataAddress dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
+        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
+        Mockito.when(request.getDestinationDataAddress()).thenReturn(dataAddress);
 
-    Assertions.assertNull(dataSinkFactory.createSink(request));
-  }
+        Assertions.assertTrue(dataSinkFactory.validate(request).failed());
+    }
+
+    @Test
+    void validate_invalidDataAddressParameters() {
+        SftpDataSinkFactory dataSinkFactory = new SftpDataSinkFactory();
+        final Map<String, String> properties =
+                Map.of(
+                        "type", "sftp",
+                        "locationHost", "localhost",
+                        "locationPort", "notANumber",
+                        "locationPath", "path",
+                        "userName", "name",
+                        "userPassword", "password");
+
+        final DataAddress dataAddress =
+                DataAddress.Builder.newInstance().properties(properties).build();
+        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
+        Mockito.when(request.getDestinationDataAddress()).thenReturn(dataAddress);
+
+        Assertions.assertTrue(dataSinkFactory.validate(request).failed());
+    }
+
+    @Test
+    void createSink_successful() {
+        SftpDataSinkFactory dataSinkFactory = new SftpDataSinkFactory();
+        SftpUser sftpUser = SftpUser.Builder.newInstance().name("name").build();
+        SftpLocation sftpLocation =
+                SftpLocation.Builder.newInstance().host("127.0.0.1").port(22).path("path").build();
+        SftpClientConfig sftpClientConfig =
+                SftpClientConfig.Builder.newInstance()
+                        .writeOpenModes(List.of(SftpClient.OpenMode.Create, SftpClient.OpenMode.Append))
+                        .sftpUser(sftpUser)
+                        .sftpLocation(sftpLocation)
+                        .build();
+
+        SftpDataAddress sftpDataAddress =
+                SftpDataAddress.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
+        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
+        Mockito.when(request.getDestinationDataAddress()).thenReturn(sftpDataAddress);
+
+        try (MockedStatic<SftpClientWrapperImpl> staticWrapper =
+                     Mockito.mockStatic(SftpClientWrapperImpl.class)) {
+            staticWrapper
+                    .when(() -> SftpClientWrapperImpl.getSftpClient(sftpClientConfig))
+                    .thenReturn(Mockito.mock(SftpClient.class));
+            Assertions.assertNotNull(dataSinkFactory.createSink(request));
+
+            staticWrapper.verify(
+                    () -> SftpClientWrapperImpl.getSftpClient(Mockito.any()), Mockito.times(1));
+        }
+    }
+
+    @Test
+    void createSink_invalidDataAddressType() {
+        SftpDataSinkFactory dataSinkFactory = new SftpDataSinkFactory();
+        DataAddress dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
+        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
+        Mockito.when(request.getDestinationDataAddress()).thenReturn(dataAddress);
+
+        Assertions.assertNull(dataSinkFactory.createSink(request));
+    }
 }

--- a/edc-extensions/transferprocess-sftp-client/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSourceFactoryTest.java
+++ b/edc-extensions/transferprocess-sftp-client/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSourceFactoryTest.java
@@ -20,8 +20,6 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.client;
 
-import java.util.Map;
-import lombok.SneakyThrows;
 import org.apache.sshd.sftp.client.SftpClient;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
@@ -33,86 +31,86 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.util.Map;
+
 class SftpDataSourceFactoryTest {
 
-  @Test
-  void validate__valid() {
-    SftpDataSourceFactory dataSourceFactory = new SftpDataSourceFactory();
-    SftpUser sftpUser = SftpUser.builder().name("name").build();
-    SftpLocation sftpLocation = SftpLocation.builder().host("host").port(22).path("path").build();
+    @Test
+    void validate_valid() {
+        SftpDataSourceFactory dataSourceFactory = new SftpDataSourceFactory();
+        SftpUser sftpUser = SftpUser.Builder.newInstance().name("name").build();
+        SftpLocation sftpLocation = SftpLocation.Builder.newInstance().host("host").port(22).path("path").build();
 
-    SftpDataAddress sftpDataAddress =
-        SftpDataAddress.builder().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
-    DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
-    Mockito.when(request.getSourceDataAddress()).thenReturn(sftpDataAddress);
+        SftpDataAddress sftpDataAddress =
+                SftpDataAddress.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
+        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
+        Mockito.when(request.getSourceDataAddress()).thenReturn(sftpDataAddress);
 
-    Assertions.assertTrue(dataSourceFactory.validate(request).succeeded());
-  }
-
-  @Test
-  void validate__invalidDataAddressType() {
-    SftpDataSourceFactory dataSourceFactory = new SftpDataSourceFactory();
-    DataAddress dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
-    DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
-    Mockito.when(request.getSourceDataAddress()).thenReturn(dataAddress);
-
-    Assertions.assertTrue(dataSourceFactory.validate(request).failed());
-  }
-
-  @Test
-  void validate__invalidDataAddressParameters() {
-    SftpDataSourceFactory dataSourceFactory = new SftpDataSourceFactory();
-    final Map<String, String> properties =
-        Map.of(
-            "type", "sftp",
-            "locationHost", "localhost",
-            "locationPort", "notANumber",
-            "locationPath", "path",
-            "userName", "name",
-            "userPassword", "password");
-
-    DataAddress dataAddress = DataAddress.Builder.newInstance().properties(properties).build();
-    DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
-    Mockito.when(request.getSourceDataAddress()).thenReturn(dataAddress);
-
-    Assertions.assertTrue(dataSourceFactory.validate(request).failed());
-  }
-
-  @Test
-  @SneakyThrows
-  void createSink__successful() {
-    SftpDataSourceFactory dataSourceFactory = new SftpDataSourceFactory();
-    SftpUser sftpUser = SftpUser.builder().name("name").build();
-    SftpLocation sftpLocation =
-        SftpLocation.builder().host("127.0.0.1").port(22).path("path").build();
-    SftpClientConfig sftpClientConfig =
-        SftpClientConfig.builder().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
-
-    SftpDataAddress sftpDataAddress =
-        SftpDataAddress.builder().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
-    DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
-    Mockito.when(request.getSourceDataAddress()).thenReturn(sftpDataAddress);
-
-    try (MockedStatic<SftpClientWrapperImpl> staticWrapper =
-        Mockito.mockStatic(SftpClientWrapperImpl.class)) {
-      staticWrapper
-          .when(() -> SftpClientWrapperImpl.getSftpClient(sftpClientConfig))
-          .thenReturn(Mockito.mock(SftpClient.class));
-      Assertions.assertNotNull(dataSourceFactory.createSource(request));
-
-      staticWrapper.verify(
-          () -> SftpClientWrapperImpl.getSftpClient(Mockito.any()), Mockito.times(1));
+        Assertions.assertTrue(dataSourceFactory.validate(request).succeeded());
     }
-  }
 
-  @Test
-  @SneakyThrows
-  void createSink__invalidDataAddressType() {
-    SftpDataSourceFactory dataSourceFactory = new SftpDataSourceFactory();
-    DataAddress dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
-    DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
-    Mockito.when(request.getSourceDataAddress()).thenReturn(dataAddress);
+    @Test
+    void validate_invalidDataAddressType() {
+        SftpDataSourceFactory dataSourceFactory = new SftpDataSourceFactory();
+        DataAddress dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
+        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
+        Mockito.when(request.getSourceDataAddress()).thenReturn(dataAddress);
 
-    Assertions.assertNull(dataSourceFactory.createSource(request));
-  }
+        Assertions.assertTrue(dataSourceFactory.validate(request).failed());
+    }
+
+    @Test
+    void validate_invalidDataAddressParameters() {
+        SftpDataSourceFactory dataSourceFactory = new SftpDataSourceFactory();
+        final Map<String, String> properties =
+                Map.of(
+                        "type", "sftp",
+                        "locationHost", "localhost",
+                        "locationPort", "notANumber",
+                        "locationPath", "path",
+                        "userName", "name",
+                        "userPassword", "password");
+
+        DataAddress dataAddress = DataAddress.Builder.newInstance().properties(properties).build();
+        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
+        Mockito.when(request.getSourceDataAddress()).thenReturn(dataAddress);
+
+        Assertions.assertTrue(dataSourceFactory.validate(request).failed());
+    }
+
+    @Test
+    void createSink_successful() {
+        SftpDataSourceFactory dataSourceFactory = new SftpDataSourceFactory();
+        SftpUser sftpUser = SftpUser.Builder.newInstance().name("name").build();
+        SftpLocation sftpLocation =
+                SftpLocation.Builder.newInstance().host("127.0.0.1").port(22).path("path").build();
+        SftpClientConfig sftpClientConfig =
+                SftpClientConfig.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
+
+        SftpDataAddress sftpDataAddress =
+                SftpDataAddress.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
+        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
+        Mockito.when(request.getSourceDataAddress()).thenReturn(sftpDataAddress);
+
+        try (MockedStatic<SftpClientWrapperImpl> staticWrapper =
+                     Mockito.mockStatic(SftpClientWrapperImpl.class)) {
+            staticWrapper
+                    .when(() -> SftpClientWrapperImpl.getSftpClient(sftpClientConfig))
+                    .thenReturn(Mockito.mock(SftpClient.class));
+            Assertions.assertNotNull(dataSourceFactory.createSource(request));
+
+            staticWrapper.verify(
+                    () -> SftpClientWrapperImpl.getSftpClient(Mockito.any()), Mockito.times(1));
+        }
+    }
+
+    @Test
+    void createSink_invalidDataAddressType() {
+        SftpDataSourceFactory dataSourceFactory = new SftpDataSourceFactory();
+        DataAddress dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
+        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
+        Mockito.when(request.getSourceDataAddress()).thenReturn(dataAddress);
+
+        Assertions.assertNull(dataSourceFactory.createSource(request));
+    }
 }

--- a/edc-extensions/transferprocess-sftp-client/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSourceTest.java
+++ b/edc-extensions/transferprocess-sftp-client/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSourceTest.java
@@ -20,7 +20,6 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.client;
 
-import lombok.SneakyThrows;
 import org.apache.sshd.sftp.client.SftpClient;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpLocation;
@@ -30,23 +29,23 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class SftpDataSourceTest {
     @Test
-    @SneakyThrows
-    void openPartStream() {
+    void openPartStream() throws IOException {
         final SftpUser userMock = Mockito.mock(SftpUser.class);
         final SftpLocation locationMock = Mockito.mock(SftpLocation.class);
         final SftpClientConfig sftpClientConfig =
-                SftpClientConfig.builder().sftpUser(userMock).sftpLocation(locationMock).build();
+                SftpClientConfig.Builder.newInstance().sftpUser(userMock).sftpLocation(locationMock).build();
         final SftpClient sftpClientMock = Mockito.mock(SftpClient.class);
         final SftpClientWrapperImpl sftpClientWrapper =
                 Mockito.spy(new SftpClientWrapperImpl(sftpClientConfig, sftpClientMock));
         SftpDataSource sftpDataSource = Mockito.spy(new SftpDataSource(sftpClientWrapper));
-        byte[] expected = new byte[]{ 0, 1, 2, 3 };
+        byte[] expected = new byte[]{0, 1, 2, 3};
         ByteArrayInputStream outputStream = new ByteArrayInputStream(expected);
 
         Mockito.when(locationMock.getPath()).thenReturn("path");

--- a/edc-extensions/transferprocess-sftp-common/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/common/SftpDataAddress.java
+++ b/edc-extensions/transferprocess-sftp-common/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/common/SftpDataAddress.java
@@ -14,66 +14,112 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.common;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NonNull;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 
-@AllArgsConstructor
-@Builder
-@Getter
+import java.util.Base64;
+
+import static java.lang.String.format;
+
 public class SftpDataAddress extends DataAddress {
-  private static final String LOCATION_HOST = "locationHost";
-  private static final String LOCATION_PORT = "locationPort";
-  private static final String LOCATION_PATH = "locationPath";
-  private static final String USER_NAME = "userName";
-  private static final String USER_PASSWORD = "userPassword";
-  private static final String USER_PRIVATE_KEY = "userPrivateKey";
+    private static final String LOCATION_HOST = "locationHost";
+    private static final String LOCATION_PORT = "locationPort";
+    private static final String LOCATION_PATH = "locationPath";
+    private static final String USER_NAME = "userName";
+    private static final String USER_PASSWORD = "userPassword";
+    private static final String USER_PRIVATE_KEY = "userPrivateKey";
 
-  @Getter private static final String CONNECTION_TYPE = "sftp";
-  @NonNull private final SftpUser sftpUser;
-  @NonNull private final SftpLocation sftpLocation;
 
-  public static SftpDataAddress fromDataAddress(DataAddress dataAddress) throws EdcSftpException {
-    if (dataAddress instanceof SftpDataAddress) {
-      return (SftpDataAddress) dataAddress;
+    private static final String CONNECTION_TYPE = "sftp";
+
+    private SftpDataAddress() {
+
     }
 
-    if (!dataAddress.getType().equalsIgnoreCase("sftp")) {
-      throw new EdcSftpException(
-          String.format(
-              "Invalid DataAddress type: %s. Expected %s.",
-              dataAddress.getType(), CONNECTION_TYPE));
+    public static SftpDataAddress fromDataAddress(DataAddress dataAddress) throws EdcSftpException {
+        if (dataAddress instanceof SftpDataAddress) {
+            return (SftpDataAddress) dataAddress;
+        }
+
+        if (!dataAddress.getType().equalsIgnoreCase("sftp")) {
+            throw new EdcSftpException(format("Invalid DataAddress type: %s. Expected %s.",
+                    dataAddress.getType(), CONNECTION_TYPE));
+        }
+
+        try {
+            var sftpUser = createSftpUser(dataAddress);
+
+            var sftpLocation = createSftpLocation(dataAddress);
+
+            return SftpDataAddress.Builder.newInstance()
+                    .sftpUser(sftpUser)
+                    .sftpLocation(sftpLocation)
+                    .build();
+        } catch (NullPointerException e) {
+            throw new EdcSftpException(e.getMessage(), e);
+        } catch (NumberFormatException e) {
+            throw new EdcSftpException(format("Port for SftpLocation %s/%s not a number", dataAddress.getProperty(LOCATION_HOST), dataAddress.getProperty(LOCATION_PATH)), e);
+        }
     }
 
-    try {
-      SftpUser sftpUser =
-          SftpUser.builder()
-              .name(dataAddress.getProperty(USER_NAME))
-              .password(dataAddress.getProperty(USER_PASSWORD))
-              .keyPair(
-                  SftpUserKeyPairGenerator.getKeyPairFromPrivateKey(
-                      dataAddress.getProperty(USER_PRIVATE_KEY),
-                      dataAddress.getProperty(USER_NAME)))
-              .build();
-
-      SftpLocation sftpLocation =
-          SftpLocation.builder()
-              .host(dataAddress.getProperty(LOCATION_HOST))
-              .port(Integer.valueOf(dataAddress.getProperty(LOCATION_PORT, "22")))
-              .path(dataAddress.getProperty(LOCATION_PATH))
-              .build();
-
-      return SftpDataAddress.builder().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
-    } catch (NullPointerException e) {
-      throw new EdcSftpException(e.getMessage(), e);
-    } catch (NumberFormatException e) {
-      throw new EdcSftpException(
-          String.format(
-              "Port for SftpLocation %s/%s not a number",
-              dataAddress.getProperty(LOCATION_HOST), dataAddress.getProperty(LOCATION_PATH)),
-          e);
+    private static SftpLocation createSftpLocation(DataAddress dataAddress) {
+        return SftpLocation.Builder.newInstance()
+                .host(dataAddress.getProperty(LOCATION_HOST))
+                .port(Integer.parseInt(dataAddress.getProperty(LOCATION_PORT, "22")))
+                .path(dataAddress.getProperty(LOCATION_PATH))
+                .build();
     }
-  }
+
+    private static SftpUser createSftpUser(DataAddress dataAddress) {
+        return SftpUser.Builder.newInstance()
+                .name(dataAddress.getProperty(USER_NAME))
+                .password(dataAddress.getProperty(USER_PASSWORD))
+                .keyPair(SftpUserKeyPairGenerator.getKeyPairFromPrivateKey(
+                        dataAddress.getProperty(USER_PRIVATE_KEY),
+                        dataAddress.getProperty(USER_NAME)))
+                .build();
+    }
+
+    public SftpUser getSftpUser() {
+        return createSftpUser(this);
+    }
+
+    public SftpLocation getSftpLocation() {
+        return createSftpLocation(this);
+    }
+
+    public static class Builder extends DataAddress.Builder<SftpDataAddress, Builder> {
+        protected Builder(SftpDataAddress address) {
+            super(address);
+        }
+
+        public static Builder newInstance() {
+            return new Builder(new SftpDataAddress());
+        }
+
+        public Builder sftpUser(SftpUser user) {
+            this.address.getProperties().put(USER_NAME, user.getName());
+            this.address.getProperties().put(USER_PASSWORD, user.getPassword());
+            if (user.getKeyPair() != null) {
+                this.address.getProperties().put(USER_PRIVATE_KEY, Base64.getEncoder().encodeToString(user.getKeyPair().getPrivate().getEncoded()));
+                this.address.getProperties().put(KEY_NAME, user.getName());
+            }
+            return this;
+        }
+
+        public Builder sftpLocation(SftpLocation location) {
+            this.address.getProperties().put(LOCATION_HOST, location.getHost());
+            this.address.getProperties().put(LOCATION_PORT, String.valueOf(location.getPort()));
+            this.address.getProperties().put(LOCATION_PATH, location.getPath());
+            return this;
+        }
+
+        @Override
+        public SftpDataAddress build() {
+            address.setType(CONNECTION_TYPE);
+
+            super.build(); //for validation
+            return address;
+        }
+    }
+
 }

--- a/edc-extensions/transferprocess-sftp-common/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/common/SftpLocation.java
+++ b/edc-extensions/transferprocess-sftp-common/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/common/SftpLocation.java
@@ -14,21 +14,64 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.common;
 
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NonNull;
+import java.util.Objects;
 
-@Builder
-@Getter
-@EqualsAndHashCode
 public class SftpLocation {
-  @NonNull private final String host;
-  @NonNull private final Integer port;
-  @NonNull private final String path;
+    private String host;
+    private int port;
+    private String path;
 
-  @Override
-  public String toString() {
-    return String.format("%s:%d/%s", host, port, path);
-  }
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s:%d/%s", host, port, path);
+    }
+
+
+    public static class Builder {
+        private final SftpLocation location;
+
+        private Builder() {
+            location = new SftpLocation();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder host(String host) {
+            location.host = host;
+            return this;
+        }
+
+        public Builder port(int port) {
+            location.port = port;
+            return this;
+        }
+
+        public Builder path(String path) {
+            location.path = path;
+            return this;
+        }
+
+        public SftpLocation build() {
+            Objects.requireNonNull(location.host, "host");
+            Objects.requireNonNull(location.path, "path");
+            if (location.port <= 0) {
+                throw new IllegalArgumentException("port must be > 0 but was " + location.port);
+            }
+            return location;
+        }
+    }
 }

--- a/edc-extensions/transferprocess-sftp-common/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/common/SftpUser.java
+++ b/edc-extensions/transferprocess-sftp-common/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/common/SftpUser.java
@@ -15,18 +15,52 @@
 package org.eclipse.tractusx.edc.transferprocess.sftp.common;
 
 import java.security.KeyPair;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.ToString;
 
-@Builder
-@Getter
-@ToString(of = "name")
-@EqualsAndHashCode
 public class SftpUser {
-  @NonNull private final String name;
-  private final String password;
-  private final KeyPair keyPair;
+    private String name;
+    private String password;
+    private KeyPair keyPair;
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public KeyPair getKeyPair() {
+        return keyPair;
+    }
+
+    public static class Builder {
+        private final SftpUser user;
+
+        private Builder() {
+            user = new SftpUser();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder name(String name) {
+            user.name = name;
+            return this;
+        }
+
+        public Builder password(String password) {
+            user.password = password;
+            return this;
+        }
+
+        public Builder keyPair(KeyPair keyPair) {
+            user.keyPair = keyPair;
+            return this;
+        }
+
+        public SftpUser build() {
+            return user;
+        }
+    }
 }

--- a/edc-extensions/transferprocess-sftp-common/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/common/SftpDataAddressTest.java
+++ b/edc-extensions/transferprocess-sftp-common/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/common/SftpDataAddressTest.java
@@ -14,198 +14,187 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.common;
 
-import java.security.KeyPair;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.Test;
+
 import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.Map;
-import lombok.SneakyThrows;
-import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
 
 class SftpDataAddressTest {
 
-  @Test
-  void fromDataAddress__password() {
-    final Map<String, String> properties =
-        Map.of(
-            "type", "sftp",
-            "locationHost", "localhost",
-            "locationPort", "22",
-            "locationPath", "path",
-            "userName", "name",
-            "userPassword", "password");
+    @Test
+    void fromDataAddress_password() {
+        var properties = Map.of(
+                "type", "sftp",
+                "locationHost", "localhost",
+                "locationPort", "22",
+                "locationPath", "path",
+                "userName", "name",
+                "userPassword", "password");
 
-    final DataAddress dataAddress =
-        DataAddress.Builder.newInstance().properties(properties).build();
+        var dataAddress = DataAddress.Builder.newInstance().properties(properties).build();
 
-    final SftpDataAddress sftpDataAddress = SftpDataAddress.fromDataAddress(dataAddress);
+        var sftpDataAddress = SftpDataAddress.fromDataAddress(dataAddress);
 
-    Assertions.assertEquals("localhost", sftpDataAddress.getSftpLocation().getHost());
-    Assertions.assertEquals(22, sftpDataAddress.getSftpLocation().getPort());
-    Assertions.assertEquals("path", sftpDataAddress.getSftpLocation().getPath());
-    Assertions.assertEquals("name", sftpDataAddress.getSftpUser().getName());
-    Assertions.assertEquals("password", sftpDataAddress.getSftpUser().getPassword());
-    Assertions.assertNull(sftpDataAddress.getSftpUser().getKeyPair());
-  }
+        assertEquals("localhost", sftpDataAddress.getSftpLocation().getHost());
+        assertEquals(22, sftpDataAddress.getSftpLocation().getPort());
+        assertEquals("path", sftpDataAddress.getSftpLocation().getPath());
+        assertEquals("name", sftpDataAddress.getSftpUser().getName());
+        assertEquals("password", sftpDataAddress.getSftpUser().getPassword());
+        assertNull(sftpDataAddress.getSftpUser().getKeyPair());
+    }
 
-  @Test
-  @SneakyThrows
-  void fromDataAddress__keyPair() {
-    final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
-    keyPairGenerator.initialize(2048);
-    final KeyPair keyPair = keyPairGenerator.generateKeyPair();
-    final byte[] privateKeyBytes = keyPair.getPrivate().getEncoded();
+    @Test
+    void fromDataAddress_keyPair() throws NoSuchAlgorithmException {
+        var keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        var keyPair = keyPairGenerator.generateKeyPair();
+        var privateKeyBytes = keyPair.getPrivate().getEncoded();
 
-    final Map<String, String> properties =
-        Map.of(
-            "type", "sftp",
-            "locationHost", "localhost",
-            "locationPort", "22",
-            "locationPath", "path",
-            "userName", "name",
-            "userPrivateKey", Base64.getEncoder().encodeToString(privateKeyBytes));
+        var properties =
+                Map.of(
+                        "type", "sftp",
+                        "locationHost", "localhost",
+                        "locationPort", "22",
+                        "locationPath", "path",
+                        "userName", "name",
+                        "userPrivateKey", Base64.getEncoder().encodeToString(privateKeyBytes));
 
-    final DataAddress dataAddress =
-        DataAddress.Builder.newInstance().properties(properties).build();
+        var dataAddress =
+                DataAddress.Builder.newInstance().properties(properties).build();
 
-    final SftpDataAddress sftpDataAddress = SftpDataAddress.fromDataAddress(dataAddress);
+        var sftpDataAddress = SftpDataAddress.fromDataAddress(dataAddress);
 
-    Assertions.assertEquals("localhost", sftpDataAddress.getSftpLocation().getHost());
-    Assertions.assertEquals(22, sftpDataAddress.getSftpLocation().getPort());
-    Assertions.assertEquals("path", sftpDataAddress.getSftpLocation().getPath());
-    Assertions.assertEquals("name", sftpDataAddress.getSftpUser().getName());
-    Assertions.assertArrayEquals(
-        privateKeyBytes, sftpDataAddress.getSftpUser().getKeyPair().getPrivate().getEncoded());
-    Assertions.assertNull(sftpDataAddress.getSftpUser().getPassword());
-  }
+        assertEquals("localhost", sftpDataAddress.getSftpLocation().getHost());
+        assertEquals(22, sftpDataAddress.getSftpLocation().getPort());
+        assertEquals("path", sftpDataAddress.getSftpLocation().getPath());
+        assertEquals("name", sftpDataAddress.getSftpUser().getName());
+        assertArrayEquals(
+                privateKeyBytes, sftpDataAddress.getSftpUser().getKeyPair().getPrivate().getEncoded());
+        assertNull(sftpDataAddress.getSftpUser().getPassword());
+    }
 
-  @Test
-  @SneakyThrows
-  void fromDataAddress__noAuth() {
-    final Map<String, String> properties =
-        Map.of(
-            "type", "sftp",
-            "locationHost", "localhost",
-            "locationPort", "22",
-            "locationPath", "path",
-            "userName", "name");
+    @Test
+    void fromDataAddress_noAuth() {
+        var properties =
+                Map.of(
+                        "type", "sftp",
+                        "locationHost", "localhost",
+                        "locationPort", "22",
+                        "locationPath", "path",
+                        "userName", "name");
 
-    final DataAddress dataAddress =
-        DataAddress.Builder.newInstance().properties(properties).build();
+        var dataAddress =
+                DataAddress.Builder.newInstance().properties(properties).build();
 
-    final SftpDataAddress sftpDataAddress = SftpDataAddress.fromDataAddress(dataAddress);
+        var sftpDataAddress = SftpDataAddress.fromDataAddress(dataAddress);
 
-    Assertions.assertEquals("localhost", sftpDataAddress.getSftpLocation().getHost());
-    Assertions.assertEquals(22, sftpDataAddress.getSftpLocation().getPort());
-    Assertions.assertEquals("path", sftpDataAddress.getSftpLocation().getPath());
-    Assertions.assertEquals("name", sftpDataAddress.getSftpUser().getName());
-    Assertions.assertNull(sftpDataAddress.getSftpUser().getPassword());
-  }
+        assertEquals("localhost", sftpDataAddress.getSftpLocation().getHost());
+        assertEquals(22, sftpDataAddress.getSftpLocation().getPort());
+        assertEquals("path", sftpDataAddress.getSftpLocation().getPath());
+        assertEquals("name", sftpDataAddress.getSftpUser().getName());
+        assertNull(sftpDataAddress.getSftpUser().getPassword());
+    }
 
-  @Test
-  @SneakyThrows
-  void fromDataAddress__invalidKeyPairBrokenBase64() {
-    final Map<String, String> properties =
-        Map.of(
-            "type", "sftp",
-            "locationHost", "localhost",
-            "locationPort", "22",
-            "locationPath", "path",
-            "userName", "name",
-            "userPrivateKey", "clearlyNotAPrivateKey");
+    @Test
+    void fromDataAddress_invalidKeyPairBrokenBase64() {
+        var properties =
+                Map.of(
+                        "type", "sftp",
+                        "locationHost", "localhost",
+                        "locationPort", "22",
+                        "locationPath", "path",
+                        "userName", "name",
+                        "userPrivateKey", "clearlyNotAPrivateKey");
 
-    final DataAddress dataAddress =
-        DataAddress.Builder.newInstance().properties(properties).build();
+        var dataAddress =
+                DataAddress.Builder.newInstance().properties(properties).build();
 
-    EdcSftpException edcSftpException =
-        Assertions.assertThrows(
-            EdcSftpException.class, () -> SftpDataAddress.fromDataAddress(dataAddress));
-    Assertions.assertEquals(
-        "Cannot decode base64 private key for user name", edcSftpException.getMessage());
-  }
+        var edcSftpException =
+                assertThrows(
+                        EdcSftpException.class, () -> SftpDataAddress.fromDataAddress(dataAddress));
+        assertEquals(
+                "Cannot decode base64 private key for user name", edcSftpException.getMessage());
+    }
 
-  @Test
-  @SneakyThrows
-  void fromDataAddress__invalidKeyPairButCorrectBase64() {
-    final Map<String, String> properties =
-        Map.of(
-            "type", "sftp",
-            "locationHost", "localhost",
-            "locationPort", "22",
-            "locationPath", "path",
-            "userName", "name",
-            "userPrivateKey", "TWFueSBoYW5kcyBtYWtlIGxpZ2h0IHdvcmsu");
+    @Test
+    void fromDataAddress_invalidKeyPairButCorrectBase64() {
+        var properties =
+                Map.of(
+                        "type", "sftp",
+                        "locationHost", "localhost",
+                        "locationPort", "22",
+                        "locationPath", "path",
+                        "userName", "name",
+                        "userPrivateKey", "TWFueSBoYW5kcyBtYWtlIGxpZ2h0IHdvcmsu");
 
-    final DataAddress dataAddress =
-        DataAddress.Builder.newInstance().properties(properties).build();
+        var dataAddress =
+                DataAddress.Builder.newInstance().properties(properties).build();
 
-    EdcSftpException edcSftpException =
-        Assertions.assertThrows(
-            EdcSftpException.class, () -> SftpDataAddress.fromDataAddress(dataAddress));
-    Assertions.assertEquals(
-        "Unable to parse provided keypair for Sftp user name", edcSftpException.getMessage());
-  }
+        var edcSftpException =
+                assertThrows(
+                        EdcSftpException.class, () -> SftpDataAddress.fromDataAddress(dataAddress));
+        assertEquals(
+                "Unable to parse provided keypair for Sftp user name", edcSftpException.getMessage());
+    }
 
-  @Test
-  void fromDataAddress__portNaN() {
-    final Map<String, String> properties =
-        Map.of(
-            "type", "sftp",
-            "locationHost", "localhost",
-            "locationPort", "notANumber",
-            "locationPath", "path",
-            "userName", "name",
-            "userPassword", "password");
+    @Test
+    void fromDataAddress_portNaN() {
+        var properties =
+                Map.of(
+                        "type", "sftp",
+                        "locationHost", "localhost",
+                        "locationPort", "notANumber",
+                        "locationPath", "path",
+                        "userName", "name",
+                        "userPassword", "password");
 
-    final DataAddress dataAddress =
-        DataAddress.Builder.newInstance().properties(properties).build();
+        var dataAddress = DataAddress.Builder.newInstance().properties(properties).build();
 
-    EdcSftpException edcSftpException =
-        Assertions.assertThrows(
-            EdcSftpException.class, () -> SftpDataAddress.fromDataAddress(dataAddress));
-    Assertions.assertEquals(
-        "Port for SftpLocation localhost/path not a number", edcSftpException.getMessage());
-  }
+        var edcSftpException =
+                assertThrows(
+                        EdcSftpException.class, () -> SftpDataAddress.fromDataAddress(dataAddress));
+        assertEquals(
+                "Port for SftpLocation localhost/path not a number", edcSftpException.getMessage());
+    }
 
-  @Test
-  void fromDataAddress__missingParameter() {
-    final Map<String, String> properties =
-        Map.of(
-            "type", "sftp",
-            "locationPort", "22",
-            "locationPath", "path",
-            "userName", "name",
-            "userPassword", "password");
+    @Test
+    void fromDataAddress_missingParameter() {
+        var properties =
+                Map.of(
+                        "type", "sftp",
+                        "locationPort", "22",
+                        "locationPath", "path",
+                        "userName", "name",
+                        "userPassword", "password");
 
-    final DataAddress dataAddress =
-        DataAddress.Builder.newInstance().properties(properties).build();
+        var dataAddress = DataAddress.Builder.newInstance().properties(properties).build();
 
-    EdcSftpException edcSftpException =
-        Assertions.assertThrows(
-            EdcSftpException.class, () -> SftpDataAddress.fromDataAddress(dataAddress));
-    Assertions.assertEquals("host is marked non-null but is null", edcSftpException.getMessage());
-  }
+        assertThatThrownBy(() -> SftpDataAddress.fromDataAddress(dataAddress))
+                .isInstanceOf(EdcSftpException.class)
+                .hasMessageStartingWith("host");
+    }
 
-  @Test
-  void fromDataAddress__notSftp() {
-    final Map<String, String> properties =
-        Map.of(
-            "type", "somethingOtherThanSftp",
-            "locationHost", "localhost",
-            "locationPort", "22",
-            "locationPath", "path",
-            "userName", "name",
-            "userPassword", "password");
+    @Test
+    void fromDataAddress_notSftp() {
+        var properties =
+                Map.of(
+                        "type", "somethingOtherThanSftp",
+                        "locationHost", "localhost",
+                        "locationPort", "22",
+                        "locationPath", "path",
+                        "userName", "name",
+                        "userPassword", "password");
 
-    final DataAddress dataAddress =
-        DataAddress.Builder.newInstance().properties(properties).build();
+        var dataAddress = DataAddress.Builder.newInstance().properties(properties).build();
 
-    EdcSftpException edcSftpException =
-        Assertions.assertThrows(
-            EdcSftpException.class, () -> SftpDataAddress.fromDataAddress(dataAddress));
-    Assertions.assertEquals(
-        "Invalid DataAddress type: somethingOtherThanSftp. Expected sftp.",
-        edcSftpException.getMessage());
-  }
+        var edcSftpException = assertThrows(EdcSftpException.class, () -> SftpDataAddress.fromDataAddress(dataAddress));
+        assertEquals("Invalid DataAddress type: somethingOtherThanSftp. Expected sftp.",
+                edcSftpException.getMessage());
+    }
 }

--- a/edc-extensions/transferprocess-sftp-provisioner/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/NoOpSftpProvider.java
+++ b/edc-extensions/transferprocess-sftp-provisioner/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/NoOpSftpProvider.java
@@ -20,47 +20,47 @@ import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpUser;
 
 public class NoOpSftpProvider implements SftpProvider {
 
-  /**
-   * This provisioner does not create cloud resources. The assumption is that users and locations
-   * already exist cloud-side. Thus, this method has no functionality.
-   *
-   * @param user The user whose credentials should be deployed.
-   */
-  @Override
-  public void createUser(SftpUser user) {
-    // do nothing
-  }
+    /**
+     * This provisioner does not create cloud resources. The assumption is that users and locations
+     * already exist cloud-side. Thus, this method has no functionality.
+     *
+     * @param user The user whose credentials should be deployed.
+     */
+    @Override
+    public void createUser(SftpUser user) {
+        // do nothing
+    }
 
-  /**
-   * This provisioner does not create cloud resources. The assumption is that users and locations
-   * already exist cloud-side. Thus, this method has no functionality.
-   *
-   * @param user The user whose credentials should be deleted.
-   */
-  @Override
-  public void deleteUser(SftpUser user) {
-    // do nothing
-  }
+    /**
+     * This provisioner does not create cloud resources. The assumption is that users and locations
+     * already exist cloud-side. Thus, this method has no functionality.
+     *
+     * @param user The user whose credentials should be deleted.
+     */
+    @Override
+    public void deleteUser(SftpUser user) {
+        // do nothing
+    }
 
-  /**
-   * This provisioner does not create cloud resources. The assumption is that users and locations
-   * already exist cloud-side. Thus, this method has no functionality.
-   *
-   * @param location The location of the cloud resource that should be made available.
-   */
-  @Override
-  public void createLocation(SftpLocation location) {
-    // do nothing
-  }
+    /**
+     * This provisioner does not create cloud resources. The assumption is that users and locations
+     * already exist cloud-side. Thus, this method has no functionality.
+     *
+     * @param location The location of the cloud resource that should be made available.
+     */
+    @Override
+    public void createLocation(SftpLocation location) {
+        // do nothing
+    }
 
-  /**
-   * This provisioner does not create cloud resources. The assumption is that users and locations
-   * already exist cloud-side. Thus, this method has no functionality.
-   *
-   * @param location The location of the cloud resource that should be made unavailable.
-   */
-  @Override
-  public void deleteLocation(SftpLocation location) {
-    // do nothing
-  }
+    /**
+     * This provisioner does not create cloud resources. The assumption is that users and locations
+     * already exist cloud-side. Thus, this method has no functionality.
+     *
+     * @param location The location of the cloud resource that should be made unavailable.
+     */
+    @Override
+    public void deleteLocation(SftpLocation location) {
+        // do nothing
+    }
 }

--- a/edc-extensions/transferprocess-sftp-provisioner/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/SftpLocationFactoryImpl.java
+++ b/edc-extensions/transferprocess-sftp-provisioner/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/SftpLocationFactoryImpl.java
@@ -14,14 +14,12 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.provisioner;
 
-import lombok.RequiredArgsConstructor;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpLocation;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpLocationFactory;
 
-@RequiredArgsConstructor
 public class SftpLocationFactoryImpl implements SftpLocationFactory {
-  @Override
-  public SftpLocation createSftpLocation(String sftpHost, Integer sftpPort, String sftpPath) {
-    return SftpLocation.builder().host(sftpHost).port(sftpPort).path(sftpPath).build();
-  }
+    @Override
+    public SftpLocation createSftpLocation(String sftpHost, Integer sftpPort, String sftpPath) {
+        return SftpLocation.Builder.newInstance().host(sftpHost).port(sftpPort).path(sftpPath).build();
+    }
 }

--- a/edc-extensions/transferprocess-sftp-provisioner/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/SftpProviderResourceDefinition.java
+++ b/edc-extensions/transferprocess-sftp-provisioner/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/SftpProviderResourceDefinition.java
@@ -14,20 +14,29 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.provisioner;
 
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpDataAddress;
 
-@Getter
-@RequiredArgsConstructor
 public class SftpProviderResourceDefinition extends ResourceDefinition {
-  @NonNull private String providerType;
-  @NonNull private SftpDataAddress sftpDataAddress;
+    private final String providerType;
+    private final SftpDataAddress sftpDataAddress;
 
-  @Override
-  public <R extends ResourceDefinition, B extends Builder<R, B>> B toBuilder() {
-    return null;
-  }
+    public SftpProviderResourceDefinition(String providerType, SftpDataAddress sftpDataAddress) {
+        this.providerType = providerType;
+        this.sftpDataAddress = sftpDataAddress;
+    }
+
+
+    public String getProviderType() {
+        return providerType;
+    }
+
+    public SftpDataAddress getSftpDataAddress() {
+        return sftpDataAddress;
+    }
+
+    @Override
+    public <R extends ResourceDefinition, B extends Builder<R, B>> B toBuilder() {
+        return null;
+    }
 }

--- a/edc-extensions/transferprocess-sftp-provisioner/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/SftpProviderResourceDefinitionGenerator.java
+++ b/edc-extensions/transferprocess-sftp-provisioner/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/SftpProviderResourceDefinitionGenerator.java
@@ -14,9 +14,6 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.provisioner;
 
-import static org.eclipse.tractusx.edc.transferprocess.sftp.provisioner.NoOpSftpProvisioner.PROVIDER_TYPE;
-
-import lombok.RequiredArgsConstructor;
 import org.eclipse.edc.connector.transfer.spi.provision.ProviderResourceDefinitionGenerator;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
@@ -26,29 +23,26 @@ import org.eclipse.tractusx.edc.transferprocess.sftp.common.EdcSftpException;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpDataAddress;
 import org.jetbrains.annotations.Nullable;
 
-@RequiredArgsConstructor
-public class SftpProviderResourceDefinitionGenerator
-    implements ProviderResourceDefinitionGenerator {
 
-  @Override
-  public @Nullable ResourceDefinition generate(
-      DataRequest dataRequest, DataAddress assetAddress, Policy policy) {
-    SftpDataAddress sftpDataAddress;
-    try {
-      sftpDataAddress = SftpDataAddress.fromDataAddress(assetAddress);
-    } catch (EdcSftpException e) {
-      return null;
-    }
-    return new SftpProviderResourceDefinition(PROVIDER_TYPE, sftpDataAddress);
-  }
+public class SftpProviderResourceDefinitionGenerator implements ProviderResourceDefinitionGenerator {
 
-  @Override
-  public boolean canGenerate(DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
-    try {
-      SftpDataAddress.fromDataAddress(dataAddress);
-    } catch (EdcSftpException e) {
-      return false;
+    @Override
+    public @Nullable ResourceDefinition generate(DataRequest dataRequest, DataAddress assetAddress, Policy policy) {
+        try {
+            var sftpDataAddress = SftpDataAddress.fromDataAddress(assetAddress);
+            return new SftpProviderResourceDefinition(NoOpSftpProvisioner.PROVIDER_TYPE, sftpDataAddress);
+        } catch (EdcSftpException e) {
+            return null;
+        }
     }
-    return true;
-  }
+
+    @Override
+    public boolean canGenerate(DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
+        try {
+            SftpDataAddress.fromDataAddress(dataAddress);
+        } catch (EdcSftpException e) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/edc-extensions/transferprocess-sftp-provisioner/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/SftpProvisionedContentResource.java
+++ b/edc-extensions/transferprocess-sftp-provisioner/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/SftpProvisionedContentResource.java
@@ -11,22 +11,81 @@
  *       Mercedes-Benz Tech Innovation GmbH - Initial API and Implementation
  *
  */
+
 package org.eclipse.tractusx.edc.transferprocess.sftp.provisioner;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import org.eclipse.edc.connector.transfer.spi.types.ProvisionedContentResource;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpDataAddress;
 
-@Getter
-@RequiredArgsConstructor
-@Builder
+import java.util.Objects;
+
 public class SftpProvisionedContentResource extends ProvisionedContentResource {
-  @NonNull private String providerType;
-  @NonNull private Policy scopedPolicy;
-  @NonNull private SftpDataAddress sftpDataAddress;
-  @NonNull private String provisionedResourceId;
+    private String providerType;
+    private Policy scopedPolicy;
+    private SftpDataAddress sftpDataAddress;
+
+    private SftpProvisionedContentResource() {
+
+    }
+
+    public String getProviderType() {
+        return providerType;
+    }
+
+    public Policy getScopedPolicy() {
+        return scopedPolicy;
+    }
+
+    public String getProvisionedResourceId() {
+        return id;
+    }
+
+    public SftpDataAddress getSftpDataAddress() {
+        return sftpDataAddress;
+    }
+
+
+    public static class Builder extends ProvisionedContentResource.Builder<SftpProvisionedContentResource, Builder> {
+
+        protected Builder(SftpProvisionedContentResource resource) {
+            super(resource);
+        }
+
+        public static Builder newInstance() {
+            return new Builder(new SftpProvisionedContentResource());
+        }
+
+        public Builder providerType(String providerType) {
+            this.provisionedResource.providerType = providerType;
+            return this;
+        }
+
+        public Builder scopedPolicy(Policy scopedPolicy) {
+            provisionedResource.scopedPolicy = scopedPolicy;
+            return this;
+        }
+
+        public Builder sftpDataAddress(SftpDataAddress dataAddress) {
+            dataAddress(dataAddress);
+            provisionedResource.sftpDataAddress = dataAddress;
+            return this;
+        }
+
+        public Builder provisionedResourceId(String resourceId) {
+            id(resourceId);
+
+            return this;
+        }
+
+        public SftpProvisionedContentResource build() {
+//            super.build();
+            provisionedResource.dataAddress = dataAddressBuilder.build();
+            Objects.requireNonNull(provisionedResource.providerType, "providerType");
+            Objects.requireNonNull(provisionedResource.scopedPolicy, "scopedPolicy");
+            Objects.requireNonNull(provisionedResource.sftpDataAddress, "dataAddress");
+            return provisionedResource;
+        }
+
+    }
 }

--- a/edc-extensions/transferprocess-sftp-provisioner/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/SftpProvisionerConfiguration.java
+++ b/edc-extensions/transferprocess-sftp-provisioner/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/SftpProvisionerConfiguration.java
@@ -16,26 +16,22 @@
 package org.eclipse.tractusx.edc.transferprocess.sftp.provisioner;
 
 import java.net.URL;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NonNull;
 
-/** Configuration to create a resource definition and provisioner pair for sftp data transfer. */
-@Getter
-@Builder
+/**
+ * Configuration to create a resource definition and provisioner pair for sftp data transfer.
+ */
 public class SftpProvisionerConfiguration {
 
-  @NonNull private final String name;
+    private String name;
 
-  @NonNull @Builder.Default
-  private final ProvisionerType provisionerType = ProvisionerType.PROVIDER;
+    private final ProvisionerType provisionerType = ProvisionerType.PROVIDER;
 
-  @NonNull private final String dataAddressType;
-  @NonNull private final String policyScope;
-  @NonNull private final URL endpoint;
+    private String dataAddressType;
+    private String policyScope;
+    private URL endpoint;
 
-  public enum ProvisionerType {
-    CONSUMER,
-    PROVIDER
-  }
+    public enum ProvisionerType {
+        CONSUMER,
+        PROVIDER
+    }
 }

--- a/edc-extensions/transferprocess-sftp-provisioner/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/SftpProvisionerExtension.java
+++ b/edc-extensions/transferprocess-sftp-provisioner/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/SftpProvisionerExtension.java
@@ -26,31 +26,29 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 @Provides(NoOpSftpProvisioner.class)
 public class SftpProvisionerExtension implements ServiceExtension {
 
-  @Inject ProvisionManager provisionManager;
-  @Inject Monitor monitor;
-  @Inject PolicyEngine policyEngine;
+    private static final String POLICY_SCOPE_CONFIG_PATH = "provisioner.sftp.policy.scope";
+    private static final String DEFAULT_POLICY_SCOPE = "sftp.provisioner";
+    @Inject
+    ProvisionManager provisionManager;
+    @Inject
+    Monitor monitor;
+    @Inject
+    PolicyEngine policyEngine;
 
-  private static final String POLICY_SCOPE_CONFIG_PATH = "provisioner.sftp.policy.scope";
-  private static final String DEFAULT_POLICY_SCOPE = "sftp.provisioner";
+    @Override
+    public String name() {
+        return "Sftp Provisioner";
+    }
 
-  @Override
-  public String name() {
-    return "Sftp Provisioner";
-  }
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var policyScope = context.getConfig().getString(POLICY_SCOPE_CONFIG_PATH, DEFAULT_POLICY_SCOPE);
 
-  @Override
-  public void initialize(ServiceExtensionContext context) {
-    final String policyScope =
-        context.getConfig().getString(POLICY_SCOPE_CONFIG_PATH, DEFAULT_POLICY_SCOPE);
-
-    final NoOpSftpProvider sftpProvider = new NoOpSftpProvider();
-    final NoOpSftpProvisioner noOpSftpProvisioner =
-        new NoOpSftpProvisioner(policyScope, policyEngine, sftpProvider);
-    final SftpProviderResourceDefinitionGenerator generator =
-        new SftpProviderResourceDefinitionGenerator();
-    provisionManager.register(noOpSftpProvisioner);
-    context.registerService(ProviderResourceDefinitionGenerator.class, generator);
-
-    monitor.info("SftpProvisionerExtension: authentication/initialization complete.");
-  }
+        var sftpProvider = new NoOpSftpProvider();
+        var noOpSftpProvisioner = new NoOpSftpProvisioner(policyScope, policyEngine, sftpProvider);
+        var generator = new SftpProviderResourceDefinitionGenerator();
+        provisionManager.register(noOpSftpProvisioner);
+        context.registerService(ProviderResourceDefinitionGenerator.class, generator);
+        monitor.info("SftpProvisionerExtension: authentication/initialization complete.");
+    }
 }

--- a/edc-extensions/transferprocess-sftp-provisioner/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/SftpUserFactoryImpl.java
+++ b/edc-extensions/transferprocess-sftp-provisioner/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/SftpUserFactoryImpl.java
@@ -14,25 +14,20 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.provisioner;
 
-import java.security.KeyPair;
-import lombok.Builder;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpUser;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpUserFactory;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpUserKeyPairGenerator;
 
-@Builder
 public class SftpUserFactoryImpl implements SftpUserFactory {
 
-  @Override
-  public SftpUser createSftpUser(
-      String sftpUserName, String sftpUserPassword, byte[] sftpUserPrivateKey) {
-    KeyPair sftpUserKeyPair =
-        SftpUserKeyPairGenerator.getKeyPairFromPrivateKey(sftpUserPrivateKey, sftpUserName);
+    @Override
+    public SftpUser createSftpUser(String sftpUserName, String sftpUserPassword, byte[] sftpUserPrivateKey) {
+        var sftpUserKeyPair = SftpUserKeyPairGenerator.getKeyPairFromPrivateKey(sftpUserPrivateKey, sftpUserName);
 
-    return SftpUser.builder()
-        .name(sftpUserName)
-        .password(sftpUserPassword)
-        .keyPair(sftpUserKeyPair)
-        .build();
-  }
+        return SftpUser.Builder.newInstance()
+                .name(sftpUserName)
+                .password(sftpUserPassword)
+                .keyPair(sftpUserKeyPair)
+                .build();
+    }
 }

--- a/edc-extensions/transferprocess-sftp-provisioner/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/NoOpSftpProvisionerTest.java
+++ b/edc-extensions/transferprocess-sftp-provisioner/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/NoOpSftpProvisionerTest.java
@@ -20,187 +20,207 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.provisioner;
 
-import java.util.concurrent.CompletableFuture;
-import lombok.NoArgsConstructor;
-import lombok.SneakyThrows;
-import org.eclipse.edc.connector.transfer.spi.types.DeprovisionedResource;
-import org.eclipse.edc.connector.transfer.spi.types.ProvisionResponse;
 import org.eclipse.edc.connector.transfer.spi.types.ProvisionedContentResource;
 import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.result.AbstractResult;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpDataAddress;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpLocation;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpUser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class NoOpSftpProvisionerTest {
-  private final String policyScope = "scope";
-  private final PolicyEngine policyEngine = Mockito.mock(PolicyEngine.class);
-  private final NoOpSftpProvider sftpProvider = new NoOpSftpProvider();
+    private final String policyScope = "scope";
+    private final PolicyEngine policyEngine = mock(PolicyEngine.class);
+    private final NoOpSftpProvider sftpProvider = new NoOpSftpProvider();
 
-  private final NoOpSftpProvisioner provisioner =
-      new NoOpSftpProvisioner(policyScope, policyEngine, sftpProvider);
+    private final NoOpSftpProvisioner provisioner =
+            new NoOpSftpProvisioner(policyScope, policyEngine, sftpProvider);
 
-  @Test
-  void canProvision__true() {
-    String provisionType = "NoOp";
-    SftpUser sftpUser = SftpUser.builder().name("name").password("password").build();
-    SftpLocation sftpLocation = SftpLocation.builder().host("host").port(22).path("path").build();
-    SftpDataAddress dataAddress = new SftpDataAddress(sftpUser, sftpLocation);
-    SftpProviderResourceDefinition resourceDefinition =
-        new SftpProviderResourceDefinition(provisionType, dataAddress);
+    @Test
+    void canProvision_true() {
+        var provisionType = "NoOp";
+        var sftpUser = SftpUser.Builder.newInstance().name("name").password("password").build();
+        var sftpLocation = SftpLocation.Builder.newInstance().host("host").port(22).path("path").build();
+        var dataAddress = SftpDataAddress.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
+        var resourceDefinition =
+                new SftpProviderResourceDefinition(provisionType, dataAddress);
 
-    Assertions.assertTrue(provisioner.canProvision(resourceDefinition));
-  }
-
-  @Test
-  void canProvision__falseProvisionType() {
-    String provisionType = "AmazonS3";
-    SftpUser sftpUser = SftpUser.builder().name("name").password("password").build();
-    SftpLocation sftpLocation = SftpLocation.builder().host("host").port(22).path("path").build();
-    SftpDataAddress dataAddress = new SftpDataAddress(sftpUser, sftpLocation);
-    SftpProviderResourceDefinition resourceDefinition =
-        new SftpProviderResourceDefinition(provisionType, dataAddress);
-
-    Assertions.assertFalse(provisioner.canProvision(resourceDefinition));
-  }
-
-  @Test
-  void canProvision__falseDefinitionType() {
-    ResourceDefinition resourceDefinition = new WrongResourceDefinition();
-
-    Assertions.assertFalse(provisioner.canProvision(resourceDefinition));
-  }
-
-  @Test
-  void canDeprovision__true() {
-    String provisionType = "NoOp";
-    SftpUser sftpUser = SftpUser.builder().name("name").password("password").build();
-    SftpLocation sftpLocation = SftpLocation.builder().host("host").port(22).path("path").build();
-    Policy scopedPolicy = Mockito.mock(Policy.class);
-    SftpDataAddress dataAddress = new SftpDataAddress(sftpUser, sftpLocation);
-    String provisionedResourceID = "resource";
-    SftpProvisionedContentResource provisionedContentResource =
-        new SftpProvisionedContentResource(
-            provisionType, scopedPolicy, dataAddress, provisionedResourceID);
-
-    Assertions.assertTrue(provisioner.canDeprovision(provisionedContentResource));
-  }
-
-  @Test
-  void canDeprovision__falseProvisionType() {
-    String provisionType = "AmazonS3";
-    SftpUser sftpUser = SftpUser.builder().name("name").password("password").build();
-    SftpLocation sftpLocation = SftpLocation.builder().host("host").port(22).path("path").build();
-    Policy scopedPolicy = Mockito.mock(Policy.class);
-    SftpDataAddress dataAddress = new SftpDataAddress(sftpUser, sftpLocation);
-    String provisionedResourceID = "resource";
-    SftpProvisionedContentResource provisionedContentResource =
-        new SftpProvisionedContentResource(
-            provisionType, scopedPolicy, dataAddress, provisionedResourceID);
-
-    Assertions.assertFalse(provisioner.canDeprovision(provisionedContentResource));
-  }
-
-  @Test
-  void canDeprovision__falseDefinitionType() {
-    ProvisionedContentResource provisionedContentResource = new WrongProvisionedContentResource();
-
-    Assertions.assertFalse(provisioner.canDeprovision(provisionedContentResource));
-  }
-
-  @Test
-  @SneakyThrows
-  void provision__successful() {
-    String provisionType = "NoOp";
-    SftpUser sftpUser = SftpUser.builder().name("name").password("password").build();
-    SftpLocation sftpLocation = SftpLocation.builder().host("host").port(22).path("path").build();
-    SftpDataAddress dataAddress = new SftpDataAddress(sftpUser, sftpLocation);
-    SftpProviderResourceDefinition resourceDefinition =
-        new SftpProviderResourceDefinition(provisionType, dataAddress);
-    Policy policy = Mockito.mock(Policy.class);
-
-    Mockito.when(policyEngine.filter(policy, policyScope)).thenReturn(policy);
-
-    CompletableFuture<StatusResult<ProvisionResponse>> future =
-        provisioner.provision(resourceDefinition, policy);
-    StatusResult<ProvisionResponse> result = future.get();
-
-    Assertions.assertTrue(result.succeeded());
-  }
-
-  @Test
-  @SneakyThrows
-  void provision__failedWrongProvisionType() {
-    String provisionType = "AmazonS3";
-    SftpUser sftpUser = SftpUser.builder().name("name").password("password").build();
-    SftpLocation sftpLocation = SftpLocation.builder().host("host").port(22).path("path").build();
-    SftpDataAddress dataAddress = new SftpDataAddress(sftpUser, sftpLocation);
-    SftpProviderResourceDefinition resourceDefinition =
-        new SftpProviderResourceDefinition(provisionType, dataAddress);
-    Policy policy = Mockito.mock(Policy.class);
-
-    Mockito.when(policyEngine.filter(policy, policyScope)).thenReturn(policy);
-
-    CompletableFuture<StatusResult<ProvisionResponse>> future =
-        provisioner.provision(resourceDefinition, policy);
-    StatusResult<ProvisionResponse> result = future.get();
-
-    Assertions.assertTrue(result.failed());
-  }
-
-  @Test
-  @SneakyThrows
-  void deprovision__successful() {
-    String provisionType = "NoOp";
-    SftpUser sftpUser = SftpUser.builder().name("name").password("password").build();
-    SftpLocation sftpLocation = SftpLocation.builder().host("host").port(22).path("path").build();
-    SftpDataAddress dataAddress = new SftpDataAddress(sftpUser, sftpLocation);
-    Policy policy = Mockito.mock(Policy.class);
-    String provisionedResourceID = "resource";
-    SftpProvisionedContentResource provisionedContentResource =
-        new SftpProvisionedContentResource(
-            provisionType, policy, dataAddress, provisionedResourceID);
-
-    CompletableFuture<StatusResult<DeprovisionedResource>> future =
-        provisioner.deprovision(provisionedContentResource, policy);
-    StatusResult<DeprovisionedResource> result = future.get();
-
-    Assertions.assertTrue(result.succeeded());
-  }
-
-  @Test
-  @SneakyThrows
-  void deprovision__failedWrongProvisionType() {
-    String provisionType = "AmazonS3";
-    SftpUser sftpUser = SftpUser.builder().name("name").password("password").build();
-    SftpLocation sftpLocation = SftpLocation.builder().host("host").port(22).path("path").build();
-    SftpDataAddress dataAddress = new SftpDataAddress(sftpUser, sftpLocation);
-    Policy policy = Mockito.mock(Policy.class);
-    String provisionedResourceID = "resource";
-    SftpProvisionedContentResource provisionedContentResource =
-        new SftpProvisionedContentResource(
-            provisionType, policy, dataAddress, provisionedResourceID);
-
-    CompletableFuture<StatusResult<DeprovisionedResource>> future =
-        provisioner.deprovision(provisionedContentResource, policy);
-    StatusResult<DeprovisionedResource> result = future.get();
-
-    Assertions.assertTrue(result.failed());
-  }
-
-  @NoArgsConstructor
-  private static class WrongResourceDefinition extends ResourceDefinition {
-    @Override
-    public <R extends ResourceDefinition, B extends Builder<R, B>> B toBuilder() {
-      return null;
+        Assertions.assertTrue(provisioner.canProvision(resourceDefinition));
     }
-  }
 
-  @NoArgsConstructor
-  private static class WrongProvisionedContentResource extends ProvisionedContentResource {}
+    @Test
+    void canProvision_falseProvisionType() {
+        var provisionType = "AmazonS3";
+        SftpUser sftpUser = SftpUser.Builder.newInstance().name("name").password("password").build();
+        SftpLocation sftpLocation = SftpLocation.Builder.newInstance().host("host").port(22).path("path").build();
+        var dataAddress = SftpDataAddress.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
+        var resourceDefinition =
+                new SftpProviderResourceDefinition(provisionType, dataAddress);
+
+        Assertions.assertFalse(provisioner.canProvision(resourceDefinition));
+    }
+
+    @Test
+    void canProvision_falseDefinitionType() {
+        ResourceDefinition resourceDefinition = new WrongResourceDefinition();
+
+        Assertions.assertFalse(provisioner.canProvision(resourceDefinition));
+    }
+
+    @Test
+    void canDeprovision_true() {
+        var provisionType = "NoOp";
+        var sftpUser = SftpUser.Builder.newInstance().name("name").password("password").build();
+        var sftpLocation = SftpLocation.Builder.newInstance().host("host").port(22).path("path").build();
+        var scopedPolicy = mock(Policy.class);
+        var dataAddress = SftpDataAddress.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
+        var provisionedResourceID = "resource";
+        var provisionedContentResource =
+                SftpProvisionedContentResource.Builder.newInstance()
+                        .providerType(provisionType)
+                        .scopedPolicy(scopedPolicy)
+                        .transferProcessId(UUID.randomUUID().toString())
+                        .resourceDefinitionId(UUID.randomUUID().toString())
+                        .resourceName("test-resource")
+                        .provisionedResourceId("test-resdef-id")
+                        .sftpDataAddress(dataAddress)
+                        .provisionedResourceId(provisionedResourceID)
+                        .build();
+
+        assertThat(provisioner.canDeprovision(provisionedContentResource)).isTrue();
+    }
+
+    @Test
+    void canDeprovision_falseProvisionType() {
+        var provisionType = "AmazonS3";
+        SftpUser sftpUser = SftpUser.Builder.newInstance().name("name").password("password").build();
+        SftpLocation sftpLocation = SftpLocation.Builder.newInstance().host("host").port(22).path("path").build();
+        var scopedPolicy = mock(Policy.class);
+        var dataAddress = SftpDataAddress.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
+        var provisionedResourceID = "resource";
+        var provisionedContentResource =
+                SftpProvisionedContentResource.Builder.newInstance()
+                        .providerType(provisionType)
+                        .scopedPolicy(scopedPolicy)
+                        .transferProcessId(UUID.randomUUID().toString())
+                        .resourceDefinitionId(UUID.randomUUID().toString())
+                        .resourceName("test-resource")
+                        .provisionedResourceId("test-resdef-id")
+                        .sftpDataAddress(dataAddress).provisionedResourceId(provisionedResourceID)
+                        .build();
+
+        Assertions.assertFalse(provisioner.canDeprovision(provisionedContentResource));
+    }
+
+    @Test
+    void canDeprovision_falseDefinitionType() {
+        ProvisionedContentResource provisionedContentResource = new WrongProvisionedContentResource();
+
+        Assertions.assertFalse(provisioner.canDeprovision(provisionedContentResource));
+    }
+
+    @Test
+    void provision_successful() throws ExecutionException, InterruptedException {
+        var provisionType = "NoOp";
+        SftpUser sftpUser = SftpUser.Builder.newInstance().name("name").password("password").build();
+        SftpLocation sftpLocation = SftpLocation.Builder.newInstance().host("host").port(22).path("path").build();
+        var dataAddress = SftpDataAddress.Builder.newInstance().type("sftp").sftpUser(sftpUser).sftpLocation(sftpLocation).build();
+        var resourceDefinition = new SftpProviderResourceDefinition(provisionType, dataAddress);
+        var policy = mock(Policy.class);
+
+        when(policyEngine.filter(policy, policyScope)).thenReturn(policy);
+
+        var future = provisioner.provision(resourceDefinition, policy);
+        assertThat(future).succeedsWithin(ofSeconds(5));
+        assertThat(future).isCompletedWithValueMatching(AbstractResult::succeeded);
+    }
+
+    @Test
+    void provision_failedWrongProvisionType() {
+        var provisionType = "AmazonS3";
+        SftpUser sftpUser = SftpUser.Builder.newInstance().name("name").password("password").build();
+        SftpLocation sftpLocation = SftpLocation.Builder.newInstance().host("host").port(22).path("path").build();
+        var dataAddress = SftpDataAddress.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
+        var resourceDefinition =
+                new SftpProviderResourceDefinition(provisionType, dataAddress);
+        var policy = mock(Policy.class);
+
+        when(policyEngine.filter(policy, policyScope)).thenReturn(policy);
+
+        var future =
+                provisioner.provision(resourceDefinition, policy);
+
+        assertThat(future).succeedsWithin(ofSeconds(5));
+        assertThat(future).isCompletedWithValueMatching(AbstractResult::failed);
+    }
+
+    @Test
+    void deprovision_successful() {
+        var provisionType = "NoOp";
+        var sftpUser = SftpUser.Builder.newInstance().name("name").password("password").build();
+        var sftpLocation = SftpLocation.Builder.newInstance().host("host").port(22).path("path").build();
+        var dataAddress = SftpDataAddress.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
+        var policy = mock(Policy.class);
+        var provisionedResourceID = "resource";
+        var provisionedContentResource = SftpProvisionedContentResource.Builder.newInstance()
+                .providerType(provisionType)
+                .scopedPolicy(policy)
+                .sftpDataAddress(dataAddress)
+                .provisionedResourceId(provisionedResourceID)
+                .transferProcessId(UUID.randomUUID().toString())
+                .resourceDefinitionId(UUID.randomUUID().toString())
+                .resourceName("test-resource")
+                .provisionedResourceId("test-resdef-id")
+                .build();
+        var future = provisioner.deprovision(provisionedContentResource, policy);
+
+        assertThat(future).succeedsWithin(ofSeconds(5));
+        assertThat(future).isCompletedWithValueMatching(AbstractResult::succeeded);
+
+    }
+
+    @Test
+    void deprovision_failedWrongProvisionType() {
+        var provisionType = "AmazonS3";
+        var sftpUser = SftpUser.Builder.newInstance().name("name").password("password").build();
+        var sftpLocation = SftpLocation.Builder.newInstance().host("host").port(22).path("path").build();
+        var dataAddress = SftpDataAddress.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
+        var policy = mock(Policy.class);
+        var provisionedResourceID = "resource";
+        var provisionedContentResource =
+                SftpProvisionedContentResource.Builder.newInstance()
+                        .providerType(provisionType)
+                        .scopedPolicy(policy)
+                        .sftpDataAddress(dataAddress).provisionedResourceId(provisionedResourceID)
+                        .transferProcessId(UUID.randomUUID().toString())
+                        .resourceDefinitionId(UUID.randomUUID().toString())
+                        .resourceName("test-resource")
+                        .provisionedResourceId("test-resdef-id")
+                        .build();
+
+        var future =
+                provisioner.deprovision(provisionedContentResource, policy);
+        assertThat(future).isCompletedWithValueMatching(AbstractResult::failed);
+    }
+
+    private static class WrongResourceDefinition extends ResourceDefinition {
+        @Override
+        public <R extends ResourceDefinition, B extends Builder<R, B>> B toBuilder() {
+            return null;
+        }
+    }
+
+    private static class WrongProvisionedContentResource extends ProvisionedContentResource {
+    }
 }

--- a/edc-extensions/transferprocess-sftp-provisioner/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/SftpUserFactoryImplTest.java
+++ b/edc-extensions/transferprocess-sftp-provisioner/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/provisioner/SftpUserFactoryImplTest.java
@@ -20,32 +20,32 @@
 
 package org.eclipse.tractusx.edc.transferprocess.sftp.provisioner;
 
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import lombok.SneakyThrows;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpUser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+
 class SftpUserFactoryImplTest {
-  private final SftpUserFactoryImpl sftpUserFactoryImpl = new SftpUserFactoryImpl();
+    private final SftpUserFactoryImpl sftpUserFactoryImpl = new SftpUserFactoryImpl();
 
-  @Test
-  @SneakyThrows
-  void generateSftpLocation() {
-    final String name = "name";
-    final String password = "password";
+    @Test
+    void generateSftpLocation() throws NoSuchAlgorithmException {
+        final String name = "name";
+        final String password = "password";
 
-    final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
-    keyPairGenerator.initialize(2048);
-    final KeyPair keyPair = keyPairGenerator.generateKeyPair();
-    final byte[] privateKeyBytes = keyPair.getPrivate().getEncoded();
+        final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        final KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        final byte[] privateKeyBytes = keyPair.getPrivate().getEncoded();
 
-    final SftpUser sftpUser = sftpUserFactoryImpl.createSftpUser(name, password, privateKeyBytes);
+        final SftpUser sftpUser = sftpUserFactoryImpl.createSftpUser(name, password, privateKeyBytes);
 
-    Assertions.assertEquals(name, sftpUser.getName());
-    Assertions.assertEquals(password, sftpUser.getPassword());
+        Assertions.assertEquals(name, sftpUser.getName());
+        Assertions.assertEquals(password, sftpUser.getPassword());
 
-    Assertions.assertArrayEquals(privateKeyBytes, sftpUser.getKeyPair().getPrivate().getEncoded());
-  }
+        Assertions.assertArrayEquals(privateKeyBytes, sftpUser.getKeyPair().getPrivate().getEncoded());
+    }
 }


### PR DESCRIPTION
## WHAT

Removes Lombok from all the `transferprocess-sftp-*` modules.

## WHY

As per decision-record 2023-03-23, Lombok is to be **removed** from the code base.

## FURTHER NOTES

While perusing the code base I found a few quite substantial problems, most notably:
- Many classes are implemented incorrectly, i.e. violated their super-class's contract, for example by not setting all required properties. This was silently introduced by Lombok not being aware of the EDC Builder hierarchy, thus creating a parallel builder, and it was quietly worked around.
- A `KeyPair` is stored directly on the `SftpDataAddress`, which is a **significant** security issue! Credentials should **never** be stored on serializable classes, but be stored **only** in a vault.
- Serializability of most classes is not tested and is assumed broken. 



**Please be aware that at the time of writing the production use of these modules is **not** recommended due the aforementioned problems! I STRONGLY recommend to either delete or completely refactor/rewrite these modules!**


Closes #155 
Closes #156
Closes #157
