### PR TITLE
docs: add decision record about activating checkstyle

### DIFF
--- a/docs/development/decision-records/2023-05-23_activate_checkstyle/README.md
+++ b/docs/development/decision-records/2023-05-23_activate_checkstyle/README.md
@@ -1,0 +1,17 @@
+# Activate Checkstyle to enforce code style
+
+## Decision
+
+From now on, Tractus-X EDC will use activate Checkstyle, i.e. change its reporting level from `WARNING` to `ERROR`.
+
+## Rationale
+
+We already have a checkstyle task in our Gradle setup, and our [PR Etiquette document](../../../../pr_etiquette.md) references
+the styleguide and mandates its use.
+
+Our CI pipeline already uses checkstyle, but only outputs warning at the moment.
+
+## Approach
+
+- in `resources/tx-checkstyle-config.xml`, Line 22, change `<property name="severity" value="warning"/>` to `<property name="severity" value="error"/>`.
+- fix all checkstyle errors


### PR DESCRIPTION
## WHAT

Adds a decision-record about activating checkstyle

## WHY

Our styleguide mandates a certain code style, which we should enforce through automatic checks.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
