### PR TITLE
docs: adds decision record about Java 17

### DIFF
--- a/docs/development/decision-records/2023-05-23_java_17_baseline/README.md
+++ b/docs/development/decision-records/2023-05-23_java_17_baseline/README.md
@@ -1,0 +1,15 @@
+# Java 17 baseline
+
+## Decision
+
+We will use Java 17 as baseline version.
+
+## Rationale
+
+Java 11 active support [will end in September 2023](https://endoflife.date/java), and, following Java "new" release cycle, we should update the baseline
+version to the current LTS from time to time.
+[EDC](https://github.com/eclipse-edc/Connector/blob/main/docs/developer/decision-records/2023-05-23-java-17-baseline/README.md) upstream is switching to Java 17.
+
+## Approach
+
+Remove the custom `javaVersion` and let the `edc-build` plugin set that when upgrading to the newest version of EDC.


### PR DESCRIPTION
## WHAT

Adds a decision-record about using Java 17 as baseline

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
