### PR TITLE
feat: remove Lombok from HashiCorp Vault impl

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,6 @@ plugins {
     `java-library`
     `maven-publish`
     `jacoco-report-aggregation`
-    id("io.freefair.lombok") version "8.0.1"
     id("com.diffplug.spotless") version "6.18.0"
     id("com.github.johnrengelman.shadow") version "8.1.1"
     id("com.bmuschko.docker-remote-api") version "9.3.1"
@@ -57,13 +56,11 @@ project.subprojects.forEach {
 
 allprojects {
     apply(plugin = "org.eclipse.edc.edc-build")
-    apply(plugin = "io.freefair.lombok")
 
     repositories {
         mavenCentral()
     }
     dependencies {
-        implementation("org.projectlombok:lombok:1.18.26")
         implementation("org.slf4j:slf4j-api:2.0.7")
         // this is used to counter version conflicts between the JUnit version pulled in by the plugin,
         // and the one expected by IntelliJ
@@ -104,7 +101,8 @@ allprojects {
         swagger {
             title.set((project.findProperty("apiTitle") ?: "Tractus-X REST API") as String)
             description =
-                (project.findProperty("apiDescription") ?: "Tractus-X REST APIs - merged by OpenApiMerger") as String
+                    (project.findProperty("apiDescription")
+                            ?: "Tractus-X REST APIs - merged by OpenApiMerger") as String
             outputFilename.set(project.name)
             outputDirectory.set(file("${rootProject.projectDir.path}/resources/openapi/yaml"))
             resourcePackages = setOf("org.eclipse.tractusx.edc")
@@ -149,7 +147,7 @@ allprojects {
 subprojects {
     afterEvaluate {
         if (project.plugins.hasPlugin("com.github.johnrengelman.shadow") &&
-            file("${project.projectDir}/src/main/docker/Dockerfile").exists()
+                file("${project.projectDir}/src/main/docker/Dockerfile").exists()
         ) {
 
             //actually apply the plugin to the (sub-)project

--- a/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
@@ -25,7 +25,7 @@ ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-in
 
 HEALTHCHECK NONE
 
-RUN apk update && apk add curl=8.1.0-r2 --no-cache
+RUN apk update && apk add curl=8.1.1-r0 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:17.0.6_10-jre-alpine

--- a/edc-controlplane/edc-controlplane-postgresql-azure-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql-azure-vault/src/main/docker/Dockerfile
@@ -24,7 +24,7 @@ ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-in
 
 HEALTHCHECK NONE
 
-RUN apk update && apk add curl=8.1.0-r2 --no-cache
+RUN apk update && apk add curl=8.1.1-r0 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:17.0.6_10-jre-alpine

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
@@ -24,7 +24,7 @@ ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-in
 
 HEALTHCHECK NONE
 
-RUN apk update && apk add curl=8.1.0-r2 --no-cache
+RUN apk update && apk add curl=8.1.1-r0 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:17.0.6_10-jre-alpine

--- a/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
@@ -24,7 +24,7 @@ ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-in
 
 HEALTHCHECK NONE
 
-RUN apk update && apk add curl=8.1.0-r2 --no-cache
+RUN apk update && apk add curl=8.1.1-r0 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:17.0.6_10-jre-alpine

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
@@ -24,7 +24,7 @@ ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-in
 
 HEALTHCHECK NONE
 
-RUN apk update && apk add curl=8.1.0-r2 --no-cache
+RUN apk update && apk add curl=8.1.1-r0 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:17.0.6_10-jre-alpine

--- a/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/AbstractHashicorpVaultExtension.java
+++ b/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/AbstractHashicorpVaultExtension.java
@@ -86,7 +86,7 @@ public class AbstractHashicorpVaultExtension {
         final boolean isHealthStandbyOk =
                 context.getSetting(VAULT_HEALTH_CHECK_STANDBY_OK, VAULT_HEALTH_CHECK_STANDBY_OK_DEFAULT);
 
-        return HashicorpVaultClientConfig.builder()
+        return HashicorpVaultClientConfig.Builder.newInstance()
                 .vaultUrl(vaultUrl)
                 .vaultToken(vaultToken)
                 .vaultApiSecretPath(apiSecretPath)

--- a/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpCertificateResolver.java
+++ b/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpCertificateResolver.java
@@ -20,8 +20,6 @@
 
 package org.eclipse.tractusx.edc.hashicorpvault;
 
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.security.CertificateResolver;
@@ -36,15 +34,17 @@ import java.security.cert.X509Certificate;
 /**
  * Resolves an X.509 certificate in Hashicorp vault.
  */
-@RequiredArgsConstructor
 public class HashicorpCertificateResolver implements CertificateResolver {
-    @NonNull
     private final Vault vault;
-    @NonNull
     private final Monitor monitor;
 
+    public HashicorpCertificateResolver(Vault vault, Monitor monitor) {
+        this.vault = vault;
+        this.monitor = monitor;
+    }
+
     @Override
-    public X509Certificate resolveCertificate(@NonNull String id) {
+    public X509Certificate resolveCertificate(String id) {
         String certificateRepresentation = vault.resolveSecret(id);
         if (certificateRepresentation == null) {
             return null;

--- a/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVault.java
+++ b/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVault.java
@@ -20,9 +20,6 @@
 
 package org.eclipse.tractusx.edc.hashicorpvault;
 
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.security.Vault;
 import org.jetbrains.annotations.NotNull;
@@ -31,16 +28,16 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Implements a vault backed by Hashicorp Vault.
  */
-@RequiredArgsConstructor
 class HashicorpVault implements Vault {
 
-    @NonNull
     private final HashicorpVaultClient hashicorpVaultClient;
-    @NonNull
-    private final Monitor monitor;
+
+    HashicorpVault(HashicorpVaultClient hashicorpVaultClient) {
+        this.hashicorpVaultClient = hashicorpVaultClient;
+    }
 
     @Override
-    public @Nullable String resolveSecret(@NonNull String key) {
+    public @Nullable String resolveSecret(String key) {
         Result<String> result = hashicorpVaultClient.getSecretValue(key);
 
         return result.succeeded() ? result.getContent() : null;
@@ -48,7 +45,7 @@ class HashicorpVault implements Vault {
 
     @Override
     @NotNull
-    public Result<Void> storeSecret(@NotNull @NonNull String key, @NotNull @NonNull String value) {
+    public Result<Void> storeSecret(@NotNull String key, @NotNull String value) {
         Result<HashicorpVaultCreateEntryResponsePayload> result =
                 hashicorpVaultClient.setSecret(key, value);
 
@@ -56,7 +53,7 @@ class HashicorpVault implements Vault {
     }
 
     @Override
-    public Result<Void> deleteSecret(@NotNull @NonNull String key) {
+    public Result<Void> deleteSecret(@NotNull String key) {
         return hashicorpVaultClient.destroySecret(key);
     }
 }

--- a/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultClientConfig.java
+++ b/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultClientConfig.java
@@ -20,27 +20,84 @@
 
 package org.eclipse.tractusx.edc.hashicorpvault;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 
 import java.time.Duration;
 
-@Builder
-@Getter
-@RequiredArgsConstructor
 class HashicorpVaultClientConfig {
-    @NonNull
-    private final String vaultUrl;
-    @NonNull
-    private final String vaultToken;
-    @NonNull
-    private final String vaultApiSecretPath;
-    @NonNull
-    private final String vaultApiHealthPath;
-    @NonNull
-    private final Duration timeout;
+    private String vaultUrl;
+    private String vaultToken;
+    private String vaultApiSecretPath;
+    private String vaultApiHealthPath;
+    private Duration timeout;
+    private boolean isVaultApiHealthStandbyOk;
 
-    private final boolean isVaultApiHealthStandbyOk;
+    public String getVaultUrl() {
+        return vaultUrl;
+    }
+
+    public String getVaultToken() {
+        return vaultToken;
+    }
+
+    public String getVaultApiSecretPath() {
+        return vaultApiSecretPath;
+    }
+
+    public String getVaultApiHealthPath() {
+        return vaultApiHealthPath;
+    }
+
+    public Duration getTimeout() {
+        return timeout;
+    }
+
+    public boolean isVaultApiHealthStandbyOk() {
+        return isVaultApiHealthStandbyOk;
+    }
+
+    public static final class Builder {
+        private final HashicorpVaultClientConfig config;
+
+        private Builder() {
+            config = new HashicorpVaultClientConfig();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder vaultUrl(String vaultUrl) {
+            this.config.vaultUrl = vaultUrl;
+            return this;
+        }
+
+        public Builder vaultToken(String vaultToken) {
+            this.config.vaultToken = vaultToken;
+            return this;
+        }
+
+        public Builder vaultApiSecretPath(String vaultApiSecretPath) {
+            this.config.vaultApiSecretPath = vaultApiSecretPath;
+            return this;
+        }
+
+        public Builder vaultApiHealthPath(String vaultApiHealthPath) {
+            this.config.vaultApiHealthPath = vaultApiHealthPath;
+            return this;
+        }
+
+        public Builder timeout(Duration timeout) {
+            this.config.timeout = timeout;
+            return this;
+        }
+
+        public Builder isVaultApiHealthStandbyOk(boolean isVaultApiHealthStandbyOk) {
+            this.config.isVaultApiHealthStandbyOk = isVaultApiHealthStandbyOk;
+            return this;
+        }
+
+        public HashicorpVaultClientConfig build() {
+            return this.config;
+        }
+    }
 }

--- a/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultCreateEntryRequestPayload.java
+++ b/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultCreateEntryRequestPayload.java
@@ -22,17 +22,9 @@ package org.eclipse.tractusx.edc.hashicorpvault;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.util.Map;
 
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 class HashicorpVaultCreateEntryRequestPayload {
 
@@ -42,13 +34,52 @@ class HashicorpVaultCreateEntryRequestPayload {
     @JsonProperty("data")
     private Map<String, String> data;
 
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Data
+    private HashicorpVaultCreateEntryRequestPayload() {
+    }
+
+    public Options getOptions() {
+        return options;
+    }
+
+    public Map<String, String> getData() {
+        return data;
+    }
+
+
     @JsonIgnoreProperties(ignoreUnknown = true)
     static class Options {
         @JsonProperty("cas")
         private Integer cas;
+
+        public Integer getCas() {
+            return cas;
+        }
+    }
+
+    public static final class Builder {
+
+        private final HashicorpVaultCreateEntryRequestPayload payload;
+
+        private Builder() {
+            payload = new HashicorpVaultCreateEntryRequestPayload();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder options(Options options) {
+            this.payload.options = options;
+            return this;
+        }
+
+        public Builder data(Map<String, String> data) {
+            this.payload.data = data;
+            return this;
+        }
+
+        public HashicorpVaultCreateEntryRequestPayload build() {
+            return payload;
+        }
     }
 }

--- a/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultCreateEntryResponsePayload.java
+++ b/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultCreateEntryResponsePayload.java
@@ -22,18 +22,14 @@ package org.eclipse.tractusx.edc.hashicorpvault;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 class HashicorpVaultCreateEntryResponsePayload {
 
     @JsonProperty("data")
     private HashicorpVaultEntryMetadata data;
+
+    public HashicorpVaultEntryMetadata getData() {
+        return data;
+    }
 }

--- a/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultEntryMetadata.java
+++ b/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultEntryMetadata.java
@@ -22,17 +22,9 @@ package org.eclipse.tractusx.edc.hashicorpvault;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.util.Map;
 
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 class HashicorpVaultEntryMetadata {
 
@@ -44,4 +36,16 @@ class HashicorpVaultEntryMetadata {
 
     @JsonProperty("version")
     private Integer version;
+
+    public Map<String, String> getCustomMetadata() {
+        return customMetadata;
+    }
+
+    public Boolean getDestroyed() {
+        return destroyed;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
 }

--- a/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultGetEntryResponsePayload.java
+++ b/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultGetEntryResponsePayload.java
@@ -22,27 +22,19 @@ package org.eclipse.tractusx.edc.hashicorpvault;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.util.Map;
 
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 class HashicorpVaultGetEntryResponsePayload {
 
     @JsonProperty("data")
     private GetVaultEntryData data;
 
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Data
+    public GetVaultEntryData getData() {
+        return data;
+    }
+
     @JsonIgnoreProperties(ignoreUnknown = true)
     static class GetVaultEntryData {
 
@@ -51,5 +43,13 @@ class HashicorpVaultGetEntryResponsePayload {
 
         @JsonProperty("metadata")
         private HashicorpVaultEntryMetadata metadata;
+
+        public Map<String, String> getData() {
+            return data;
+        }
+
+        public HashicorpVaultEntryMetadata getMetadata() {
+            return metadata;
+        }
     }
 }

--- a/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultHealthCheck.java
+++ b/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultHealthCheck.java
@@ -14,18 +14,16 @@
 
 package org.eclipse.tractusx.edc.hashicorpvault;
 
-import lombok.RequiredArgsConstructor;
+import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.health.HealthCheckResult;
 import org.eclipse.edc.spi.system.health.LivenessProvider;
 import org.eclipse.edc.spi.system.health.ReadinessProvider;
 import org.eclipse.edc.spi.system.health.StartupStatusProvider;
 
-import java.io.IOException;
+import static java.lang.String.format;
 
-@RequiredArgsConstructor
-public class HashicorpVaultHealthCheck
-        implements ReadinessProvider, LivenessProvider, StartupStatusProvider {
+public class HashicorpVaultHealthCheck implements ReadinessProvider, LivenessProvider, StartupStatusProvider {
 
     private static final String HEALTH_CHECK_ERROR_TEMPLATE =
             "HashiCorp Vault HealthCheck unsuccessful. %s %s";
@@ -33,63 +31,67 @@ public class HashicorpVaultHealthCheck
     private final HashicorpVaultClient client;
     private final Monitor monitor;
 
+    public HashicorpVaultHealthCheck(HashicorpVaultClient client, Monitor monitor) {
+        this.client = client;
+        this.monitor = monitor;
+    }
+
     @Override
     public HealthCheckResult get() {
 
+        HashicorpVaultHealthResponse response;
         try {
-            final HashicorpVaultHealthResponse response = client.getHealth();
-
-            switch (response.getCodeAsEnum()) {
-                case INITIALIZED_UNSEALED_AND_ACTIVE:
-                    monitor.debug("HashiCorp Vault HealthCheck successful. " + response.getPayload());
-                    return HealthCheckResult.success();
-                case UNSEALED_AND_STANDBY:
-                    final String standbyMsg =
-                            String.format(
-                                    HEALTH_CHECK_ERROR_TEMPLATE, "Vault is in standby", response.getPayload());
-                    monitor.warning(standbyMsg);
-                    return HealthCheckResult.failed(standbyMsg);
-                case DISASTER_RECOVERY_MODE_REPLICATION_SECONDARY_AND_ACTIVE:
-                    final String recoveryModeMsg =
-                            String.format(
-                                    HEALTH_CHECK_ERROR_TEMPLATE, "Vault is in recovery mode", response.getPayload());
-                    monitor.warning(recoveryModeMsg);
-                    return HealthCheckResult.failed(recoveryModeMsg);
-                case PERFORMANCE_STANDBY:
-                    final String performanceStandbyMsg =
-                            String.format(
-                                    HEALTH_CHECK_ERROR_TEMPLATE,
-                                    "Vault is in performance standby",
-                                    response.getPayload());
-                    monitor.warning(performanceStandbyMsg);
-                    return HealthCheckResult.failed(performanceStandbyMsg);
-                case NOT_INITIALIZED:
-                    final String notInitializedMsg =
-                            String.format(
-                                    HEALTH_CHECK_ERROR_TEMPLATE, "Vault is not initialized", response.getPayload());
-                    monitor.warning(notInitializedMsg);
-                    return HealthCheckResult.failed(notInitializedMsg);
-                case SEALED:
-                    final String sealedMsg =
-                            String.format(HEALTH_CHECK_ERROR_TEMPLATE, "Vault is sealed", response.getPayload());
-                    monitor.warning(sealedMsg);
-                    return HealthCheckResult.failed(sealedMsg);
-                case UNSPECIFIED:
-                default:
-                    final String unspecifiedMsg =
-                            String.format(
-                                    HEALTH_CHECK_ERROR_TEMPLATE,
-                                    "Unspecified response from vault. Code: " + response.getCode(),
-                                    response.getPayload());
-                    monitor.warning(unspecifiedMsg);
-                    return HealthCheckResult.failed(unspecifiedMsg);
-            }
-
-        } catch (IOException e) {
-            final String exceptionMsg =
-                    String.format(HEALTH_CHECK_ERROR_TEMPLATE, "IOException: " + e.getMessage(), "");
-            monitor.severe(exceptionMsg);
+            response = client.getHealth();
+        } catch (EdcException e) {  // can be thrown by the client, e.g. on JSON parsing error, etc.
+            var exceptionMsg = format(HEALTH_CHECK_ERROR_TEMPLATE, "EdcException: " + e.getMessage(), "");
+            monitor.severe(exceptionMsg, e);
             return HealthCheckResult.failed(exceptionMsg);
+        }
+
+        switch (response.getCodeAsEnum()) {
+            case INITIALIZED_UNSEALED_AND_ACTIVE:
+                monitor.debug("HashiCorp Vault HealthCheck successful. " + response.getPayload());
+                return HealthCheckResult.success();
+            case UNSEALED_AND_STANDBY:
+                final String standbyMsg =
+                        format(
+                                HEALTH_CHECK_ERROR_TEMPLATE, "Vault is in standby", response.getPayload());
+                monitor.warning(standbyMsg);
+                return HealthCheckResult.failed(standbyMsg);
+            case DISASTER_RECOVERY_MODE_REPLICATION_SECONDARY_AND_ACTIVE:
+                final String recoveryModeMsg =
+                        format(
+                                HEALTH_CHECK_ERROR_TEMPLATE, "Vault is in recovery mode", response.getPayload());
+                monitor.warning(recoveryModeMsg);
+                return HealthCheckResult.failed(recoveryModeMsg);
+            case PERFORMANCE_STANDBY:
+                final String performanceStandbyMsg =
+                        format(
+                                HEALTH_CHECK_ERROR_TEMPLATE,
+                                "Vault is in performance standby",
+                                response.getPayload());
+                monitor.warning(performanceStandbyMsg);
+                return HealthCheckResult.failed(performanceStandbyMsg);
+            case NOT_INITIALIZED:
+                final String notInitializedMsg =
+                        format(
+                                HEALTH_CHECK_ERROR_TEMPLATE, "Vault is not initialized", response.getPayload());
+                monitor.warning(notInitializedMsg);
+                return HealthCheckResult.failed(notInitializedMsg);
+            case SEALED:
+                final String sealedMsg =
+                        format(HEALTH_CHECK_ERROR_TEMPLATE, "Vault is sealed", response.getPayload());
+                monitor.warning(sealedMsg);
+                return HealthCheckResult.failed(sealedMsg);
+            case UNSPECIFIED:
+            default:
+                final String unspecifiedMsg =
+                        format(
+                                HEALTH_CHECK_ERROR_TEMPLATE,
+                                "Unspecified response from vault. Code: " + response.getCode(),
+                                response.getPayload());
+                monitor.warning(unspecifiedMsg);
+                return HealthCheckResult.failed(unspecifiedMsg);
         }
     }
 }

--- a/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultHealthResponse.java
+++ b/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultHealthResponse.java
@@ -14,18 +14,17 @@
 
 package org.eclipse.tractusx.edc.hashicorpvault;
 
-import lombok.Builder;
-import lombok.Getter;
-import org.jetbrains.annotations.Nullable;
-
-@Builder
-@Getter
 public class HashicorpVaultHealthResponse {
 
-    @Nullable
     private HashicorpVaultHealthResponsePayload payload;
-
     private int code;
+
+    private HashicorpVaultHealthResponse() {
+    }
+
+    public int getCode() {
+        return code;
+    }
 
     public HashiCorpVaultHealthResponseCode getCodeAsEnum() {
         switch (code) {
@@ -48,6 +47,11 @@ public class HashicorpVaultHealthResponse {
         }
     }
 
+    public HashicorpVaultHealthResponsePayload getPayload() {
+        return payload;
+    }
+
+
     public enum HashiCorpVaultHealthResponseCode {
         UNSPECIFIED, // undefined status codes
         INITIALIZED_UNSEALED_AND_ACTIVE, // status code 200
@@ -56,5 +60,32 @@ public class HashicorpVaultHealthResponse {
         PERFORMANCE_STANDBY, // status code 473
         NOT_INITIALIZED, // status code 501
         SEALED // status code 503
+    }
+
+    public static final class Builder {
+
+        private final HashicorpVaultHealthResponse response;
+
+        private Builder() {
+            response = new HashicorpVaultHealthResponse();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder payload(HashicorpVaultHealthResponsePayload payload) {
+            this.response.payload = payload;
+            return this;
+        }
+
+        public Builder code(int code) {
+            this.response.code = code;
+            return this;
+        }
+
+        public HashicorpVaultHealthResponse build() {
+            return response;
+        }
     }
 }

--- a/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultHealthResponsePayload.java
+++ b/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultHealthResponsePayload.java
@@ -16,17 +16,7 @@ package org.eclipse.tractusx.edc.hashicorpvault;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
 
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
-@ToString
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HashicorpVaultHealthResponsePayload {
     @JsonProperty("initialized")
@@ -58,4 +48,44 @@ public class HashicorpVaultHealthResponsePayload {
 
     @JsonProperty("cluster_id")
     private String clusterId;
+
+    public boolean isInitialized() {
+        return isInitialized;
+    }
+
+    public boolean isSealed() {
+        return isSealed;
+    }
+
+    public boolean isStandby() {
+        return isStandby;
+    }
+
+    public boolean isPerformanceStandby() {
+        return isPerformanceStandby;
+    }
+
+    public String getReplicationPerformanceMode() {
+        return replicationPerformanceMode;
+    }
+
+    public String getReplicationDrMode() {
+        return replicationDrMode;
+    }
+
+    public long getServerTimeUtc() {
+        return serverTimeUtc;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getClusterName() {
+        return clusterName;
+    }
+
+    public String getClusterId() {
+        return clusterId;
+    }
 }

--- a/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultVaultExtension.java
+++ b/edc-extensions/hashicorp-vault/src/main/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultVaultExtension.java
@@ -44,10 +44,9 @@ public class HashicorpVaultVaultExtension extends AbstractHashicorpVaultExtensio
 
         final OkHttpClient okHttpClient = createOkHttpClient(config);
 
-        final HashicorpVaultClient client =
-                new HashicorpVaultClient(config, okHttpClient, context.getTypeManager().getMapper());
+        final HashicorpVaultClient client = new HashicorpVaultClient(config, okHttpClient, context.getTypeManager().getMapper());
 
-        final HashicorpVault vault = new HashicorpVault(client, context.getMonitor());
+        final HashicorpVault vault = new HashicorpVault(client);
         final CertificateResolver certificateResolver =
                 new HashicorpCertificateResolver(vault, context.getMonitor());
         final VaultPrivateKeyResolver privateKeyResolver = new VaultPrivateKeyResolver(vault);

--- a/edc-extensions/hashicorp-vault/src/test/java/org/eclipse/tractusx/edc/hashicorpvault/AbstractHashicorpIt.java
+++ b/edc-extensions/hashicorp-vault/src/test/java/org/eclipse/tractusx/edc/hashicorpvault/AbstractHashicorpIt.java
@@ -20,7 +20,6 @@
 
 package org.eclipse.tractusx.edc.hashicorpvault;
 
-import lombok.Getter;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.eclipse.edc.spi.security.CertificateResolver;
@@ -62,12 +61,11 @@ class AbstractHashicorpIt {
     static final String TOKEN = UUID.randomUUID().toString();
     @Container
     @ClassRule
-    private static final VaultContainer<?> VAULTCONTAINER =
-            new VaultContainer<>(DockerImageName.parse(DOCKER_IMAGE_NAME))
-                    .withVaultToken(TOKEN)
-                    .withSecretInVault(
-                            "secret/" + VAULT_ENTRY_KEY,
-                            String.format("%s=%s", VAULT_DATA_ENTRY_NAME, VAULT_ENTRY_VALUE));
+    private static final VaultContainer<?> VAULTCONTAINER = new VaultContainer<>(DockerImageName.parse(DOCKER_IMAGE_NAME))
+            .withVaultToken(TOKEN)
+            .withSecretInVault(
+                    "secret/" + VAULT_ENTRY_KEY,
+                    String.format("%s=%s", VAULT_DATA_ENTRY_NAME, VAULT_ENTRY_VALUE));
     private final TestExtension testExtension = new TestExtension();
 
     protected Vault getVault() {
@@ -97,7 +95,6 @@ class AbstractHashicorpIt {
         };
     }
 
-    @Getter
     private static class TestExtension implements ServiceExtension {
         private Vault vault;
         private CertificateResolver certificateResolver;
@@ -106,6 +103,14 @@ class AbstractHashicorpIt {
         public void initialize(ServiceExtensionContext context) {
             vault = context.getService(Vault.class);
             certificateResolver = context.getService(CertificateResolver.class);
+        }
+
+        public CertificateResolver getCertificateResolver() {
+            return certificateResolver;
+        }
+
+        public Vault getVault() {
+            return vault;
         }
     }
 

--- a/edc-extensions/hashicorp-vault/src/test/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpCertificateResolverIntegrationTest.java
+++ b/edc-extensions/hashicorp-vault/src/test/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpCertificateResolverIntegrationTest.java
@@ -20,20 +20,22 @@
 
 package org.eclipse.tractusx.edc.hashicorpvault;
 
-import lombok.SneakyThrows;
+import org.bouncycastle.operator.OperatorCreationException;
 import org.eclipse.edc.spi.security.CertificateResolver;
 import org.eclipse.edc.spi.security.Vault;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.UUID;
 
-class HashicorpCertificateResolverIt extends AbstractHashicorpIt {
+class HashicorpCertificateResolverIntegrationTest extends AbstractHashicorpIt {
 
     @Test
-    @SneakyThrows
-    void resolveCertificate_success() {
+    void resolveCertificate_success() throws CertificateException, IOException, NoSuchAlgorithmException, OperatorCreationException {
         String key = UUID.randomUUID().toString();
         X509Certificate certificateExpected = X509CertificateTestUtil.generateCertificate(5, "Test");
         String pem = X509CertificateTestUtil.convertToPem(certificateExpected);
@@ -47,7 +49,6 @@ class HashicorpCertificateResolverIt extends AbstractHashicorpIt {
     }
 
     @Test
-    @SneakyThrows
     void resolveCertificate_malformed() {
         String key = UUID.randomUUID().toString();
         String value = UUID.randomUUID().toString();

--- a/edc-extensions/hashicorp-vault/src/test/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpCertificateResolverTest.java
+++ b/edc-extensions/hashicorp-vault/src/test/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpCertificateResolverTest.java
@@ -20,13 +20,16 @@
 
 package org.eclipse.tractusx.edc.hashicorpvault;
 
-import lombok.SneakyThrows;
+import org.bouncycastle.operator.OperatorCreationException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
 class HashicorpCertificateResolverTest {
@@ -44,8 +47,7 @@ class HashicorpCertificateResolverTest {
     }
 
     @Test
-    @SneakyThrows
-    void resolveCertificate() {
+    void resolveCertificate() throws CertificateException, IOException, NoSuchAlgorithmException, OperatorCreationException {
         // prepare
         X509Certificate certificateExpected = X509CertificateTestUtil.generateCertificate(5, "Test");
         String pem = X509CertificateTestUtil.convertToPem(certificateExpected);
@@ -59,7 +61,6 @@ class HashicorpCertificateResolverTest {
     }
 
     @Test
-    @SneakyThrows
     void nullIfVaultEmpty() {
         // prepare
         Mockito.when(vault.resolveSecret(KEY)).thenReturn(null);

--- a/edc-extensions/hashicorp-vault/src/test/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultClientTest.java
+++ b/edc-extensions/hashicorp-vault/src/test/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultClientTest.java
@@ -21,19 +21,24 @@
 package org.eclipse.tractusx.edc.hashicorpvault;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.SneakyThrows;
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import org.eclipse.edc.spi.result.Result;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.UUID;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class HashicorpVaultClientTest {
     private static final String KEY = "key";
@@ -43,13 +48,12 @@ class HashicorpVaultClientTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Test
-    @SneakyThrows
-    void getSecretValue() {
+    void getSecretValue() throws IOException {
         // prepare
-        String vaultUrl = "https://mock.url";
-        String vaultToken = UUID.randomUUID().toString();
+        var vaultUrl = "https://mock.url";
+        var vaultToken = UUID.randomUUID().toString();
         HashicorpVaultClientConfig hashicorpVaultClientConfig =
-                HashicorpVaultClientConfig.builder()
+                HashicorpVaultClientConfig.Builder.newInstance()
                         .vaultUrl(vaultUrl)
                         .vaultApiSecretPath(CUSTOM_SECRET_PATH)
                         .vaultApiHealthPath(HEALTH_PATH)
@@ -58,40 +62,39 @@ class HashicorpVaultClientTest {
                         .timeout(TIMEOUT)
                         .build();
 
-        OkHttpClient okHttpClient = Mockito.mock(OkHttpClient.class);
-        HashicorpVaultClient vaultClient =
+        var okHttpClient = mock(OkHttpClient.class);
+        var vaultClient =
                 new HashicorpVaultClient(hashicorpVaultClientConfig, okHttpClient, OBJECT_MAPPER);
-        Call call = Mockito.mock(Call.class);
-        Response response = Mockito.mock(Response.class);
-        ResponseBody body = Mockito.mock(ResponseBody.class);
-        HashicorpVaultGetEntryResponsePayload payload = new HashicorpVaultGetEntryResponsePayload();
+        var call = mock(Call.class);
+        var response = mock(Response.class);
+        var body = mock(ResponseBody.class);
+        var payload = new HashicorpVaultGetEntryResponsePayload();
 
-        Mockito.when(okHttpClient.newCall(Mockito.any(Request.class))).thenReturn(call);
-        Mockito.when(call.execute()).thenReturn(response);
-        Mockito.when(response.code()).thenReturn(200);
-        Mockito.when(response.body()).thenReturn(body);
-        Mockito.when(body.string()).thenReturn(payload.toString());
+        when(okHttpClient.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.code()).thenReturn(200);
+        when(response.body()).thenReturn(body);
+        when(body.string()).thenReturn(payload.toString());
 
         // invoke
-        Result<String> result = vaultClient.getSecretValue(KEY);
+        var result = vaultClient.getSecretValue(KEY);
 
         // verify
         Assertions.assertNotNull(result);
-        Mockito.verify(okHttpClient, Mockito.times(1))
-                .newCall(Mockito.argThat(request -> request.method().equalsIgnoreCase("GET") &&
+        verify(okHttpClient, times(1))
+                .newCall(argThat(request -> request.method().equalsIgnoreCase("GET") &&
                         request.url().encodedPath().contains(CUSTOM_SECRET_PATH + "/data") &&
                         request.url().encodedPathSegments().contains(KEY)));
     }
 
     @Test
-    @SneakyThrows
-    void setSecretValue() {
+    void setSecretValue() throws IOException {
         // prepare
-        String vaultUrl = "https://mock.url";
-        String vaultToken = UUID.randomUUID().toString();
-        String secretValue = UUID.randomUUID().toString();
+        var vaultUrl = "https://mock.url";
+        var vaultToken = UUID.randomUUID().toString();
+        var secretValue = UUID.randomUUID().toString();
         HashicorpVaultClientConfig hashicorpVaultClientConfig =
-                HashicorpVaultClientConfig.builder()
+                HashicorpVaultClientConfig.Builder.newInstance()
                         .vaultUrl(vaultUrl)
                         .vaultApiSecretPath(CUSTOM_SECRET_PATH)
                         .vaultApiHealthPath(HEALTH_PATH)
@@ -100,31 +103,31 @@ class HashicorpVaultClientTest {
                         .timeout(TIMEOUT)
                         .build();
 
-        OkHttpClient okHttpClient = Mockito.mock(OkHttpClient.class);
-        HashicorpVaultClient vaultClient =
+        var okHttpClient = mock(OkHttpClient.class);
+        var vaultClient =
                 new HashicorpVaultClient(hashicorpVaultClientConfig, okHttpClient, OBJECT_MAPPER);
-        HashicorpVaultCreateEntryResponsePayload payload =
+        var payload =
                 new HashicorpVaultCreateEntryResponsePayload();
 
-        Call call = Mockito.mock(Call.class);
-        Response response = Mockito.mock(Response.class);
-        ResponseBody body = Mockito.mock(ResponseBody.class);
+        var call = mock(Call.class);
+        var response = mock(Response.class);
+        var body = mock(ResponseBody.class);
 
-        Mockito.when(okHttpClient.newCall(Mockito.any(Request.class))).thenReturn(call);
-        Mockito.when(call.execute()).thenReturn(response);
-        Mockito.when(response.code()).thenReturn(200);
-        Mockito.when(response.body()).thenReturn(body);
-        Mockito.when(body.string()).thenReturn(payload.toString());
+        when(okHttpClient.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.code()).thenReturn(200);
+        when(response.body()).thenReturn(body);
+        when(body.string()).thenReturn(payload.toString());
 
         // invoke
-        Result<HashicorpVaultCreateEntryResponsePayload> result =
+        var result =
                 vaultClient.setSecret(KEY, secretValue);
 
         // verify
         Assertions.assertNotNull(result);
-        Mockito.verify(okHttpClient, Mockito.times(1))
+        verify(okHttpClient, times(1))
                 .newCall(
-                        Mockito.argThat(
+                        argThat(
                                 request ->
                                         request.method().equalsIgnoreCase("POST") &&
                                                 request.url().encodedPath().contains(CUSTOM_SECRET_PATH + "/data") &&
@@ -132,14 +135,13 @@ class HashicorpVaultClientTest {
     }
 
     @Test
-    @SneakyThrows
-    void getHealth() {
+    void getHealth() throws IOException {
         // prepare
-        String vaultUrl = "https://mock.url";
-        String vaultToken = UUID.randomUUID().toString();
-        String secretValue = UUID.randomUUID().toString();
+        var vaultUrl = "https://mock.url";
+        var vaultToken = UUID.randomUUID().toString();
+        var secretValue = UUID.randomUUID().toString();
         HashicorpVaultClientConfig hashicorpVaultClientConfig =
-                HashicorpVaultClientConfig.builder()
+                HashicorpVaultClientConfig.Builder.newInstance()
                         .vaultUrl(vaultUrl)
                         .vaultApiSecretPath(CUSTOM_SECRET_PATH)
                         .vaultApiHealthPath(HEALTH_PATH)
@@ -148,20 +150,20 @@ class HashicorpVaultClientTest {
                         .timeout(TIMEOUT)
                         .build();
 
-        OkHttpClient okHttpClient = Mockito.mock(OkHttpClient.class);
-        HashicorpVaultClient vaultClient =
+        var okHttpClient = mock(OkHttpClient.class);
+        var vaultClient =
                 new HashicorpVaultClient(hashicorpVaultClientConfig, okHttpClient, OBJECT_MAPPER);
-        HashicorpVaultHealthResponsePayload payload = new HashicorpVaultHealthResponsePayload();
+        var payload = new HashicorpVaultHealthResponsePayload();
 
-        Call call = Mockito.mock(Call.class);
-        Response response = Mockito.mock(Response.class);
-        ResponseBody body = Mockito.mock(ResponseBody.class);
+        var call = mock(Call.class);
+        var response = mock(Response.class);
+        var body = mock(ResponseBody.class);
 
-        Mockito.when(okHttpClient.newCall(Mockito.any(Request.class))).thenReturn(call);
-        Mockito.when(call.execute()).thenReturn(response);
-        Mockito.when(response.code()).thenReturn(200);
-        Mockito.when(response.body()).thenReturn(body);
-        Mockito.when(body.string())
+        when(okHttpClient.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.code()).thenReturn(200);
+        when(response.body()).thenReturn(body);
+        when(body.string())
                 .thenReturn(
                         "{ " +
                                 "\"initialized\": true, " +
@@ -177,13 +179,13 @@ class HashicorpVaultClientTest {
                                 " }");
 
         // invoke
-        HashicorpVaultHealthResponse result = vaultClient.getHealth();
+        var result = vaultClient.getHealth();
 
         // verify
         Assertions.assertNotNull(result);
-        Mockito.verify(okHttpClient, Mockito.times(1))
+        verify(okHttpClient, times(1))
                 .newCall(
-                        Mockito.argThat(
+                        argThat(
                                 request ->
                                         request.method().equalsIgnoreCase("GET") &&
                                                 request.url().encodedPath().contains(HEALTH_PATH) &&
@@ -211,13 +213,12 @@ class HashicorpVaultClientTest {
     }
 
     @Test
-    @SneakyThrows
-    void destroySecretValue() {
+    void destroySecretValue() throws IOException {
         // prepare
-        String vaultUrl = "https://mock.url";
-        String vaultToken = UUID.randomUUID().toString();
+        var vaultUrl = "https://mock.url";
+        var vaultToken = UUID.randomUUID().toString();
         HashicorpVaultClientConfig hashicorpVaultClientConfig =
-                HashicorpVaultClientConfig.builder()
+                HashicorpVaultClientConfig.Builder.newInstance()
                         .vaultUrl(vaultUrl)
                         .vaultApiSecretPath(CUSTOM_SECRET_PATH)
                         .vaultApiHealthPath(HEALTH_PATH)
@@ -226,26 +227,26 @@ class HashicorpVaultClientTest {
                         .timeout(TIMEOUT)
                         .build();
 
-        OkHttpClient okHttpClient = Mockito.mock(OkHttpClient.class);
-        HashicorpVaultClient vaultClient =
+        var okHttpClient = mock(OkHttpClient.class);
+        var vaultClient =
                 new HashicorpVaultClient(hashicorpVaultClientConfig, okHttpClient, OBJECT_MAPPER);
 
-        Call call = Mockito.mock(Call.class);
-        Response response = Mockito.mock(Response.class);
-        ResponseBody body = Mockito.mock(ResponseBody.class);
-        Mockito.when(okHttpClient.newCall(Mockito.any(Request.class))).thenReturn(call);
-        Mockito.when(call.execute()).thenReturn(response);
-        Mockito.when(response.code()).thenReturn(200);
-        Mockito.when(response.body()).thenReturn(body);
+        var call = mock(Call.class);
+        var response = mock(Response.class);
+        var body = mock(ResponseBody.class);
+        when(okHttpClient.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.code()).thenReturn(200);
+        when(response.body()).thenReturn(body);
 
         // invoke
-        Result<Void> result = vaultClient.destroySecret(KEY);
+        var result = vaultClient.destroySecret(KEY);
 
         // verify
         Assertions.assertNotNull(result);
-        Mockito.verify(okHttpClient, Mockito.times(1))
+        verify(okHttpClient, times(1))
                 .newCall(
-                        Mockito.argThat(
+                        argThat(
                                 request ->
                                         request.method().equalsIgnoreCase("DELETE") &&
                                                 request.url().encodedPath().contains(CUSTOM_SECRET_PATH + "/metadata") &&

--- a/edc-extensions/hashicorp-vault/src/test/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultHealthCheckTest.java
+++ b/edc-extensions/hashicorp-vault/src/test/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultHealthCheckTest.java
@@ -20,16 +20,14 @@
 
 package org.eclipse.tractusx.edc.hashicorpvault;
 
+import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.system.health.HealthCheckResult;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
-
-import java.io.IOException;
 
 class HashicorpVaultHealthCheckTest {
 
@@ -49,13 +47,12 @@ class HashicorpVaultHealthCheckTest {
 
     @ParameterizedTest
     @ValueSource(ints = {200, 409, 472, 473, 501, 503, 999})
-    void testResponseFromCode(int code) throws IOException {
+    void testResponseFromCode(int code) {
 
         Mockito.when(client.getHealth())
-                .thenReturn(
-                        new HashicorpVaultHealthResponse(new HashicorpVaultHealthResponsePayload(), code));
+                .thenReturn(HashicorpVaultHealthResponse.Builder.newInstance().payload(new HashicorpVaultHealthResponsePayload()).code(code).build());
 
-        final HealthCheckResult result = healthCheck.get();
+        var result = healthCheck.get();
 
         if (code == 200) {
             Mockito.verify(monitor, Mockito.times(1)).debug(Mockito.anyString());
@@ -67,10 +64,10 @@ class HashicorpVaultHealthCheckTest {
     }
 
     @Test
-    void testResponseFromException() throws IOException {
-        Mockito.when(client.getHealth()).thenThrow(new IOException());
+    void testResponseFromException() {
+        Mockito.when(client.getHealth()).thenThrow(new EdcException("foo-bar"));
 
-        final HealthCheckResult result = healthCheck.get();
+        var result = healthCheck.get();
         Assertions.assertFalse(result.succeeded());
     }
 }

--- a/edc-extensions/hashicorp-vault/src/test/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultTest.java
+++ b/edc-extensions/hashicorp-vault/src/test/java/org/eclipse/tractusx/edc/hashicorpvault/HashicorpVaultTest.java
@@ -20,7 +20,6 @@
 
 package org.eclipse.tractusx.edc.hashicorpvault;
 
-import lombok.SneakyThrows;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.junit.jupiter.api.Assertions;
@@ -41,11 +40,10 @@ class HashicorpVaultTest {
     void setup() {
         vaultClient = Mockito.mock(HashicorpVaultClient.class);
         final Monitor monitor = Mockito.mock(Monitor.class);
-        vault = new HashicorpVault(vaultClient, monitor);
+        vault = new HashicorpVault(vaultClient);
     }
 
     @Test
-    @SneakyThrows
     void getSecretSuccess() {
         // prepare
         String value = UUID.randomUUID().toString();
@@ -64,7 +62,6 @@ class HashicorpVaultTest {
     }
 
     @Test
-    @SneakyThrows
     void getSecretFailure() {
         // prepare
         Result<String> result = Mockito.mock(Result.class);
@@ -81,7 +78,6 @@ class HashicorpVaultTest {
     }
 
     @Test
-    @SneakyThrows
     void setSecretSuccess() {
         // prepare
         String value = UUID.randomUUID().toString();
@@ -99,7 +95,6 @@ class HashicorpVaultTest {
     }
 
     @Test
-    @SneakyThrows
     void setSecretFailure() {
         // prepare
         String value = UUID.randomUUID().toString();
@@ -117,7 +112,6 @@ class HashicorpVaultTest {
     }
 
     @Test
-    @SneakyThrows
     void destroySecretSuccess() {
         // prepare
         Result<Void> result = Mockito.mock(Result.class);
@@ -134,7 +128,6 @@ class HashicorpVaultTest {
     }
 
     @Test
-    @SneakyThrows
     void destroySecretFailure() {
         // prepare
         Result<Void> result = Mockito.mock(Result.class);

--- a/edc-extensions/hashicorp-vault/src/test/java/org/eclipse/tractusx/edc/hashicorpvault/X509CertificateTestUtil.java
+++ b/edc-extensions/hashicorp-vault/src/test/java/org/eclipse/tractusx/edc/hashicorpvault/X509CertificateTestUtil.java
@@ -20,8 +20,6 @@
 
 package org.eclipse.tractusx.edc.hashicorpvault;
 
-import lombok.SneakyThrows;
-import lombok.experimental.UtilityClass;
 import org.bouncycastle.asn1.oiw.OIWObjectIdentifiers;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
@@ -60,14 +58,13 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.Optional;
 
-@UtilityClass
-final class X509CertificateTestUtil {
+public class X509CertificateTestUtil {
     private static final String SIGNATURE_ALGORITHM = "SHA256WithRSAEncryption";
     private static final Provider PROVIDER = new BouncyCastleProvider();
     private static final JcaX509CertificateConverter JCA_X509_CERTIFICATE_CONVERTER =
             new JcaX509CertificateConverter().setProvider(PROVIDER);
 
-    static X509Certificate generateCertificate(int validity, String cn)
+    public static X509Certificate generateCertificate(int validity, String cn)
             throws CertificateException, OperatorCreationException, IOException,
             NoSuchAlgorithmException {
 
@@ -125,15 +122,16 @@ final class X509CertificateTestUtil {
         return new X509ExtensionUtils(digCalc).createAuthorityKeyIdentifier(publicKeyInfo);
     }
 
-    @SneakyThrows
     static String convertToPem(X509Certificate certificate) {
-        try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
+        try (var stream = new ByteArrayOutputStream()) {
             try (OutputStreamWriter writer = new OutputStreamWriter(stream)) {
                 JcaPEMWriter pemWriter = new JcaPEMWriter(writer);
                 pemWriter.writeObject(certificate);
                 pemWriter.flush();
             }
             return stream.toString(StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/lombok.config
+++ b/lombok.config
@@ -1,2 +1,0 @@
-config.stopBubbling = true
-lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
## WHAT

Removes Lombok from the HashiCorp Vault implementation, and purges the Lombok Gradle plugin from the code base.

## WHY

As per Decision Record 2023-03-23, Lombok is to be removed from the code base.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #154
