### PR TITLE
build: add workflow to manually release maven artefacts

### DIFF
--- a/.github/workflows/publish-maven.yaml
+++ b/.github/workflows/publish-maven.yaml
@@ -1,0 +1,68 @@
+#
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
+---
+name: "Manually publish Maven Artefacts to OSSRH"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: false
+        description: 'a semver string denoting the version. Append -SNAPSHOT for snapshots. If ommitted, the version is taken from gradle.properties'
+
+concurrency:
+  # cancel only running jobs on pull requests
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  maven-release:
+    name: 'Publish all artefacts to Sonatype/MavenCentral'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      # Set-Up
+      - uses: actions/checkout@v3.5.2
+      - uses: ./.github/actions/setup-java
+
+      # Import GPG Key
+      - uses: ./.github/actions/import-gpg-key
+        name: "Import GPG Key"
+        with:
+          gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
+
+      # publish releases
+      - name: Publish version
+        env:
+          OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
+          OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
+        run: |-
+          if [ -z ${{ inputs.version }} ]; 
+          then 
+            VERSION=$(./gradlew properties -q | grep "version:" | awk '{print $2}')
+            echo "Publishing using version from gradle.properties: $VERSION"
+            ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Pversion=$VERSION -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ secrets.ORG_GPG_PASSPHRASE }}"
+          else 
+            echo "Publishing using version from parameter: ${{ inputs.version }}"
+            ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Pversion=${{ inputs.version }} -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ secrets.ORG_GPG_PASSPHRASE }}"
+          fi

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@
 
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 import com.github.jengelman.gradle.plugins.shadow.ShadowJavaPlugin
+import java.time.Duration
 
 plugins {
     `java-library`
@@ -27,13 +28,13 @@ plugins {
     id("com.diffplug.spotless") version "6.18.0"
     id("com.github.johnrengelman.shadow") version "8.1.1"
     id("com.bmuschko.docker-remote-api") version "9.3.1"
+    id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
 }
 
 val javaVersion: String by project
 val txScmConnection: String by project
 val txWebsiteUrl: String by project
 val txScmUrl: String by project
-val groupId: String by project
 val annotationProcessorVersion: String by project
 val metaModelVersion: String by project
 
@@ -88,10 +89,9 @@ allprojects {
             metaModel.set(metaModelVersion)
 
         }
-        val gid = groupId
         pom {
             // this is actually important, so we can publish under the correct GID
-            groupId = gid
+            groupId = project.group.toString()
             projectName.set(project.name)
             description.set("edc :: ${project.name}")
             projectUrl.set(txWebsiteUrl)
@@ -169,5 +169,12 @@ subprojects {
             // make sure "shadowJar" always runs before "dockerize"
             dockerTask.dependsOn(tasks.findByName(ShadowJavaPlugin.SHADOW_JAR_TASK_NAME))
         }
+    }
+}
+
+nexusPublishing {
+    transitionCheckOptions {
+        maxRetries.set(120)
+        delayBetween.set(Duration.ofSeconds(10))
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-groupId=org.eclipse.tractusx.edc
+group=org.eclipse.tractusx.edc
 version=0.4.1-SNAPSHOT
 javaVersion=11
 # configure the build:


### PR DESCRIPTION
change group property

## WHAT

Adds a workflow that allows manually publishing to MAvenCentral/Sonatype.
Also fixes a bug with the group-id, and adds a timeout for nexus publishing.

## WHY

Publishing maven artefacts failed previously due to the group bug. This will provide a convenient way to publish artifacts on-demand.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #166 
