### PR TITLE
chore: fix DAPS module dependency, update to java 17

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,6 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
 }
 
-val javaVersion: String by project
 val txScmConnection: String by project
 val txWebsiteUrl: String by project
 val txScmUrl: String by project
@@ -107,7 +106,6 @@ allprojects {
             outputDirectory.set(file("${rootProject.projectDir.path}/resources/openapi/yaml"))
             resourcePackages = setOf("org.eclipse.tractusx.edc")
         }
-        javaLanguageVersion.set(JavaLanguageVersion.of(javaVersion))
     }
 
     configure<CheckstyleExtension> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,6 @@
 group=org.eclipse.tractusx.edc
 version=0.4.1-SNAPSHOT
-javaVersion=11
 # configure the build:
-# 0.0.1-SNAPSHOT is needed to leverage gradle 8
 annotationProcessorVersion=0.0.1-milestone-9
 edcGradlePluginsVersion=0.0.1-milestone-9
 metaModelVersion=0.0.1-milestone-9

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,7 +60,7 @@ edc-iam-mock = { module = "org.eclipse.edc:iam-mock", version.ref = "edc" }
 edc-policy-engine = { module = "org.eclipse.edc:policy-engine", version.ref = "edc" }
 edc-auth-tokenbased = { module = "org.eclipse.edc:auth-tokenbased", version.ref = "edc" }
 edc-auth-oauth2-core = { module = "org.eclipse.edc:oauth2-core", version.ref = "edc" }
-edc-auth-oauth2-daps = { module = "org.eclipse.edc:oauth2-core", version.ref = "edc" }
+edc-auth-oauth2-daps = { module = "org.eclipse.edc:oauth2-daps", version.ref = "edc" }
 edc-transaction-local = { module = "org.eclipse.edc:transaction-local", version.ref = "edc" }
 edc-ext-http = { module = "org.eclipse.edc:http", version.ref = "edc" }
 edc-ext-azure-cosmos-core = { module = "org.eclipse.edc:azure-cosmos-core", version.ref = "edc" }


### PR DESCRIPTION
## WHAT

Fixes the DAPS module dependency
Updates to Java 17

## WHY

bugfix.

Java 17 is used by EDC and there's a D-R about it.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
