### PR TITLE
fix: limit search for Chart.yaml to avoid subchart updates

### DIFF
--- a/.github/workflows/draft-new-release.yaml
+++ b/.github/workflows/draft-new-release.yaml
@@ -66,7 +66,7 @@ jobs:
         uses: mikefarah/yq@v4.34.1
         with:
           cmd: |-
-            find charts -name Chart.yaml | xargs -n1 yq -i '.appVersion = "${{ github.event.inputs.version }}" | .version = "${{ github.event.inputs.version }}"'
+            find charts -name Chart.yaml -maxdepth 3 | xargs -n1 yq -i '.appVersion = "${{ github.event.inputs.version }}" | .version = "${{ github.event.inputs.version }}"'
       -
         name: Update Chart READMEs
         uses: addnab/docker-run-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.1] - 2023-05-31
 
-## [0.4.1] - 2023-05-31
-
 ### Added
 
--   SQL implementation for the EDR Cache
--   E2E test variant using PostgreSQL
--   Documentation
+- SQL implementation for the EDR Cache
+- E2E test variant using PostgreSQL
+- Documentation
 
 ### Changed
 
--   Moved to Java 17
--   Switched to Eclipse Dataspace Components `0.1.0`
+- Moved to Java 17
+- Switched to Eclipse Dataspace Components `0.1.0`
 
 ### Removed
 
--   Lombok
+- Lombok
 
 ## [0.4.0] - 2023-05-18
 

--- a/charts/tractusx-connector-azure-vault/subcharts/omejdn/Chart.yaml
+++ b/charts/tractusx-connector-azure-vault/subcharts/omejdn/Chart.yaml
@@ -32,9 +32,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.1"
+appVersion: "0.0.1"

--- a/charts/tractusx-connector/subcharts/omejdn/Chart.yaml
+++ b/charts/tractusx-connector/subcharts/omejdn/Chart.yaml
@@ -32,9 +32,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.1"
+appVersion: "0.0.1"


### PR DESCRIPTION
## WHAT

When we update the versions in our `Chart.yml` files, we need to limit the search so that the nested `daps` charts don't get updated.

## WHY

this would cause the chart packaging to fail, since the subchart version, and the one referenced in the parent charts don't match anymore.

## FURTHER NOTES

for example see: https://github.com/eclipse-tractusx/tractusx-edc/actions/runs/5132313351/jobs/9233450666

Closes # <-- _insert Issue number if one exists_
