### PR TITLE
chore(helm): fix indentation for ingress labels

### DIFF
--- a/charts/tractusx-connector-azure-vault/templates/ingress-controlplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/ingress-controlplane.yaml
@@ -18,7 +18,7 @@
   #
 
 {{- $fullName := include "txdc.fullname" . }}
-{{- $controlLabels := include "txdc.controlplane.labels" . | nindent 4 }}
+{{- $controlLabels := include "txdc.controlplane.labels" . }}
 {{- $controlEdcEndpoints := .Values.controlplane.endpoints }}
 {{- $gitVersion := .Capabilities.KubeVersion.GitVersion }}
 {{- $namespace := .Release.Namespace }}
@@ -39,7 +39,7 @@ metadata:
   name: {{ $controlIngressName }}
   namespace: {{ $namespace | default "default" | quote }}
   labels:
-    {{- $controlLabels | nindent 2 }}
+    {{- $controlLabels | nindent 4 }}
   annotations:
     {{- if and .className (not (semverCompare ">=1.18-0" $gitVersion)) }}
     {{- if not (hasKey .annotations "kubernetes.io/ingress.class") }}

--- a/charts/tractusx-connector-azure-vault/templates/ingress-dataplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/ingress-dataplane.yaml
@@ -18,7 +18,7 @@
   #
 
 {{- $fullName := include "txdc.fullname" . }}
-{{- $dataLabels := include "txdc.dataplane.labels" . | nindent 4 }}
+{{- $dataLabels := include "txdc.dataplane.labels" . }}
 {{- $dataEdcEndpoints := .Values.dataplane.endpoints }}
 {{- $gitVersion := .Capabilities.KubeVersion.GitVersion }}
 {{- $namespace := .Release.Namespace }}
@@ -39,7 +39,7 @@ metadata:
   name: {{ $dataIngressName }}
   namespace: {{ $namespace | default "default" | quote }}
   labels:
-    {{- $dataLabels | nindent 2 }}
+    {{- $dataLabels | nindent 4 }}
   annotations:
     {{- if and .className (not (semverCompare ">=1.18-0" $gitVersion)) }}
     {{- if not (hasKey .annotations "kubernetes.io/ingress.class") }}

--- a/charts/tractusx-connector-memory/templates/ingress-runtime.yaml
+++ b/charts/tractusx-connector-memory/templates/ingress-runtime.yaml
@@ -21,7 +21,7 @@
 #
 
 {{- $fullName := include "txdc.fullname" . }}
-{{- $controlLabels := include "txdc.runtime.labels" . | nindent 4 }}
+{{- $controlLabels := include "txdc.runtime.labels" . }}
 {{- $controlEdcEndpoints := .Values.runtime.endpoints }}
 {{- $gitVersion := .Capabilities.KubeVersion.GitVersion }}
 {{- $namespace := .Release.Namespace }}
@@ -42,7 +42,7 @@ metadata:
   name: {{ $controlIngressName }}
   namespace: {{ $namespace | default "default" | quote }}
   labels:
-    {{- $controlLabels | nindent 2 }}
+    {{- $controlLabels | nindent 4 }}
   annotations:
     {{- if and .className (not (semverCompare ">=1.18-0" $gitVersion)) }}
     {{- if not (hasKey .annotations "kubernetes.io/ingress.class") }}

--- a/charts/tractusx-connector/templates/ingress-controlplane.yaml
+++ b/charts/tractusx-connector/templates/ingress-controlplane.yaml
@@ -21,7 +21,7 @@
 #
 
 {{- $fullName := include "txdc.fullname" . }}
-{{- $controlLabels := include "txdc.controlplane.labels" . | nindent 4 }}
+{{- $controlLabels := include "txdc.controlplane.labels" . }}
 {{- $controlEdcEndpoints := .Values.controlplane.endpoints }}
 {{- $gitVersion := .Capabilities.KubeVersion.GitVersion }}
 {{- $namespace := .Release.Namespace }}
@@ -42,7 +42,7 @@ metadata:
   name: {{ $controlIngressName }}
   namespace: {{ $namespace | default "default" | quote }}
   labels:
-    {{- $controlLabels | nindent 2 }}
+    {{- $controlLabels | nindent 4 }}
   annotations:
     {{- if and .className (not (semverCompare ">=1.18-0" $gitVersion)) }}
     {{- if not (hasKey .annotations "kubernetes.io/ingress.class") }}

--- a/charts/tractusx-connector/templates/ingress-dataplane.yaml
+++ b/charts/tractusx-connector/templates/ingress-dataplane.yaml
@@ -21,7 +21,7 @@
 #
 
 {{- $fullName := include "txdc.fullname" . }}
-{{- $dataLabels := include "txdc.dataplane.labels" . | nindent 4 }}
+{{- $dataLabels := include "txdc.dataplane.labels" . }}
 {{- $dataEdcEndpoints := .Values.dataplane.endpoints }}
 {{- $gitVersion := .Capabilities.KubeVersion.GitVersion }}
 {{- $namespace := .Release.Namespace }}
@@ -42,7 +42,7 @@ metadata:
   name: {{ $dataIngressName }}
   namespace: {{ $namespace | default "default" | quote }}
   labels:
-    {{- $dataLabels | nindent 2 }}
+    {{- $dataLabels | nindent 4 }}
   annotations:
     {{- if and .className (not (semverCompare ">=1.18-0" $gitVersion)) }}
     {{- if not (hasKey .annotations "kubernetes.io/ingress.class") }}


### PR DESCRIPTION
## WHAT

Fix indentation for the ingress templates to use single 4 spaces indentations as expected (currently 6).
Also removing blank line between labels keyword and key-value pairs.

## WHY

To fix the indentation to correct Helm syntax

## FURTHER NOTES

See diff templating:

```diff
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: test
  namespace: "testing"
  labels:
-  
-      helm.sh/chart: tractusx-connector-0.4.1
-      app.kubernetes.io/name: tractusx-connector-controlplane
-      app.kubernetes.io/instance: test-controlplane
-      app.kubernetes.io/version: "0.4.1"
-      app.kubernetes.io/managed-by: Helm
-      app.kubernetes.io/component: edc-controlplane
-      app.kubernetes.io/part-of: edc
+    helm.sh/chart: tractusx-connector-0.4.1
+    app.kubernetes.io/name: tractusx-connector-controlplane
+    app.kubernetes.io/instance: test-controlplane
+    app.kubernetes.io/version: "0.4.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: edc-controlplane
+    app.kubernetes.io/part-of: edc
```