### PR TITLE
feat(helm): allow to omit ingress annotations key

### DIFF
--- a/charts/tractusx-connector-azure-vault/templates/ingress-controlplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/ingress-controlplane.yaml
@@ -26,6 +26,7 @@
 {{- range .Values.controlplane.ingresses }}
 {{- if and .enabled .endpoints }}
 {{- $controlIngressName := printf "%s-controlplane-%s" $fullName .hostname }}
+{{- $annotations := .annotations | default dict }}
 ---
 {{- if semverCompare ">=1.19-0" $gitVersion }}
 apiVersion: networking.k8s.io/v1
@@ -42,19 +43,19 @@ metadata:
     {{- $controlLabels | nindent 2 }}
   annotations:
     {{- if and .className (not (semverCompare ">=1.18-0" $gitVersion)) }}
-    {{- if not (hasKey .annotations "kubernetes.io/ingress.class") }}
-    {{- $_ := set .annotations "kubernetes.io/ingress.class" .className}}
+    {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
+    {{- $_ := set $annotations "kubernetes.io/ingress.class" .className}}
     {{- end }}
     {{- end }}
     {{- if .certManager }}
     {{- if .certManager.issuer }}
-    {{- $_ := set .annotations "cert-manager.io/issuer" .certManager.issuer}}
+    {{- $_ := set $annotations "cert-manager.io/issuer" .certManager.issuer}}
     {{- end }}
     {{- if .certManager.clusterIssuer }}
-    {{- $_ := set .annotations "cert-manager.io/cluster-issuer" .certManager.clusterIssuer}}
+    {{- $_ := set $annotations "cert-manager.io/cluster-issuer" .certManager.clusterIssuer}}
     {{- end }}
     {{- end }}
-    {{- with .annotations }}
+    {{- with $annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:

--- a/charts/tractusx-connector-azure-vault/templates/ingress-dataplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/ingress-dataplane.yaml
@@ -26,6 +26,7 @@
 {{- range .Values.dataplane.ingresses }}
 {{- if and .enabled .endpoints }}
 {{- $dataIngressName := printf "%s-dataplane-%s" $fullName .hostname }}
+{{- $annotations := .annotations | default dict }}
 ---
 {{- if semverCompare ">=1.19-0" $gitVersion }}
 apiVersion: networking.k8s.io/v1
@@ -42,19 +43,19 @@ metadata:
     {{- $dataLabels | nindent 2 }}
   annotations:
     {{- if and .className (not (semverCompare ">=1.18-0" $gitVersion)) }}
-    {{- if not (hasKey .annotations "kubernetes.io/ingress.class") }}
-    {{- $_ := set .annotations "kubernetes.io/ingress.class" .className}}
+    {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
+    {{- $_ := set $annotations "kubernetes.io/ingress.class" .className}}
     {{- end }}
     {{- end }}
     {{- if .certManager }}
     {{- if .certManager.issuer }}
-    {{- $_ := set .annotations "cert-manager.io/issuer" .certManager.issuer}}
+    {{- $_ := set $annotations "cert-manager.io/issuer" .certManager.issuer}}
     {{- end }}
     {{- if .certManager.clusterIssuer }}
-    {{- $_ := set .annotations "cert-manager.io/cluster-issuer" .certManager.clusterIssuer}}
+    {{- $_ := set $annotations "cert-manager.io/cluster-issuer" .certManager.clusterIssuer}}
     {{- end }}
     {{- end }}
-    {{- with .annotations }}
+    {{- with $annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:

--- a/charts/tractusx-connector-memory/templates/ingress-runtime.yaml
+++ b/charts/tractusx-connector-memory/templates/ingress-runtime.yaml
@@ -29,6 +29,7 @@
 {{- range .Values.runtime.ingresses }}
 {{- if and .enabled .endpoints }}
 {{- $controlIngressName := printf "%s-runtime-%s" $fullName .hostname }}
+{{- $annotations := .annotations | default dict }}
 ---
 {{- if semverCompare ">=1.19-0" $gitVersion }}
 apiVersion: networking.k8s.io/v1
@@ -45,19 +46,19 @@ metadata:
     {{- $controlLabels | nindent 2 }}
   annotations:
     {{- if and .className (not (semverCompare ">=1.18-0" $gitVersion)) }}
-    {{- if not (hasKey .annotations "kubernetes.io/ingress.class") }}
-    {{- $_ := set .annotations "kubernetes.io/ingress.class" .className}}
+    {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
+    {{- $_ := set $annotations "kubernetes.io/ingress.class" .className}}
     {{- end }}
     {{- end }}
     {{- if .certManager }}
     {{- if .certManager.issuer }}
-    {{- $_ := set .annotations "cert-manager.io/issuer" .certManager.issuer}}
+    {{- $_ := set $annotations "cert-manager.io/issuer" .certManager.issuer}}
     {{- end }}
     {{- if .certManager.clusterIssuer }}
-    {{- $_ := set .annotations "cert-manager.io/cluster-issuer" .certManager.clusterIssuer}}
+    {{- $_ := set $annotations "cert-manager.io/cluster-issuer" .certManager.clusterIssuer}}
     {{- end }}
     {{- end }}
-    {{- with .annotations }}
+    {{- with $annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:

--- a/charts/tractusx-connector/templates/ingress-controlplane.yaml
+++ b/charts/tractusx-connector/templates/ingress-controlplane.yaml
@@ -29,6 +29,7 @@
 {{- range .Values.controlplane.ingresses }}
 {{- if and .enabled .endpoints }}
 {{- $controlIngressName := printf "%s-controlplane-%s" $fullName .hostname }}
+{{- $annotations := .annotations | default dict }}
 ---
 {{- if semverCompare ">=1.19-0" $gitVersion }}
 apiVersion: networking.k8s.io/v1
@@ -45,19 +46,19 @@ metadata:
     {{- $controlLabels | nindent 2 }}
   annotations:
     {{- if and .className (not (semverCompare ">=1.18-0" $gitVersion)) }}
-    {{- if not (hasKey .annotations "kubernetes.io/ingress.class") }}
-    {{- $_ := set .annotations "kubernetes.io/ingress.class" .className}}
+    {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
+    {{- $_ := set $annotations "kubernetes.io/ingress.class" .className}}
     {{- end }}
     {{- end }}
     {{- if .certManager }}
     {{- if .certManager.issuer }}
-    {{- $_ := set .annotations "cert-manager.io/issuer" .certManager.issuer}}
+    {{- $_ := set $annotations "cert-manager.io/issuer" .certManager.issuer}}
     {{- end }}
     {{- if .certManager.clusterIssuer }}
-    {{- $_ := set .annotations "cert-manager.io/cluster-issuer" .certManager.clusterIssuer}}
+    {{- $_ := set $annotations "cert-manager.io/cluster-issuer" .certManager.clusterIssuer}}
     {{- end }}
     {{- end }}
-    {{- with .annotations }}
+    {{- with $annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:

--- a/charts/tractusx-connector/templates/ingress-dataplane.yaml
+++ b/charts/tractusx-connector/templates/ingress-dataplane.yaml
@@ -29,6 +29,7 @@
 {{- range .Values.dataplane.ingresses }}
 {{- if and .enabled .endpoints }}
 {{- $dataIngressName := printf "%s-dataplane-%s" $fullName .hostname }}
+{{- $annotations := .annotations | default dict }}
 ---
 {{- if semverCompare ">=1.19-0" $gitVersion }}
 apiVersion: networking.k8s.io/v1
@@ -45,19 +46,19 @@ metadata:
     {{- $dataLabels | nindent 2 }}
   annotations:
     {{- if and .className (not (semverCompare ">=1.18-0" $gitVersion)) }}
-    {{- if not (hasKey .annotations "kubernetes.io/ingress.class") }}
-    {{- $_ := set .annotations "kubernetes.io/ingress.class" .className}}
+    {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
+    {{- $_ := set $annotations "kubernetes.io/ingress.class" .className}}
     {{- end }}
     {{- end }}
     {{- if .certManager }}
     {{- if .certManager.issuer }}
-    {{- $_ := set .annotations "cert-manager.io/issuer" .certManager.issuer}}
+    {{- $_ := set $annotations "cert-manager.io/issuer" .certManager.issuer}}
     {{- end }}
     {{- if .certManager.clusterIssuer }}
-    {{- $_ := set .annotations "cert-manager.io/cluster-issuer" .certManager.clusterIssuer}}
+    {{- $_ := set $annotations "cert-manager.io/cluster-issuer" .certManager.clusterIssuer}}
     {{- end }}
     {{- end }}
-    {{- with .annotations }}
+    {{- with $annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:


### PR DESCRIPTION
## WHAT

If in a `ingresses` item list element no `annotations` key is given the templating fails.
Then a empty dictionary `{}` needs to be passed.

```yaml
dataplane:
  ingresses:
    - enabled: true
      hostname: "edc-data.local"
      annotations: {} # <-- required
```

This PR will change that - and will allow to omit this value if not required.
Inside the templating a variable will used to set a default (empty dict) if no annotations are given.

## WHY

If no `dataplane.ingresses[*].annotations` is set following error message will be returned when Helm chart is templated:

> Error: template: tractusx-connector/templates/ingress-dataplane.yaml:57:18: executing "tractusx-connector/templates/ingress-dataplane.yaml" at <.annotations>: wrong type for value; expected map[string]interface {}; got interface {}

## FURTHER NOTES

This also occurs for controlplane.
The changes are made for every chart (tractusx-connector, tractusx-connector-azure-vault, tractusx-connector-memory).
