### PR TITLE
chore(helm): fix tractusx-connector chart install cmd

### DIFF
--- a/charts/tractusx-connector/README.md.gotmpl
+++ b/charts/tractusx-connector/README.md.gotmpl
@@ -36,7 +36,7 @@ Combined, run this shell command to start the in-memory Tractus-X EDC runtime:
 
 ```shell
 helm repo add tractusx-edc https://eclipse-tractusx.github.io/charts/dev
-helm install my-release tractusx-edc/tractusx-connector-azure-vault --version {{ .Version }} \
+helm install my-release tractusx-edc/tractusx-connector --version {{ .Version }} \
      -f <path-to>/tractusx-connector-test.yaml
 ```
 


### PR DESCRIPTION
## WHAT

Inside the `tractusx-connector` chart the wrong chart is referenced in the installations docs.
This PR will change the go-template to the correct chart name.


<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))