### PR TITLE
fix: wrong postgres env vars for deployment templates

### DIFF
--- a/charts/tractusx-connector-azure-vault/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/deployment-controlplane.yaml
@@ -178,9 +178,9 @@ spec:
             - name: "EDC_DATASOURCE_ASSET_NAME"
               value: "asset"
             - name: "EDC_DATASOURCE_ASSET_USER"
-              value: {{ .Values.postgresql.username | required ".Values.postgresql.username is required" | quote }}
+              value: {{ .Values.postgresql.auth.username | required ".Values.postgresql.auth.username is required" | quote }}
             - name: "EDC_DATASOURCE_ASSET_PASSWORD"
-              value: {{ .Values.postgresql.password | required ".Values.postgresql.password is required" | quote }}
+              value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_ASSET_URL"
               value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
 
@@ -188,9 +188,9 @@ spec:
             - name: "EDC_DATASOURCE_CONTRACTDEFINITION_NAME"
               value: "contractdefinition"
             - name: "EDC_DATASOURCE_CONTRACTDEFINITION_USER"
-              value: {{ .Values.postgresql.username | required ".Values.postgresql.username is required" | quote }}
+              value: {{ .Values.postgresql.auth.username | required ".Values.postgresql.auth.username is required" | quote }}
             - name: "EDC_DATASOURCE_CONTRACTDEFINITION_PASSWORD"
-              value: {{ .Values.postgresql.password | required ".Values.postgresql.password is required" | quote }}
+              value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_CONTRACTDEFINITION_URL"
               value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
 
@@ -198,9 +198,9 @@ spec:
             - name: "EDC_DATASOURCE_CONTRACTNEGOTIATION_NAME"
               value: "contractnegotiation"
             - name: "EDC_DATASOURCE_CONTRACTNEGOTIATION_USER"
-              value: {{ .Values.postgresql.username | required ".Values.postgresql.username is required" | quote }}
+              value: {{ .Values.postgresql.auth.username | required ".Values.postgresql.auth.username is required" | quote }}
             - name: "EDC_DATASOURCE_CONTRACTNEGOTIATION_PASSWORD"
-              value: {{ .Values.postgresql.password | required ".Values.postgresql.password is required" | quote }}
+              value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_CONTRACTNEGOTIATION_URL"
               value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
 
@@ -208,9 +208,9 @@ spec:
             - name: "EDC_DATASOURCE_POLICY_NAME"
               value: "policy"
             - name: "EDC_DATASOURCE_POLICY_USER"
-              value: {{ .Values.postgresql.username | required ".Values.postgresql.username is required" | quote }}
+              value: {{ .Values.postgresql.auth.username | required ".Values.postgresql.auth.username is required" | quote }}
             - name: "EDC_DATASOURCE_POLICY_PASSWORD"
-              value: {{ .Values.postgresql.password | required ".Values.postgresql.password is required" | quote }}
+              value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_POLICY_URL"
               value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
 
@@ -218,9 +218,9 @@ spec:
             - name: "EDC_DATASOURCE_TRANSFERPROCESS_NAME"
               value: "transferprocess"
             - name: "EDC_DATASOURCE_TRANSFERPROCESS_USER"
-              value: {{ .Values.postgresql.username | required ".Values.postgresql.username is required" | quote }}
+              value: {{ .Values.postgresql.auth.username | required ".Values.postgresql.auth.username is required" | quote }}
             - name: "EDC_DATASOURCE_TRANSFERPROCESS_PASSWORD"
-              value: {{ .Values.postgresql.password | required ".Values.postgresql.password is required" | quote }}
+              value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_TRANSFERPROCESS_URL"
               value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
 
@@ -228,9 +228,9 @@ spec:
             - name: "EDC_DATASOURCE_EDR_NAME"
               value: "edr"
             - name: "EDC_DATASOURCE_EDR_USER"
-              value: {{ .Values.postgresql.username | required ".Values.postgresql.username is required" | quote }}
+              value: {{ .Values.postgresql.auth.username | required ".Values.postgresql.auth.username is required" | quote }}
             - name: "EDC_DATASOURCE_EDR_PASSWORD"
-              value: {{ .Values.postgresql.password | required ".Values.postgresql.password is required" | quote }}
+              value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_EDR_URL"
               value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
 

--- a/charts/tractusx-connector-azure-vault/templates/deployment-dataplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/deployment-dataplane.yaml
@@ -155,9 +155,9 @@ spec:
             - name: "EDC_DATASOURCE_EDR_NAME"
               value: "edr"
             - name: "EDC_DATASOURCE_EDR_USER"
-              value: {{ .Values.postgresql.username | required ".Values.postgresql.username is required" | quote }}
+              value: {{ .Values.postgresql.auth.username | required ".Values.postgresql.auth.username is required" | quote }}
             - name: "EDC_DATASOURCE_EDR_PASSWORD"
-              value: {{ .Values.postgresql.password | required ".Values.postgresql.password is required" | quote }}
+              value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_EDR_URL"
               value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
 

--- a/charts/tractusx-connector/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-controlplane.yaml
@@ -228,9 +228,9 @@ spec:
             - name: "EDC_DATASOURCE_EDR_NAME"
               value: "edr"
             - name: "EDC_DATASOURCE_EDR_USER"
-              value: {{ .Values.postgresql.username | required ".Values.postgresql.username is required" | quote }}
+              value: {{ .Values.postgresql.auth.username | required ".Values.postgresql.auth.username is required" | quote }}
             - name: "EDC_DATASOURCE_EDR_PASSWORD"
-              value: {{ .Values.postgresql.password | required ".Values.postgresql.password is required" | quote }}
+              value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_EDR_URL"
               value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
 

--- a/charts/tractusx-connector/templates/deployment-dataplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-dataplane.yaml
@@ -155,9 +155,9 @@ spec:
             - name: "EDC_DATASOURCE_EDR_NAME"
               value: "edr"
             - name: "EDC_DATASOURCE_EDR_USER"
-              value: {{ .Values.postgresql.username | required ".Values.postgresql.username is required" | quote }}
+              value: {{ .Values.postgresql.auth.username | required ".Values.postgresql.auth.username is required" | quote }}
             - name: "EDC_DATASOURCE_EDR_PASSWORD"
-              value: {{ .Values.postgresql.password | required ".Values.postgresql.password is required" | quote }}
+              value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_EDR_URL"
               value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
 


### PR DESCRIPTION
## WHAT

Fixes the environment variables in some deployment templates where the wrong postgres creds values were used.

## WHY

Helm Charts currently unusable.

## FURTHER NOTES

Closes #463
