### PR TITLE
Remove catenax references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ conceived from the outset as an open network with solutions ready for SMEs,
 where these companies will be able to participate quickly and with little IT
 infrastructure investment. Tractus-X is meant to be the PoC project of the
 Catena-X alliance focusing on parts traceability.
+ <!-- TODO: Can this reference stay? -->
 
 * <https://projects.eclipse.org/projects/automotive.tractusx>
 

--- a/docs/kit/adoption-view/page_adoption-view.md
+++ b/docs/kit/adoption-view/page_adoption-view.md
@@ -28,7 +28,7 @@ The [EDC][edc-url] as a connector implements a framework agreement for sovereign
 
 The objective is to set up a decentralized software component on the part of the respective partner, which bundles the skills required to participate in a data room and enables peer-to-peer connections between participants.
 The focus here is particularly on the data sovereignty of the independent companies.
-The functionality required for this is bundled in the open-source project "Eclipse Dataspace Connectors", to which the Catena-X partners contribute as part of the Eclipse Foundation.
+The functionality required for this is bundled in the open-source project "Eclipse Dataspace Connector", to which members of the Eclipse Foundation contribute.
 
 The main difference between the EDC and the previous connectors of the [IDSA][idsa-url] is the separation of the communication into a channel for the metadata and one for the actual data exchange. The channel for the data supports various transmission protocols via so-called data plane extensions. The metadata is transmitted directly via the EDC interface, while the actual data exchange then takes place via the appropriate channel extension. In this way, a highly scalable data exchange is made possible.
 

--- a/docs/kit/operation-view/page03_local_setup_controlplane.md
+++ b/docs/kit/operation-view/page03_local_setup_controlplane.md
@@ -63,7 +63,7 @@ edc.hostname=localhost
 edc.api.auth.key=password
 
 # OAuth / DAPS related configuration
-edc.oauth.token.url=https://daps.catena-x.net
+edc.oauth.token.url=https://daps.example.net
 edc.oauth.certificate.alias=key-to-daps-certificate-in-keyvault
 edc.oauth.private.key.alias=key-to-private-key-in-keyvault
 edc.oauth.client.id=daps-oauth-client-id

--- a/docs/migration/Version_0.0.x_0.1.x.md
+++ b/docs/migration/Version_0.0.x_0.1.x.md
@@ -298,7 +298,7 @@ must be renamed to `edc.dataplane.token.validation.endpoint`.
 ### 3.2 DataPlane Selector
 
 With this version a new feature was introduced which allows to have separate DataPlane instances for different
-transfer-flows (HttpProxy, S3, etc.). The Catena-X EDC team has additionally a new extension created which allows a
-simpler registration of additional dataplanes. Therefor some changes needs to be applied. Further documentation can
+transfer-flows (HttpProxy, S3, etc.). The Tractus-X EDC also has a new extension which allows for a
+simpler registration of additional dataplanes. Further documentation can
 be found in the extension folder:
 [dataplane-selector-configuration](../../edc-extensions/dataplane-selector-configuration/README.md)

--- a/docs/release-notes/Version 0.1.1.md
+++ b/docs/release-notes/Version 0.1.1.md
@@ -29,7 +29,7 @@ The following extensions are now included in the base image of the connector.
 
 ### 2.1 CX IAM OAuth2 Extension
 
-Using the open source OAuth Extension it is possible for a connector to re-use an IDS DAPS Token and forge the own identity (replay attack). To mitigate the security issue for the upcoming release Catena-X introduces its own OAuth2 IAM Extension. Except for the audience, the IAM configuration stays similar.
+Using the open source OAuth Extension it is possible for a connector to re-use an IDS DAPS Token and forge the own identity (replay attack). To mitigate the security issue for the upcoming release Tractus-X introduces its own OAuth2 IAM Extension. Except for the audience, the IAM configuration stays similar.
 
 [Documentation](../../edc-extensions/cx-oauth2/README.md)
 

--- a/edc-controlplane/edc-controlplane-postgresql-azure-vault/README.md
+++ b/edc-controlplane/edc-controlplane-postgresql-azure-vault/README.md
@@ -35,7 +35,7 @@ Details regarding each configuration property can be found at the [documentary s
 | edc.ids.catalog.id                               |          | urn:catalog:default                                                          |                            |
 | ids.webhook.address                              |          | <http://localhost:8282/api/v1/ids>                                           |                            |
 | edc.hostname                                     |          | localhost                                                                    |                            |
-| edc.oauth.token.url                              | X        | <https://daps.catena-x.net>                                                  |                            |
+| edc.oauth.token.url                              | X        | <https://daps.example.net>                                                   |                            |
 | edc.oauth.public.key.alias                       | X        | key-to-daps-certificate-in-keyvault                                          |                            |
 | edc.oauth.private.key.alias                      | X        | key-to-private-key-in-keyvault                                               |                            |
 | edc.oauth.client.id                              | X        | daps-oauth-client-id                                                         |                            |
@@ -103,7 +103,7 @@ edc.hostname=localhost
 edc.api.auth.key=password
 
 # OAuth / DAPS related configuration
-edc.oauth.token.url=https://daps.catena-x.net
+edc.oauth.token.url=https://daps.example.net
 edc.oauth.public.key.alias=key-to-daps-certificate-in-keyvault
 edc.oauth.private.key.alias=key-to-private-key-in-keyvault
 edc.oauth.client.id=daps-oauth-client-id

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/README.md
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/README.md
@@ -35,7 +35,7 @@ Details regarding each configuration property can be found at the [documentary s
 | edc.ids.catalog.id                               |          | urn:catalog:default                                                          |                            |
 | ids.webhook.address                              |          | <http://localhost:8282/api/v1/ids>                                           |                            |
 | edc.hostname                                     |          | localhost                                                                    |                            |
-| edc.oauth.token.url                              | X        | <https://daps.catena-x.net>                                                  |                            |
+| edc.oauth.token.url                              | X        | <https://daps.example.net>                                                   |                            |
 | edc.oauth.public.key.alias                       | X        | key-to-daps-certificate-in-keyvault                                          |                            |
 | edc.oauth.private.key.alias                      | X        | key-to-private-key-in-keyvault                                               |                            |
 | edc.oauth.client.id                              | X        | daps-oauth-client-id                                                         |                            |
@@ -102,7 +102,7 @@ edc.hostname=localhost
 edc.api.auth.key=password
 
 # OAuth / DAPS related configuration
-edc.oauth.token.url=https://daps.catena-x.net
+edc.oauth.token.url=https://daps.example.net
 edc.oauth.public.key.alias=key-to-daps-certificate-in-keyvault
 edc.oauth.private.key.alias=key-to-private-key-in-keyvault
 edc.oauth.client.id=daps-oauth-client-id

--- a/edc-controlplane/edc-runtime-memory/README.md
+++ b/edc-controlplane/edc-runtime-memory/README.md
@@ -48,7 +48,7 @@ the [documentary section of the EDC](https://github.com/eclipse-edc/Connector/tr
 | edc.ids.catalog.id                               |          | urn:catalog:default                 |                            |
 | ids.webhook.address                              |          | <http://localhost:8282/api/v1/ids>  |                            |
 | edc.hostname                                     |          | localhost                           |                            |
-| edc.oauth.token.url                              | X        | <https://daps.catena-x.net>         |                            |
+| edc.oauth.token.url                              | X        | <https://daps.example.net>          |                            |
 | edc.oauth.public.key.alias                       | X        | key-to-daps-certificate-in-keyvault |                            |
 | edc.oauth.private.key.alias                      | X        | key-to-private-key-in-keyvault      |                            |
 | edc.oauth.client.id                              | X        | daps-oauth-client-id                |                            |
@@ -93,7 +93,7 @@ edc.hostname=localhost
 edc.api.auth.key=password
 
 # OAuth / DAPS related configuration
-edc.oauth.token.url=https://daps.catena-x.net
+edc.oauth.token.url=https://daps.example.net
 edc.oauth.public.key.alias=key-to-daps-certificate-in-keyvault
 edc.oauth.private.key.alias=key-to-private-key-in-keyvault
 edc.oauth.client.id=daps-oauth-client-id

--- a/edc-extensions/business-partner-validation/README.md
+++ b/edc-extensions/business-partner-validation/README.md
@@ -1,7 +1,7 @@
 # Business Partner Validation Extension
 
 Using the Business Partner Validation Extension it's possible to add configurable validation against
-Catena-X `Participants` in the `ContractDefinition.AccessPolicy`. Using a BPN in `ContractDefinition.ContractPolicy` is possible, too, but once the contract is complete there is no policy enforcement in place from the EDC.
+BPNs in the `ContractDefinition.AccessPolicy`. Using a BPN in `ContractDefinition.ContractPolicy` is possible, too, but once the contract is complete there is no policy enforcement in place from the EDC.
 
 It is recommended to have a basic understanding of the EDC contract/policy domain before using this extension. The
 corresponding documentation can be found in the [EDC GitHub Repository](https://github.com/eclipse-edc/Connector).
@@ -73,7 +73,7 @@ It will permit the constraints contained to be evaluated using the `OR` operator
     {
       "edctype": "dataspaceconnector:permission",
       "action": {
-        "type": "USE",
+        "type": "USE"
       },
       "constraints": [
         {

--- a/edc-extensions/cx-oauth2/README.md
+++ b/edc-extensions/cx-oauth2/README.md
@@ -1,6 +1,6 @@
-# Catena-X OAuth2 Extension
+# Tractus-X OAuth2 Extension
 
-## Why Catena-X needs this extension
+## Why Tractus-X needs this extension
 
 In IDS the DAPS token audience is always `idsc:IDS_CONNECTORS_ALL`. At first glance this makes it possible for other connectors to steal and reuse an received token. To mitigate this security risk IDS introduces something called `transportCertsSha256`, which couples the connector audience with its corresponding TLS/SSL certificate.
 
@@ -8,7 +8,7 @@ From [GitHub IDS-G](https://github.com/International-Data-Spaces-Association/IDS
 
 > - **transportCertsSha256** Contains the public keys of the used transport certificates, hashed using SHA256. The identifying X509 certificate should not be used for the communication encryption. Therefore, the receiving party needs to connect the identity of a connector by relating its hostname (from the communication encryption layer) and the used private/public key pair, with its IDS identity claim of the DAT. The public transportation key must be one of the `transportCertsSha256` values. Otherwise, the receiving connector must expect that the requesting connector is using a false identity claim. In general, this claim holds an Array of Strings, but it may optionally hold a single String instead if the Array would have exactly one element.
 
-The reason IDS did this is to prevent the IDS DAPS to know, which connectors talk to each other. But this solution introduces a new level of complexity for different deployment scenarios. The Catena-X OAuth2 Extension introduces the classic audience validation again, so that Catena-X does not have to deal with these things for now.
+The reason IDS did this is to prevent the IDS DAPS to know, which connectors talk to each other. But this solution introduces a new level of complexity for different deployment scenarios. The OAuth2 Extension introduces the classic audience validation again, so that users do not have to deal with these things for now.
 
 ## Configuration
 
@@ -32,12 +32,12 @@ When a connector receives a message, it will checks the token audience is equal 
 
 ![sequence diagram](./diagrams/sequence.png)
 
-## Catena-X Participant Extension
+##  Participant Extension
 
 Starting from `0.0.1-milestone-9` EDC requires a mandatory setting `edc.participant.id`, which in this case should be the BPN number which is transmitted over the wire to identifying the participants IDs.
 To verify that in the DAPS token an extension has been created, that extract from the `ClaimToken` the BPN number and then EDC compare that identity with the one provided over the wire, for security reason.
 
-By default the extension parse the `referringConnector` url and extract the BPN number as the last parameter in the URL eg (http://sokrates-controlplane/BPNSOKRATES).
+By default, the extension parse the `referringConnector` url and extract the BPN number as the last parameter in the URL eg (http://sokrates-controlplane/BPNSOKRATES).
 
 ### Configuration
 

--- a/edc-extensions/hashicorp-vault/README.md
+++ b/edc-extensions/hashicorp-vault/README.md
@@ -30,9 +30,9 @@ with level _WARNING_.
 
 ---
 
-### Health Checks in Catena-X
+### Health Checks
 
-If your project uses the Catena-X HashiCorp Vault please set `edc.vault.hashicorp.health.check.standby.ok` to _true_. Otherwise the health check would fail if the Vault is in standby.
+If your project uses the Tractus-X HashiCorp Vault please set `edc.vault.hashicorp.health.check.standby.ok` to _true_. Otherwise, the health check would fail if the Vault is in standby.
 
 ```plain
 # Logs of successful check with standby vault
@@ -90,14 +90,14 @@ or
 edc.oauth.private.key.alias=my-daps-key
 ```
 
-## Example: Catena-X Argo CD Vault Configuration
+## Example: Argo CD Vault Configuration
 
 ```properties
 #########
 # Vault #
 #########
 
-edc.vault.hashicorp.url=https://vault.demo.catena-x.net
+edc.vault.hashicorp.url=https://vault.demo.tractus-x.net
 # or even better configure token as k8 secret
 edc.vault.hashicorp.token=<token>
 edc.vault.hashicorp.api.secret.path=/v1/<tenant>/
@@ -107,6 +107,6 @@ edc.vault.hashicorp.health.check.standby.ok=true
 # E.g. OAuth Extension #
 ########################
 
-# from UI: secret stored in https://vault.demo.catena-x.net/ui/vault/secrets/<tenant>/show/my-daps-key
+# from UI: secret stored in https://vault.demo.tractus-x.net/ui/vault/secrets/<tenant>/show/my-daps-key
 edc.oauth.private.key.alias=my-daps-key
 ```


### PR DESCRIPTION
## WHAT

Removes obsolete references to catena-x

## WHY

For legal reasons, I assume.

## FURTHER NOTES


Closes #271
