### PR TITLE
docs: add decision record about the use of iron-verifiable-credentials

### DIFF
--- a/docs/development/decision-records/2023-06-13_use_of_iron_library/README.md
+++ b/docs/development/decision-records/2023-06-13_use_of_iron_library/README.md
@@ -1,0 +1,22 @@
+# Usage of `iron-verifiable-credentials`
+
+## Decision
+
+Tractus-X EDC will use the [iron-verifiable-credentials](https://github.com/filip26/iron-verifiable-credentials) library
+for all processing of VerifiableCredentials and VerifiablePresentations.
+
+## Rationale
+
+The Eclipse Dataspaces Components project uses iron's sister
+library, [titanium-json-ld](https://github.com/filip26/titanium-json-ld/) for processing JSON-LD, which achieves close
+to 100% of conformance with the JSON-LD specification.
+
+It thus stands to reason that we use `iron-verifiable-credentials`, because it supports issuing/verifying VCs/VPs, has
+support for JSON-LD (internally it also uses `titanium-json-ld`) and otherwise has a very light dependency footprint.
+which means high runtime type compatibility can be expected and minimal mapping/compatibility layers are needed. Crypto
+suites are pluggable, so in addition to `iron-ed25519-cryptosuite-2020`, which is also provided, we will implement
+support for `JsonWebKey2020` which was mandated by the Catena-X consortium.
+
+## Approach
+
+- add support for `JsonWebKey2020` to Tractus-X EDC using `iron-verifiable-credentials`.


### PR DESCRIPTION
## WHAT

Adds a decision record mandating the use of `iron-verifiable-credentials`.

## WHY

traceable decisions.

## FURTHER NOTES

.

Closes # <-- _insert Issue number if one exists_
