### PR TITLE
feat(helm): use release.name inside vault dependency

### DIFF
--- a/charts/tractusx-connector/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-controlplane.yaml
@@ -268,7 +268,7 @@ spec:
 
             # see extension https://github.com/eclipse-tractusx/tractusx-edc/tree/main/edc-extensions/hashicorp-vault
             - name: "EDC_VAULT_HASHICORP_URL"
-              value: {{ .Values.vault.hashicorp.url | required ".Values.vault.hashicorp.url is required" | quote }}
+              value: {{ tpl .Values.vault.hashicorp.url . | quote }}
             - name: "EDC_VAULT_HASHICORP_TOKEN"
               value: {{ .Values.vault.hashicorp.token | required ".Values.vault.hashicorp.token is required" | quote }}
             - name: "EDC_VAULT_HASHICORP_TIMEOUT_SECONDS"

--- a/charts/tractusx-connector/templates/deployment-dataplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-dataplane.yaml
@@ -167,7 +167,7 @@ spec:
 
             # see extension https://github.com/eclipse-tractusx/tractusx-edc/tree/main/edc-extensions/hashicorp-vault
             - name: "EDC_VAULT_HASHICORP_URL"
-              value: {{ .Values.vault.hashicorp.url | required ".Values.vault.hashicorp.url is required" | quote }}
+              value: {{ tpl .Values.vault.hashicorp.url . | quote }}
             - name: "EDC_VAULT_HASHICORP_TOKEN"
               value: {{ .Values.vault.hashicorp.token | required ".Values.vault.hashicorp.token is required" | quote }}
             - name: "EDC_VAULT_HASHICORP_TIMEOUT_SECONDS"

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -502,7 +502,6 @@ postgresql:
     username: "user"
     password: "password"
 vault:
-  fullnameOverride: "vault"
   injector:
     enabled: false
   server:
@@ -512,7 +511,7 @@ vault:
     # Must be the same certificate that is configured in section 'daps'
     postStart:    # must be set externally!
   hashicorp:
-    url: ""
+    url: "http://{{ .Release.Name }}-vault:8200"
     token: ""
     timeout: 30
     healthCheck:

--- a/edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml
+++ b/edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml
@@ -63,7 +63,7 @@ postgresql:
 
 vault:
   hashicorp:
-    url: http://vault:8200
+    url: http://{{ .Release.Name }}-vault:8200
     token: root
 
   secretNames:


### PR DESCRIPTION
## WHAT

This PR changes the HashiCorp Vault url behavior.
Instead of using a `fullnameOverride` to set the service name fix to `vault` the name is now including the `.Release.Name` variable.

## WHY

This helps Helm chart users to deploy multiple separate instances of the tractusx-connector chart in the same namespace.
Also the naming convention of pods / services will follow the others.

## FURTHER NOTES

```bash
$ kubectl get pod # without PR change
NAME                                                         READY   STATUS    RESTARTS   AGE
daps-7677896f79-rkpzl                                        0/1     Running   0          5s
myrelease-tractusx-connector-controlplane-86784bc6c4-rxcdx   0/1     Running   0          5s
myrelease-tractusx-connector-dataplane-7964df994-jqx2d       0/1     Running   0          5s
postgresql-0                                                 0/1     Running   0          5s
vault-0                                                      0/1     Running   0          5s
```

```bash
$ kubectl get pod # with all PRs
NAME                                                         READY   STATUS    RESTARTS   AGE
myrelease-daps-7677896f79-mr7h7                              0/1     Running   0          4s
myrelease-postgresql-0                                       0/1     Running   0          4s
myrelease-tractusx-connector-controlplane-768d4447d4-7qd55   0/1     Running   0          4s
myrelease-tractusx-connector-dataplane-7b79b5dc58-h8b9j      0/1     Running   0          4s
myrelease-vault-0                                            0/1     Running   0          4s
```

### OTHER PRs

- daps: #475
- psql: #474

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))