### PR TITLE
feat(helm): use release.name inside psql dependency

### DIFF
--- a/charts/tractusx-connector-azure-vault/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/deployment-controlplane.yaml
@@ -182,7 +182,7 @@ spec:
             - name: "EDC_DATASOURCE_ASSET_PASSWORD"
               value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_ASSET_URL"
-              value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
+              value: {{ tpl .Values.postgresql.jdbcUrl . | quote }}
 
             # see extension https://github.com/eclipse-edc/Connector/tree/main/extensions/control-plane/store/sql/contract-definition-store-sql
             - name: "EDC_DATASOURCE_CONTRACTDEFINITION_NAME"
@@ -192,7 +192,7 @@ spec:
             - name: "EDC_DATASOURCE_CONTRACTDEFINITION_PASSWORD"
               value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_CONTRACTDEFINITION_URL"
-              value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
+              value: {{ tpl .Values.postgresql.jdbcUrl . | quote }}
 
             # see extension https://github.com/eclipse-edc/Connector/tree/main/extensions/control-plane/store/sql/contract-negotiation-store-sql
             - name: "EDC_DATASOURCE_CONTRACTNEGOTIATION_NAME"
@@ -202,7 +202,7 @@ spec:
             - name: "EDC_DATASOURCE_CONTRACTNEGOTIATION_PASSWORD"
               value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_CONTRACTNEGOTIATION_URL"
-              value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
+              value: {{ tpl .Values.postgresql.jdbcUrl . | quote }}
 
             # see extension https://github.com/eclipse-edc/Connector/tree/main/extensions/control-plane/store/sql/policy-store-sql
             - name: "EDC_DATASOURCE_POLICY_NAME"
@@ -212,7 +212,7 @@ spec:
             - name: "EDC_DATASOURCE_POLICY_PASSWORD"
               value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_POLICY_URL"
-              value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
+              value: {{ tpl .Values.postgresql.jdbcUrl . | quote }}
 
             # see extension https://github.com/eclipse-edc/Connector/tree/main/extensions/control-plane/store/sql/transfer-process-store-sql
             - name: "EDC_DATASOURCE_TRANSFERPROCESS_NAME"
@@ -222,7 +222,7 @@ spec:
             - name: "EDC_DATASOURCE_TRANSFERPROCESS_PASSWORD"
               value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_TRANSFERPROCESS_URL"
-              value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
+              value: {{ tpl .Values.postgresql.jdbcUrl . | quote }}
 
             # see extension https://github.com/eclipse-tractusx/tractusx-edc/tree/main/edc-extensions/edr-cache-sql
             - name: "EDC_DATASOURCE_EDR_NAME"
@@ -232,7 +232,7 @@ spec:
             - name: "EDC_DATASOURCE_EDR_PASSWORD"
               value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_EDR_URL"
-              value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
+              value: {{ tpl .Values.postgresql.jdbcUrl . | quote }}
 
             ################
             ## DATA PLANE ##

--- a/charts/tractusx-connector-azure-vault/values.yaml
+++ b/charts/tractusx-connector-azure-vault/values.yaml
@@ -495,8 +495,7 @@ dataplane:
     public: ""
 
 postgresql:
-  jdbcUrl: ""
-  fullnameOverride: "postgresql"
+  jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/edc"
   primary:
     persistence:
   enabled: false

--- a/charts/tractusx-connector/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-controlplane.yaml
@@ -182,7 +182,7 @@ spec:
             - name: "EDC_DATASOURCE_ASSET_PASSWORD"
               value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_ASSET_URL"
-              value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
+              value: {{ tpl .Values.postgresql.jdbcUrl . | quote }}
 
             # see extension https://github.com/eclipse-edc/Connector/tree/main/extensions/control-plane/store/sql/contract-definition-store-sql
             - name: "EDC_DATASOURCE_CONTRACTDEFINITION_NAME"
@@ -192,7 +192,7 @@ spec:
             - name: "EDC_DATASOURCE_CONTRACTDEFINITION_PASSWORD"
               value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_CONTRACTDEFINITION_URL"
-              value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
+              value: {{ tpl .Values.postgresql.jdbcUrl . | quote }}
 
             # see extension https://github.com/eclipse-edc/Connector/tree/main/extensions/control-plane/store/sql/contract-negotiation-store-sql
             - name: "EDC_DATASOURCE_CONTRACTNEGOTIATION_NAME"
@@ -202,7 +202,7 @@ spec:
             - name: "EDC_DATASOURCE_CONTRACTNEGOTIATION_PASSWORD"
               value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_CONTRACTNEGOTIATION_URL"
-              value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
+              value: {{ tpl .Values.postgresql.jdbcUrl . | quote }}
 
             # see extension https://github.com/eclipse-edc/Connector/tree/main/extensions/control-plane/store/sql/policy-store-sql
             - name: "EDC_DATASOURCE_POLICY_NAME"
@@ -212,7 +212,7 @@ spec:
             - name: "EDC_DATASOURCE_POLICY_PASSWORD"
               value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_POLICY_URL"
-              value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
+              value: {{ tpl .Values.postgresql.jdbcUrl . | quote }}
 
             # see extension https://github.com/eclipse-edc/Connector/tree/main/extensions/control-plane/store/sql/transfer-process-store-sql
             - name: "EDC_DATASOURCE_TRANSFERPROCESS_NAME"
@@ -222,7 +222,7 @@ spec:
             - name: "EDC_DATASOURCE_TRANSFERPROCESS_PASSWORD"
               value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_TRANSFERPROCESS_URL"
-              value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
+              value: {{ tpl .Values.postgresql.jdbcUrl . | quote }}
 
             # see extension https://github.com/eclipse-tractusx/tractusx-edc/tree/main/edc-extensions/edr-cache-sql
             - name: "EDC_DATASOURCE_EDR_NAME"
@@ -232,7 +232,7 @@ spec:
             - name: "EDC_DATASOURCE_EDR_PASSWORD"
               value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_EDR_URL"
-              value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
+              value: {{ tpl .Values.postgresql.jdbcUrl . | quote }}
 
             ################
             ## DATA PLANE ##

--- a/charts/tractusx-connector/templates/deployment-dataplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-dataplane.yaml
@@ -159,7 +159,7 @@ spec:
             - name: "EDC_DATASOURCE_EDR_PASSWORD"
               value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
             - name: "EDC_DATASOURCE_EDR_URL"
-              value: {{ .Values.postgresql.jdbcUrl | required ".Values.postgresql.jdbcUrl is required" | quote }}
+              value: {{ tpl .Values.postgresql.jdbcUrl . | quote }}
 
             ###########
             ## VAULT ##

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -489,8 +489,7 @@ dataplane:
     # -- Explicitly declared url for reaching the public api (e.g. if ingresses not used)
     public: ""
 postgresql:
-  jdbcUrl: ""
-  fullnameOverride: "postgresql"
+  jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/edc"
   primary:
     persistence:
       enabled: false

--- a/edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml
+++ b/edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml
@@ -56,7 +56,7 @@ dataplane:
       accessKeyId: qwerty123
 
 postgresql:
-  jdbcUrl: jdbc:postgresql://postgresql:5432/edc
+  jdbcUrl: jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/edc
   auth:
     username: user
     password: password


### PR DESCRIPTION
## WHAT

This PR changes the psql url behavior.
Instead of using a `fullnameOverride` to set the service name fix to `postgresql` the name is now including the `.Release.Name` variable.

## WHY

This helps Helm chart users to deploy multiple separate instances of the tractusx-connector chart in the same namespace.
Also the naming convention of pods / services will follow the others.

## FURTHER NOTES

```bash
$ kubectl get pod # without PR change
NAME                                                         READY   STATUS    RESTARTS   AGE
daps-7677896f79-rkpzl                                        0/1     Running   0          5s
myrelease-tractusx-connector-controlplane-86784bc6c4-rxcdx   0/1     Running   0          5s
myrelease-tractusx-connector-dataplane-7964df994-jqx2d       0/1     Running   0          5s
postgresql-0                                                 0/1     Running   0          5s
vault-0                                                      0/1     Running   0          5s
```

```bash
$ kubectl get pod # with all PRs
NAME                                                         READY   STATUS    RESTARTS   AGE
myrelease-daps-7677896f79-mr7h7                              0/1     Running   0          4s
myrelease-postgresql-0                                       0/1     Running   0          4s
myrelease-tractusx-connector-controlplane-768d4447d4-7qd55   0/1     Running   0          4s
myrelease-tractusx-connector-dataplane-7b79b5dc58-h8b9j      0/1     Running   0          4s
myrelease-vault-0                                            0/1     Running   0          4s
```

### OTHER PRs

- daps: #475
- vault: #473

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))