### PR TITLE
feat(helm): use release.name inside daps dependency

### DIFF
--- a/charts/tractusx-connector-azure-vault/subcharts/omejdn/templates/configmap.yaml
+++ b/charts/tractusx-connector-azure-vault/subcharts/omejdn/templates/configmap.yaml
@@ -31,7 +31,7 @@ data:
 
   omejdn.yml: |-
     ---
-    host: http://daps:4567/
+    host: http://{{ .Release.Name }}-daps:4567/
     path_prefix: ''
     bind_to: 0.0.0.0
     allow_origin: "*"
@@ -41,7 +41,7 @@ data:
       - yaml
     user_backend_default: yaml
     accept_audience: idsc:IDS_CONNECTORS_ALL
-    issuer: http://daps:4567/
+    issuer: http://{{ .Release.Name }}-daps:4567/
     environment: development
     default_audience:
       - idsc:IDS_CONNECTORS_ALL

--- a/charts/tractusx-connector-azure-vault/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/deployment-controlplane.yaml
@@ -123,9 +123,9 @@ spec:
             - name: EDC_OAUTH_CLIENT_ID
               value: {{ .Values.daps.clientId | required ".Values.daps.clientId is required" | quote }}
             - name: EDC_OAUTH_PROVIDER_JWKS_URL
-              value: {{ printf "%s%s" .Values.daps.url .Values.daps.paths.jwks }}
+              value: {{ printf "%s%s" (tpl .Values.daps.url .) .Values.daps.paths.jwks }}
             - name: EDC_OAUTH_TOKEN_URL
-              value: {{ printf "%s%s" .Values.daps.url .Values.daps.paths.token }}
+              value: {{ printf "%s%s" (tpl .Values.daps.url .) .Values.daps.paths.token }}
             - name: EDC_OAUTH_PRIVATE_KEY_ALIAS
               value: {{ .Values.vault.secretNames.dapsPrivateKey | required ".Values.vault.secretNames.dapsPrivateKey is required" | quote }}
             - name: EDC_OAUTH_CERTIFICATE_ALIAS

--- a/charts/tractusx-connector-azure-vault/values.yaml
+++ b/charts/tractusx-connector-azure-vault/values.yaml
@@ -523,8 +523,7 @@ vault:
     dapsPublicKey: daps-public-key
 
 daps:
-  fullnameOverride: "daps"
-  url: ""
+  url: "http://{{ .Release.Name }}-daps:4567"
   clientId: ""
   paths:
     jwks: /jwks.json

--- a/charts/tractusx-connector-memory/example.yaml
+++ b/charts/tractusx-connector-memory/example.yaml
@@ -63,7 +63,7 @@ vault:
   secrets:
 
 daps:
-  url: "http://daps:4567"
+  url: "http://{{ .Release.Name }}-daps:4567"
   clientId: "99:83:A7:17:86:FF:98:93:CE:A0:DD:A1:F1:36:FA:F6:0F:75:0A:23:keyid:99:83:A7:17:86:FF:98:93:CE:A0:DD:A1:F1:36:FA:F6:0F:75:0A:23"
 
 backendService:

--- a/charts/tractusx-connector-memory/subcharts/omejdn/templates/configmap.yaml
+++ b/charts/tractusx-connector-memory/subcharts/omejdn/templates/configmap.yaml
@@ -31,7 +31,7 @@ data:
 
   omejdn.yml: |-
     ---
-    host: http://daps:4567/
+    host: http://{{ .Release.Name }}-daps:4567/
     path_prefix: ''
     bind_to: 0.0.0.0
     allow_origin: "*"
@@ -41,7 +41,7 @@ data:
       - yaml
     user_backend_default: yaml
     accept_audience: idsc:IDS_CONNECTORS_ALL
-    issuer: http://daps:4567/
+    issuer: http://{{ .Release.Name }}-daps:4567/
     environment: development
     default_audience:
       - idsc:IDS_CONNECTORS_ALL

--- a/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
+++ b/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
@@ -123,9 +123,9 @@ spec:
             - name: EDC_OAUTH_CLIENT_ID
               value: {{ .Values.daps.clientId | required ".Values.daps.clientId is required" | quote }}
             - name: EDC_OAUTH_PROVIDER_JWKS_URL
-              value: {{ printf "%s%s" .Values.daps.url .Values.daps.paths.jwks }}
+              value: {{ printf "%s%s" (tpl .Values.daps.url .) .Values.daps.paths.jwks }}
             - name: EDC_OAUTH_TOKEN_URL
-              value: {{ printf "%s%s" .Values.daps.url .Values.daps.paths.token }}
+              value: {{ printf "%s%s" (tpl .Values.daps.url .) .Values.daps.paths.token }}
             - name: EDC_OAUTH_PRIVATE_KEY_ALIAS
               value: {{ .Values.vault.secretNames.dapsPrivateKey | required ".Values.vault.secretNames.dapsPrivateKey is required" | quote }}
             - name: EDC_OAUTH_PUBLIC_KEY_ALIAS

--- a/charts/tractusx-connector-memory/values.yaml
+++ b/charts/tractusx-connector-memory/values.yaml
@@ -298,8 +298,7 @@ vault:
   server:
     postStart: |-
 daps:
-  fullnameOverride: "daps"
-  url: ""
+  url: "http://{{ .Release.Name }}-daps:4567"
   clientId: ""
   paths:
     jwks: /jwks.json

--- a/charts/tractusx-connector/subcharts/omejdn/templates/configmap.yaml
+++ b/charts/tractusx-connector/subcharts/omejdn/templates/configmap.yaml
@@ -31,7 +31,7 @@ data:
 
   omejdn.yml: |-
     ---
-    host: http://daps:4567/
+    host: http://{{ .Release.Name }}-daps:4567/
     path_prefix: ''
     bind_to: 0.0.0.0
     allow_origin: "*"
@@ -41,7 +41,7 @@ data:
       - yaml
     user_backend_default: yaml
     accept_audience: idsc:IDS_CONNECTORS_ALL
-    issuer: http://daps:4567/
+    issuer: http://{{ .Release.Name }}-daps:4567/
     environment: development
     default_audience:
       - idsc:IDS_CONNECTORS_ALL

--- a/charts/tractusx-connector/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-controlplane.yaml
@@ -123,9 +123,9 @@ spec:
             - name: EDC_OAUTH_CLIENT_ID
               value: {{ .Values.daps.clientId | required ".Values.daps.clientId is required" | quote }}
             - name: EDC_OAUTH_PROVIDER_JWKS_URL
-              value: {{ printf "%s%s" .Values.daps.url .Values.daps.paths.jwks }}
+              value: {{ printf "%s%s" (tpl .Values.daps.url .) .Values.daps.paths.jwks }}
             - name: EDC_OAUTH_TOKEN_URL
-              value: {{ printf "%s%s" .Values.daps.url .Values.daps.paths.token }}
+              value: {{ printf "%s%s" (tpl .Values.daps.url .) .Values.daps.paths.token }}
             - name: EDC_OAUTH_PRIVATE_KEY_ALIAS
               value: {{ .Values.vault.secretNames.dapsPrivateKey | required ".Values.vault.secretNames.dapsPrivateKey is required" | quote }}
             - name: EDC_OAUTH_CERTIFICATE_ALIAS

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -528,8 +528,7 @@ vault:
     dapsPrivateKey: daps-private-key
     dapsPublicKey: daps-public-key
 daps:
-  fullnameOverride: "daps"
-  url: ""
+  url: "http://{{ .Release.Name }}-daps:4567"
   clientId: ""
   paths:
     jwks: /jwks.json

--- a/docs/samples/example-dataspace/daps/templates/configmap.yaml
+++ b/docs/samples/example-dataspace/daps/templates/configmap.yaml
@@ -31,7 +31,7 @@ data:
 
   omejdn.yml: |-
     ---
-    host: http://daps:4567/
+    host: http://{{ .Release.Name }}-daps:4567/
     path_prefix: ''
     bind_to: 0.0.0.0
     allow_origin: "*"
@@ -41,7 +41,7 @@ data:
       - yaml
     user_backend_default: yaml
     accept_audience: idsc:IDS_CONNECTORS_ALL
-    issuer: http://daps:4567/
+    issuer: http://{{ .Release.Name }}-daps:4567/
     environment: development
     default_audience:
       - idsc:IDS_CONNECTORS_ALL

--- a/docs/samples/example-dataspace/plato-values.yaml
+++ b/docs/samples/example-dataspace/plato-values.yaml
@@ -72,7 +72,7 @@ vault:
     secrets:
   server:
 daps:
-  url: "http://daps:4567"
+  url: "http://{{ .Release.Name }}-daps:4567"
   clientId: "E7:07:2D:74:56:66:31:F0:7B:10:EA:B6:03:06:4C:23:7F:ED:A6:65:keyid:E7:07:2D:74:56:66:31:F0:7B:10:EA:B6:03:06:4C:23:7F:ED:A6:69"
 backendService:
   httpProxyTokenReceiverUrl: "http://backend:8080"

--- a/docs/samples/example-dataspace/sokrates-values.yaml
+++ b/docs/samples/example-dataspace/sokrates-values.yaml
@@ -71,7 +71,7 @@ vault:
     secrets:
   server:
 daps:
-  url: "http://daps:4567"
+  url: "http://{{ .Release.Name }}-daps:4567"
   clientId: "E7:07:2D:74:56:66:31:F0:7B:10:EA:B6:03:06:4C:23:7F:ED:A6:65:keyid:E7:07:2D:74:56:66:31:F0:7B:10:EA:B6:03:06:4C:23:7F:ED:A6:65"
 backendService:
   httpProxyTokenReceiverUrl: "http://backend:8080"

--- a/edc-tests/deployment/src/main/resources/helm/tractusx-connector-azure-vault-test.yaml
+++ b/edc-tests/deployment/src/main/resources/helm/tractusx-connector-azure-vault-test.yaml
@@ -96,7 +96,7 @@ vault:
   secrets:
 
 daps:
-  url: "http://daps:4567"
+  url: "http://{{ .Release.Name }}-daps:4567"
   clientId: "E7:07:2D:74:56:66:31:F0:7B:10:EA:B6:03:06:4C:23:7F:ED:A6:65:keyid:E7:07:2D:74:56:66:31:F0:7B:10:EA:B6:03:06:4C:23:7F:ED:A6:65"
 
 backendService:

--- a/edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml
+++ b/edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml
@@ -78,7 +78,7 @@ vault:
     secrets:
 
 daps:
-  url: "http://daps:4567"
+  url: "http://{{ .Release.Name }}-daps:4567"
   clientId: "E7:07:2D:74:56:66:31:F0:7B:10:EA:B6:03:06:4C:23:7F:ED:A6:65:keyid:E7:07:2D:74:56:66:31:F0:7B:10:EA:B6:03:06:4C:23:7F:ED:A6:65"
 
 backendService:


### PR DESCRIPTION
## WHAT

This PR changes the daps url behavior.
Instead of using a `fullnameOverride` to set the service name fix to `daps` the name is now including the `.Release.Name` variable.

## WHY

This helps Helm chart users to deploy multiple separate instances of the tractusx-connector chart in the same namespace.
Also the naming convention of pods / services will follow the others.

## FURTHER NOTES

```bash
$ kubectl get pod # without PR change
NAME                                                         READY   STATUS    RESTARTS   AGE
daps-7677896f79-rkpzl                                        0/1     Running   0          5s
myrelease-tractusx-connector-controlplane-86784bc6c4-rxcdx   0/1     Running   0          5s
myrelease-tractusx-connector-dataplane-7964df994-jqx2d       0/1     Running   0          5s
postgresql-0                                                 0/1     Running   0          5s
vault-0                                                      0/1     Running   0          5s
```

```bash
$ kubectl get pod # with all PRs
NAME                                                         READY   STATUS    RESTARTS   AGE
myrelease-daps-7677896f79-mr7h7                              0/1     Running   0          4s
myrelease-postgresql-0                                       0/1     Running   0          4s
myrelease-tractusx-connector-controlplane-768d4447d4-7qd55   0/1     Running   0          4s
myrelease-tractusx-connector-dataplane-7b79b5dc58-h8b9j      0/1     Running   0          4s
myrelease-vault-0                                            0/1     Running   0          4s
```

### OTHER PRs

- psql: #474
- vault: #473

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))