### PR TITLE
chore(helm): add hook-delete-policy for Helm chart tests

### DIFF
--- a/charts/tractusx-connector-azure-vault/templates/tests/test-controlplane-readiness.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/tests/test-controlplane-readiness.yaml
@@ -26,6 +26,7 @@ metadata:
     {{- include "txdc.controlplane.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   containers:
     - name: wget

--- a/charts/tractusx-connector-azure-vault/templates/tests/test-dataplane-readiness.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/tests/test-dataplane-readiness.yaml
@@ -26,6 +26,7 @@ metadata:
     {{- include "txdc.dataplane.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   containers:
     - name: wget

--- a/charts/tractusx-connector-memory/templates/tests/test-readiness.yaml
+++ b/charts/tractusx-connector-memory/templates/tests/test-readiness.yaml
@@ -29,6 +29,7 @@ metadata:
     {{- include "txdc.runtime.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   containers:
     - name: wget

--- a/charts/tractusx-connector/templates/tests/test-controlplane-readiness.yaml
+++ b/charts/tractusx-connector/templates/tests/test-controlplane-readiness.yaml
@@ -26,6 +26,7 @@ metadata:
     {{- include "txdc.controlplane.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   containers:
     - name: wget

--- a/charts/tractusx-connector/templates/tests/test-dataplane-readiness.yaml
+++ b/charts/tractusx-connector/templates/tests/test-dataplane-readiness.yaml
@@ -26,6 +26,7 @@ metadata:
     {{- include "txdc.dataplane.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   containers:
     - name: wget


### PR DESCRIPTION
## WHAT

Adding [Hook deletion policies](https://helm.sh/docs/topics/charts_hooks/#hook-deletion-policies) for the Helm tests.

## WHY

When running tests with Helm the pods will not be tidied up.
When the annotation `"helm.sh/hook-delete-policy": hook-succeeded` is added, after a successful run the pod will be deleted afterwards.
If the pod fails it will still be present.

Also the value `before-hook-creation` was added to be able to run the test again if it failed without manually deleting the pod.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))
