### PR TITLE
chore(helm): move test value file for memory chart to common directory

### DIFF
--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -79,10 +79,10 @@ jobs:
         with:
           imagename: edc-runtime-memory
           rootDir: edc-controlplane/edc-runtime-memory
-          values_file: charts/tractusx-connector-memory/example.yaml
+          values_file: edc-tests/deployment/src/main/resources/helm/tractusx-connector-memory-test.yaml
           helm_command: |-
             helm install tx-inmem charts/tractusx-connector-memory \
-            -f charts/tractusx-connector-memory/example.yaml \
+            -f edc-tests/deployment/src/main/resources/helm/tractusx-connector-memory-test.yaml \
             --set vault.secrets="daps-crt:$(cat daps.cert);daps-key:$(cat daps.key)" \
             --wait-for-jobs --timeout=120s --dependency-update
             

--- a/charts/tractusx-connector-memory/README.md.gotmpl
+++ b/charts/tractusx-connector-memory/README.md.gotmpl
@@ -27,7 +27,7 @@ export DAPS_CERT="$(cat daps.cert)"
 The in-memory vault can be seeded directly with secrets that are passed in `<key>:<value>;<key2>:<value2>;...` format.
 This config value can be passed to the runtime using the `vault.secrets` parameter. In addition, the runtime requires a
 couple of configuration parameters, all of which can be found in the section below. Please also consider using
-[this example configuration](https://github.com/eclipse-tractusx/tractusx-edc/blob/main/charts/tractusx-connector-memory/example.yaml)
+[this example configuration](https://github.com/eclipse-tractusx/tractusx-edc/blob/main/edc-tests/deployment/src/main/resources/helm/tractusx-connector-memory-test.yaml)
 to launch the application.
 
 Combined, run this shell command to start the in-memory Tractus-X EDC runtime:
@@ -35,7 +35,7 @@ Combined, run this shell command to start the in-memory Tractus-X EDC runtime:
 ```shell
 helm repo add tractusx-edc https://eclipse-tractusx.github.io/charts/dev
 helm install my-release tractusx-edc/tractusx-connector-memory --version {{ .Version }} \
-     -f <path-to>/example.yaml \
+     -f <path-to>/tractusx-connector-memory-test.yaml \
      --set vault.secrets="daps-cert:$DAPS_CERT;daps-key:$DAPS_KEY" \
 ```
 

--- a/edc-tests/deployment/src/main/resources/helm/tractusx-connector-memory-test.yaml
+++ b/edc-tests/deployment/src/main/resources/helm/tractusx-connector-memory-test.yaml
@@ -28,7 +28,7 @@
 ##  export DAPSKEY="<private-key-content>"
 ##  export DAPSCRT="<certificate-content>"
 ##  export YOUR_VAULT_SECRETS="daps-key:$DAPSKEY;daps-crt:$DAPSCRT"
-##  helm install trudy charts/tractusx-connector-memory -f charts/tractusx-connector-memory/example.yaml --set vault.secrets=$YOUR_VAULT_SECRETS
+##  helm install trudy charts/tractusx-connector-memory -f edc-tests/deployment/src/main/resources/helm/tractusx-connector-memory-test.yaml --set vault.secrets=$YOUR_VAULT_SECRETS
 
 ---
 fullnameOverride: tx-inmem


### PR DESCRIPTION
## WHAT

Move and rename the `tractusx-connector-memory` testing values file to the same location as other test value files.

## WHY

Currently the values file for all tests are located inside  [`edc-tests/deployment/src/main/resources/helm`](https://github.com/eclipse-tractusx/tractusx-edc/tree/b1be1fe14ab254115f0ad2c1aee83a1d323af2e6/edc-tests/deployment/src/main/resources/helm) with the exception of the [tractusx-connector-memory](https://github.com/eclipse-tractusx/tractusx-edc/blob/b1be1fe14ab254115f0ad2c1aee83a1d323af2e6/charts/tractusx-connector-memory/example.yaml) values file.

This should be unified to the same path.

## FURTHER NOTES

also see different locations in the workflow `deployment-test`:

https://github.com/eclipse-tractusx/tractusx-edc/blob/b1be1fe14ab254115f0ad2c1aee83a1d323af2e6/.github/workflows/deployment-test.yaml#L106

https://github.com/eclipse-tractusx/tractusx-edc/blob/b1be1fe14ab254115f0ad2c1aee83a1d323af2e6/.github/workflows/deployment-test.yaml#L82

https://github.com/eclipse-tractusx/tractusx-edc/blob/b1be1fe14ab254115f0ad2c1aee83a1d323af2e6/.github/workflows/deployment-test.yaml#L136

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))