### PR TITLE
feat(build): only increase patch version on final releases

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -233,9 +233,18 @@ jobs:
           git checkout main && git merge -X theirs releases --no-commit --no-ff
 
           # Extract release version
-          IFS=. read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH<<<"${{ env.RELEASE_VERSION }}"
-          # Compute new snapshot version
-          VERSION="$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$((RELEASE_VERSION_PATCH+1))-SNAPSHOT"
+          IFS=. read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH SNAPSHOT<<<"${{ env.RELEASE_VERSION }}"
+          INC=0
+          # Compute new snapshot version, do not increment snapshot on non-final releases, e.g. -rc1
+          if [ -z $SNAPSHOT ]; then
+            # snapshot
+            echo "${{ env.RELEASE_VERSION }} is a final release version, increase patch for next snapshot"
+            INC=1
+          else
+            echo "${{ env.RELEASE_VERSION }} is not a final release version (contains \"$SNAPSHOT\"), will not increase patch"
+          fi
+          
+          VERSION="$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$((RELEASE_VERSION_PATCH+$INC))-SNAPSHOT"
           SNAPSHOT_VERSION=$VERSION
 
           # Persist the "version" in the gradle.properties

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -233,7 +233,7 @@ jobs:
           git checkout main && git merge -X theirs releases --no-commit --no-ff
 
           # Extract release version
-          IFS=. read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH SNAPSHOT<<<"${{ env.RELEASE_VERSION }}"
+          IFS=.- read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH SNAPSHOT<<<"${{ env.RELEASE_VERSION }}"
           INC=0
           # Compute new snapshot version, do not increment snapshot on non-final releases, e.g. -rc1
           if [ -z $SNAPSHOT ]; then


### PR DESCRIPTION
## WHAT

This PR improves the release workflow by changing the logic where the new snapshot version is selected.

Assuming `<major>.<minor>.<patch>` versions, previously, we always incremented the `patch` version, regardless of what the input was. So `0.5.0-rc1` would have resulted in a `0.5.1-SNAPSHOT`, which is incorrect.

Now, we only increase the `<patch>` version, if there is no `-rc1` or anything:
- `0.5.0` becomes `0.5.1-SNAPSHOT`
- `0.5.0-rc1` becomes `0.5.0-SNAPSHOT`

## WHY

The existing logic would have handled release candidates etc. incorrectly.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
