### PR TITLE
chore: prepare Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0-rc2] - 2023-06-23
+
+### Changed
+
+Upgraded to EDC 0.1.2
+
 ## [0.5.0-rc1] - 2023-06-21
 
 ## Fixed


### PR DESCRIPTION
## WHAT

adds the soon-to-be-created `0.5.0-rc2` version to the changelog.

## WHY

changelog

## FURTHER NOTES

- there will not be a dedicated migration guide, because there is no significant difference to `0.5.0-rc1`

Closes # <-- _insert Issue number if one exists_
