### PR TITLE
refactor(build): restructure and serialize the build pipeline

### DIFF
--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -26,10 +26,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
 
   secret-presence:

--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -22,21 +22,8 @@
 name: "Deployment Tests"
 
 on:
-  push:
-    branches:
-      - main
-      - develop
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
-  release:
-    types:
-      - published
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-    branches:
-      - '*'
+  workflow_call:
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -174,7 +174,7 @@ jobs:
   # Release: GitHub tag & release; Merges back releases into main; Starts a new development cycle;
   github-release:
     name: Publish new github release
-    needs: [ release-version ]
+    needs: [ release-version, maven-release, docker-release, helm-release ]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,25 +21,21 @@
 #
 
 ---
-name: "Build"
+name: "Publish Artefacts"
 
 on:
-  push:
+  workflow_run:
+    workflows: [ "Test-All" ]
     branches:
       - main
       - releases
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - release/*
+      - hotfix/*
+    types:
+      - completed
   release:
     types:
       - published
-  pull_request:
-    paths-ignore:
-      - 'charts/**'
-      - 'docs/**'
-      - '**/*.md'
-    branches:
-      - '*'
   workflow_dispatch:
 
 

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -1,0 +1,65 @@
+#
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
+---
+## This is a master test workflow that runs the verify.yaml workflow and the deployment-test.yaml workflow
+name: Run-All-Tests
+
+on:
+  push:
+    branches:
+      - main
+      - releases
+      - previews/*
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  release:
+    types:
+      - published
+  pull_request:
+    paths-ignore:
+      - 'charts/**'
+  workflow_dispatch:
+
+concurrency:
+  # cancel older running jobs on the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  run-verify:
+    uses: ./.github/workflows/verify.yml
+    secrets: inherit
+
+  run-deployment-test:
+    uses: ./.github/workflows/deployment-test.yml
+    secrets: inherit
+
+  summary:
+    needs:
+      - unit-test
+      - deployment-test
+    runs-on: ubuntu-latest
+    steps:
+      # Runs a single command using the runners shell
+      - name: 'Master test job'
+        run: echo "all test jobs have run by now"
+

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -45,21 +45,22 @@ concurrency:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  run-verify:
+  verify:
     uses: ./.github/workflows/verify.yaml
     secrets: inherit
 
-  run-deployment-test:
+  deployment-test:
     uses: ./.github/workflows/deployment-test.yaml
     secrets: inherit
 
+  # this job really serves no other purpose than waiting for the other two test workflows
+  # in future iterations, this could be used as a choke point to collect test data, etc.
   summary:
     needs:
-      - run-verify
-      - run-deployment-test
+      - verify
+      - deployment-test
     runs-on: ubuntu-latest
     steps:
-      # Runs a single command using the runners shell
       - name: 'Master test job'
         run: echo "all test jobs have run by now"
 

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -46,17 +46,17 @@ concurrency:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   run-verify:
-    uses: ./.github/workflows/verify.yml
+    uses: ./.github/workflows/verify.yaml
     secrets: inherit
 
   run-deployment-test:
-    uses: ./.github/workflows/deployment-test.yml
+    uses: ./.github/workflows/deployment-test.yaml
     secrets: inherit
 
   summary:
     needs:
-      - unit-test
-      - deployment-test
+      - run-verify
+      - run-deployment-test
     runs-on: ubuntu-latest
     steps:
       # Runs a single command using the runners shell

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -25,7 +25,7 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
   workflow_run:
-    workflows: [ "Build" ]
+    workflows: [ "Publish Artefacts" ]
     branches:
       - main
       - releases

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -26,11 +26,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-concurrency:
-  # cancel older running jobs on the same branch
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   
   verify-license-headers:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -22,19 +22,8 @@
 name: "Verify"
 
 on:
-  push:
-    branches:
-      - main
-      - releases
-      - previews/*
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
-  release:
-    types:
-      - published
-  pull_request:
-    paths-ignore:
-      - 'charts/**'
+  workflow_call:
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## WHAT

This PR restructures our CI pipeline in the following aspects:
- adds a `test-all` workflow, that starts `verify` and `deployment-test` 
- rename `build` -> `publish`, run only after `test-all` has completed
- when releasing, the GitHub Release is created only _after_ all publications were successful

## WHY

this causes the CI to publish artefacts _only after_ all tests were successful, avoiding partial or even broken artefacts

## FURTHER NOTES

- concurrency handling is done by the `test-all` workflow


Closes #229 
