### PR TITLE
fix(build): use correct workflow name to trigger publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,7 +25,7 @@ name: "Publish Artefacts"
 
 on:
   workflow_run:
-    workflows: [ "Test-All" ]
+    workflows: [ "Run-All-Tests" ]
     branches:
       - main
       - releases


### PR DESCRIPTION
## WHAT

In a previous PR the wrong workflow name was used to trigger the publish job.

## WHY

the publish workflow is triggered by the test job.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #229 
