### PR TITLE
fix(test): enable coverage report via Sonar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,7 @@ project.subprojects.forEach {
     dependencies {
         jacocoAggregation(project(it.path))
     }
+
 }
 
 allprojects {
@@ -175,4 +176,8 @@ nexusPublishing {
         maxRetries.set(120)
         delayBetween.set(Duration.ofSeconds(10))
     }
+}
+
+tasks.check {
+    dependsOn(tasks.named<JacocoReport>("testCodeCoverageReport"))
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -57,7 +57,6 @@ include(":edc-tests:runtime:extensions")
 include(":edc-tests:runtime:runtime-memory")
 include(":edc-tests:runtime:runtime-memory-ssi")
 include(":edc-tests:runtime:runtime-postgresql")
-include(":edc-tests:cucumber")
 
 // modules for controlplane artifacts
 include(":edc-controlplane")


### PR DESCRIPTION
## WHAT

This is an attempt to enable Coverage Reports via SonarQube, by enabling the test coverage report generation.

## WHY

No coverage reports where generated.

## FURTHER NOTES

It is unclear which gradle tasks the Sonar server executes before running the analysis, so this is really more of an attempt.
Should this not be successful, we'll deactivate the automatic Sonar analysis, and replace it with an explicit `./gradlew sonar ...` task, the way it was in the past.

Closes #389 
