### PR TITLE
fix: replace '__' with '--' in the Sql EDR Store

### DIFF
--- a/edc-extensions/edr-cache-sql/src/main/java/org/eclipse/tractusx/edc/edr/store/sql/SqlEndpointDataReferenceCache.java
+++ b/edc-extensions/edr-cache-sql/src/main/java/org/eclipse/tractusx/edc/edr/store/sql/SqlEndpointDataReferenceCache.java
@@ -46,7 +46,7 @@ import static org.eclipse.edc.sql.SqlQueryExecutor.executeQuerySingle;
 
 public class SqlEndpointDataReferenceCache extends AbstractSqlStore implements EndpointDataReferenceCache {
 
-    public static final String SEPARATOR = "__";
+    public static final String SEPARATOR = "--";
     public static final String VAULT_PREFIX = "edr" + SEPARATOR;
     private final EdrStatements statements;
     private final Clock clock;

--- a/edc-extensions/edr-cache-sql/src/test/java/org/eclipse/tractusx/edc/edr/store/sql/SqlEndpointDataReferenceCacheTest.java
+++ b/edc-extensions/edr-cache-sql/src/test/java/org/eclipse/tractusx/edc/edr/store/sql/SqlEndpointDataReferenceCacheTest.java
@@ -25,6 +25,7 @@ import org.eclipse.tractusx.edc.edr.store.sql.schema.EdrStatements;
 import org.eclipse.tractusx.edc.edr.store.sql.schema.postgres.PostgresEdrStatements;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
@@ -33,10 +34,15 @@ import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.time.Clock;
 
+import static java.util.UUID.randomUUID;
 import static org.eclipse.tractusx.edc.edr.spi.TestFunctions.edr;
+import static org.eclipse.tractusx.edc.edr.spi.TestFunctions.edrEntry;
 import static org.eclipse.tractusx.edc.edr.store.sql.SqlEndpointDataReferenceCache.SEPARATOR;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @PostgresqlDbIntegrationTest
@@ -69,6 +75,20 @@ public class SqlEndpointDataReferenceCacheTest extends EndpointDataReferenceCach
     @AfterEach
     void tearDown(PostgresqlStoreSetupExtension extension) throws SQLException {
         extension.runQuery("DROP TABLE " + statements.getEdrTable() + " CASCADE");
+    }
+
+    @Test
+    void verify_unoffensive_secretKey() {
+        var tpId = "tp1";
+        var assetId = "asset1";
+        var edrId = "edr1";
+
+        var edr = edr(edrId);
+        var entry = edrEntry(assetId, randomUUID().toString(), tpId);
+
+        getStore().save(entry, edr);
+
+        verify(vault).storeSecret(argThat(s -> s.startsWith("edr--")), anyString());
     }
 
     @Override

--- a/spi/edr-cache-spi/src/testFixtures/java/org/eclipse/tractusx/edc/edr/spi/EndpointDataReferenceCacheBaseTest.java
+++ b/spi/edr-cache-spi/src/testFixtures/java/org/eclipse/tractusx/edc/edr/spi/EndpointDataReferenceCacheBaseTest.java
@@ -126,5 +126,5 @@ public abstract class EndpointDataReferenceCacheBaseTest {
                 .extracting(StoreResult::reason)
                 .isEqualTo(StoreFailure.Reason.NOT_FOUND);
     }
-    
+
 }


### PR DESCRIPTION
## WHAT

Replaces the prefix for EDRs, from `edr__` to `edr--`. 
## WHY

Some vaults, such as Azure KeyVault, are quite particular about allowed characters, and disallow "__"

## FURTHER NOTES

- a corresponding issue in https://github.com/eclipse-edc/technology-azure will be opened, that improves the sanitization process.

Closes # <-- _insert Issue number if one exists_