### PR TITLE
feat: add BPN as header in the call from dataplane to http source

### DIFF
--- a/edc-extensions/provision-additional-headers/README.md
+++ b/edc-extensions/provision-additional-headers/README.md
@@ -8,3 +8,4 @@ This gives for example the provider backend service the possibility to audit the
 The following headers are added to the `HttpDataAddress`:
 
 - `Edc-Contract-Agreement-Id`: the id of the contract agreement
+- `Edc-Bpn`: the BPN of the consumer

--- a/edc-extensions/provision-additional-headers/build.gradle.kts
+++ b/edc-extensions/provision-additional-headers/build.gradle.kts
@@ -23,15 +23,9 @@ plugins {
 }
 
 dependencies {
+    implementation(libs.edc.spi.controlplane)
     implementation(libs.edc.spi.core)
     implementation(libs.edc.spi.transfer)
 
-    testImplementation(libs.awaitility)
     testImplementation(libs.edc.junit)
-
-    testImplementation(libs.edc.core.controlplane)
-    testImplementation(libs.edc.dpf.selector.core)
-    testImplementation(libs.edc.dsp)
-    testImplementation(libs.edc.iam.mock)
-    testImplementation(libs.mockito.inline)
 }

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisioner.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisioner.java
@@ -32,9 +32,7 @@ import org.eclipse.edc.spi.types.domain.HttpDataAddress;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
-public class AdditionalHeadersProvisioner
-        implements Provisioner<
-        AdditionalHeadersResourceDefinition, AdditionalHeadersProvisionedResource> {
+public class AdditionalHeadersProvisioner implements Provisioner<AdditionalHeadersResourceDefinition, AdditionalHeadersProvisionedResource> {
 
     @Override
     public boolean canProvision(ResourceDefinition resourceDefinition) {
@@ -53,6 +51,7 @@ public class AdditionalHeadersProvisioner
                 HttpDataAddress.Builder.newInstance()
                         .copyFrom(resourceDefinition.getDataAddress())
                         .addAdditionalHeader("Edc-Contract-Agreement-Id", resourceDefinition.getContractId())
+                        .addAdditionalHeader("Edc-Bpn", resourceDefinition.getBpn())
                         .build();
 
         var provisioned =

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinition.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinition.java
@@ -33,6 +33,7 @@ class AdditionalHeadersResourceDefinition extends ResourceDefinition {
 
     private String contractId;
     private DataAddress dataAddress;
+    private String bpn;
 
     @Override
     public Builder toBuilder() {
@@ -45,6 +46,10 @@ class AdditionalHeadersResourceDefinition extends ResourceDefinition {
 
     public String getContractId() {
         return contractId;
+    }
+
+    public String getBpn() {
+        return bpn;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -61,12 +66,17 @@ class AdditionalHeadersResourceDefinition extends ResourceDefinition {
         }
 
         public Builder contractId(String contractId) {
-            this.resourceDefinition.contractId = contractId;
+            resourceDefinition.contractId = contractId;
             return this;
         }
 
         public Builder dataAddress(DataAddress dataAddress) {
-            this.resourceDefinition.dataAddress = dataAddress;
+            resourceDefinition.dataAddress = dataAddress;
+            return this;
+        }
+
+        public Builder bpn(String bpn) {
+            resourceDefinition.bpn = bpn;
             return this;
         }
     }

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinitionGenerator.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersResourceDefinitionGenerator.java
@@ -20,6 +20,8 @@
 
 package org.eclipse.tractusx.edc.provision.additionalheaders;
 
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.spi.contractagreement.ContractAgreementService;
 import org.eclipse.edc.connector.transfer.spi.provision.ProviderResourceDefinitionGenerator;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
@@ -27,9 +29,16 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
 import java.util.UUID;
 
 class AdditionalHeadersResourceDefinitionGenerator implements ProviderResourceDefinitionGenerator {
+
+    private final ContractAgreementService contractAgreementService;
+
+    AdditionalHeadersResourceDefinitionGenerator(ContractAgreementService contractAgreementService) {
+        this.contractAgreementService = contractAgreementService;
+    }
 
     @Override
     public boolean canGenerate(DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
@@ -39,10 +48,16 @@ class AdditionalHeadersResourceDefinitionGenerator implements ProviderResourceDe
     @Override
     public @Nullable ResourceDefinition generate(
             DataRequest dataRequest, DataAddress dataAddress, Policy policy) {
+        var bpn = Optional.of(dataRequest.getContractId())
+                .map(contractAgreementService::findById)
+                .map(ContractAgreement::getConsumerId)
+                .orElse(null);
+
         return AdditionalHeadersResourceDefinition.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .dataAddress(dataAddress)
                 .contractId(dataRequest.getContractId())
+                .bpn(bpn)
                 .build();
     }
 }

--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtension.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/ProvisionAdditionalHeadersExtension.java
@@ -20,6 +20,7 @@
 
 package org.eclipse.tractusx.edc.provision.additionalheaders;
 
+import org.eclipse.edc.connector.spi.contractagreement.ContractAgreementService;
 import org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager;
 import org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -38,10 +39,13 @@ public class ProvisionAdditionalHeadersExtension implements ServiceExtension {
     @Inject
     private TypeManager typeManager;
 
+    @Inject
+    private ContractAgreementService contractAgreementService;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
         typeManager.registerTypes(AdditionalHeadersResourceDefinition.class, AdditionalHeadersProvisionedResource.class);
-        resourceManifestGenerator.registerGenerator(new AdditionalHeadersResourceDefinitionGenerator());
+        resourceManifestGenerator.registerGenerator(new AdditionalHeadersResourceDefinitionGenerator(contractAgreementService));
         provisionManager.register(new AdditionalHeadersProvisioner());
     }
 }

--- a/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisionerTest.java
+++ b/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisionerTest.java
@@ -49,19 +49,19 @@ class AdditionalHeadersProvisionerTest {
 
     @Test
     void cannotDeprovisionAdditionalHeadersResourceDefinition() {
-        assertThat(provisioner.canDeprovision(mock(AdditionalHeadersProvisionedResource.class)))
-                .isFalse();
+        assertThat(provisioner.canDeprovision(mock(AdditionalHeadersProvisionedResource.class))).isFalse();
         assertThat(provisioner.canDeprovision(mock(ProvisionedResource.class))).isFalse();
     }
 
     @Test
-    void shouldAddContractIdAdditionalHeader() {
+    void shouldAddAdditionalHeaders() {
         var address = HttpDataAddress.Builder.newInstance().baseUrl("http://any").build();
         var resourceDefinition =
                 AdditionalHeadersResourceDefinition.Builder.newInstance()
                         .id(UUID.randomUUID().toString())
                         .transferProcessId(UUID.randomUUID().toString())
                         .contractId("contractId")
+                        .bpn("bpn")
                         .dataAddress(address)
                         .build();
 
@@ -77,6 +77,7 @@ class AdditionalHeadersProvisionerTest {
                 .extracting(a -> HttpDataAddress.Builder.newInstance().copyFrom(a).build())
                 .extracting(HttpDataAddress::getAdditionalHeaders)
                 .asInstanceOf(map(String.class, String.class))
-                .containsEntry("Edc-Contract-Agreement-Id", "contractId");
+                .containsEntry("Edc-Contract-Agreement-Id", "contractId")
+                .containsEntry("Edc-Bpn", "bpn");
     }
 }

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/AbstractHttpConsumerPullWithProxyTest.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/AbstractHttpConsumerPullWithProxyTest.java
@@ -128,6 +128,7 @@ public abstract class AbstractHttpConsumerPullWithProxyTest {
         var rq = server.takeRequest();
         assertThat(rq.getHeader(authCodeHeaderName)).isEqualTo(authCode);
         assertThat(rq.getHeader("Edc-Contract-Agreement-Id")).isEqualTo(contractAgreementId.get());
+        assertThat(rq.getHeader("Edc-Bpn")).isEqualTo(SOKRATES.getBpn());
         assertThat(rq.getMethod()).isEqualToIgnoringCase("GET");
     }
 


### PR DESCRIPTION
## WHAT

Add a `Edc-Bpn` header to the dataplane call to the http data source.

## WHY

It's needed for authentication and auditing purposes by the Use Cases

## FURTHER NOTES

- lightened the extension tests, passing from a "component" to a "unit" one, since the e2e behavior is already verified by e2e-tests.

Closes #539 
