### PR TITLE
fix(charts): add temporary emptyDir volume to the controlplane charts

### DIFF
--- a/charts/tractusx-connector-azure-vault/templates/deployment-dataplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/deployment-dataplane.yaml
@@ -208,6 +208,8 @@ spec:
             - name: "configuration"
               mountPath: "/app/logging.properties"
               subPath: "logging.properties"
+            - name: "tmp"
+              mountPath: "/tmp"
       volumes:
         - name: "configuration"
           configMap:
@@ -217,6 +219,8 @@ spec:
                 path: "opentelemetry.properties"
               - key: "logging.properties"
                 path: "logging.properties"
+        - name: "tmp"
+          emptyDir: { }
       {{- with .Values.dataplane.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
+++ b/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
@@ -276,6 +276,8 @@ spec:
             - name: "configuration"
               mountPath: "/app/logging.properties"
               subPath: "logging.properties"
+            - name: "tmp"
+              mountPath: "/tmp"
       volumes:
         - name: "configuration"
           configMap:
@@ -283,6 +285,8 @@ spec:
             items:
               - key: "logging.properties"
                 path: "logging.properties"
+        - name: "tmp"
+          emptyDir: { }
       {{- with .Values.runtime.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/tractusx-connector/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-controlplane.yaml
@@ -335,6 +335,8 @@ spec:
             - name: "configuration"
               mountPath: "/app/logging.properties"
               subPath: "logging.properties"
+            - name: "tmp"
+              mountPath: "/tmp"
       volumes:
         - name: "configuration"
           configMap:
@@ -344,6 +346,8 @@ spec:
                 path: "opentelemetry.properties"
               - key: "logging.properties"
                 path: "logging.properties"
+        - name: "tmp"
+          emptyDir: { }
       {{- with .Values.controlplane.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/docs/samples/example-dataspace/plato-values.yaml
+++ b/docs/samples/example-dataspace/plato-values.yaml
@@ -54,9 +54,6 @@ dataplane:
     pullPolicy: Never
     tag: "latest"
     repository: "edc-dataplane-hashicorp-vault"
-  securityContext:
-    # avoids some errors in the log: cannot write temp files of large multipart requests when R/O
-    readOnlyRootFilesystem: false
   aws:
     endpointOverride: http://minio:9000
     secretAccessKey: qwerty123

--- a/docs/samples/example-dataspace/sokrates-values.yaml
+++ b/docs/samples/example-dataspace/sokrates-values.yaml
@@ -35,9 +35,6 @@ controlplane:
     pullPolicy: Never
     tag: "latest"
     repository: "edc-controlplane-postgresql-hashicorp-vault"
-  securityContext:
-    # avoids some errors in the log: cannot write temp files of large multipart requests when R/O
-    readOnlyRootFilesystem: false
   # SSI configuration
   ssi:
     miw:


### PR DESCRIPTION
## WHAT

It turned out that this https://github.com/eclipse-tractusx/tractusx-edc/discussions/556 was caused by the default security context that prevented the JSON-LD extensions to properly load the cached context from disks.

Logs:
```
WARNING  Failed to register cached json-ld document: Cannot read resource document/credential-v1.jsonld: 
WARNING  Failed to register cached json-ld document: Cannot read resource document/summary-vc-context-v1.jsonld: 
WARNING  Failed to register cached json-ld document: Cannot read resource document/summary-vc-context-v1.jsonld:
```

This can be fixed by allowing the setting the property in the securityContext `readOnlyRootFilesystem:false` so that the process can write in the `/tmp` directory. With this PR it will not be needed anymore since in all charts a temporary volume will be mounted for `/tmp` that will be writable.

A proper fix that avoids the temporary volume could be done in EDC upstream by not requiring a `File` for cached context

