### PR TITLE
fix(test): converted some MockWebServer to long-running instances

### DIFF
--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/edr/AbstractNegotiateEdrTest.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/edr/AbstractNegotiateEdrTest.java
@@ -135,7 +135,7 @@ public abstract class AbstractNegotiateEdrTest {
     }
 
 
-    ReceivedEvent waitForEvent(ReceivedEvent event) {
+    private ReceivedEvent waitForEvent(ReceivedEvent event) {
         try {
             var request = server.takeRequest(20, TimeUnit.SECONDS);
             if (request != null) {

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/negotiation/SsiContractNegotiationInMemoryTest.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/negotiation/SsiContractNegotiationInMemoryTest.java
@@ -19,8 +19,8 @@ import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.tractusx.edc.lifecycle.ParticipantRuntime;
 import org.eclipse.tractusx.edc.token.KeycloakDispatcher;
 import org.eclipse.tractusx.edc.token.MiwDispatcher;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
@@ -56,13 +56,13 @@ public class SsiContractNegotiationInMemoryTest extends AbstractContractNegotiat
             SOKRATES_BPN,
             sokratesSsiConfiguration()
     );
-    MockWebServer miwSokratesServer;
-    MockWebServer miwPlatoServer;
-    MockWebServer oauthServer;
+    private static MockWebServer miwSokratesServer;
+    private static MockWebServer miwPlatoServer;
+    private static MockWebServer oauthServer;
 
 
-    @BeforeEach
-    void setup() throws IOException {
+    @BeforeAll
+    static void setup() throws IOException {
         miwSokratesServer = new MockWebServer();
         miwPlatoServer = new MockWebServer();
         oauthServer = new MockWebServer();
@@ -79,8 +79,8 @@ public class SsiContractNegotiationInMemoryTest extends AbstractContractNegotiat
         oauthServer.setDispatcher(new KeycloakDispatcher());
     }
 
-    @AfterEach
-    void teardown() throws IOException {
+    @AfterAll
+    static void teardown() throws IOException {
         miwSokratesServer.shutdown();
         miwPlatoServer.shutdown();
         oauthServer.shutdown();

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/AbstractHttpConsumerPullWithProxyTest.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/AbstractHttpConsumerPullWithProxyTest.java
@@ -53,7 +53,7 @@ public abstract class AbstractHttpConsumerPullWithProxyTest {
 
     private static final Duration ASYNC_TIMEOUT = ofSeconds(45);
     private static final Duration ASYNC_POLL_INTERVAL = ofSeconds(1);
-    MockWebServer server;
+    private MockWebServer server;
 
     @BeforeEach
     void setup() throws IOException {

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/SsiHttpConsumerPullWithProxyInMemoryTest.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/SsiHttpConsumerPullWithProxyInMemoryTest.java
@@ -20,7 +20,8 @@ import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.tractusx.edc.lifecycle.ParticipantRuntime;
 import org.eclipse.tractusx.edc.token.KeycloakDispatcher;
 import org.eclipse.tractusx.edc.token.MiwDispatcher;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -59,13 +60,12 @@ public class SsiHttpConsumerPullWithProxyInMemoryTest extends AbstractHttpConsum
             platoSsiConfiguration()
     );
 
-    private MockWebServer oauthServer;
-    private MockWebServer miwPlatoServer;
-    private MockWebServer miwSokratesServer;
+    private static MockWebServer oauthServer;
+    private static MockWebServer miwPlatoServer;
+    private static MockWebServer miwSokratesServer;
 
-    @BeforeEach
-    void setup() throws IOException {
-        super.setup();
+    @BeforeAll
+    static void prepare() throws IOException {
         miwSokratesServer = new MockWebServer();
         miwPlatoServer = new MockWebServer();
         oauthServer = new MockWebServer();
@@ -82,11 +82,17 @@ public class SsiHttpConsumerPullWithProxyInMemoryTest extends AbstractHttpConsum
         oauthServer.setDispatcher(new KeycloakDispatcher());
     }
 
-    @AfterEach
-    void teardown() throws IOException {
+    @AfterAll
+    static void unwind() throws IOException {
         miwSokratesServer.shutdown();
         miwPlatoServer.shutdown();
         oauthServer.shutdown();
+    }
+
+    @BeforeEach
+    void setup() throws IOException {
+        super.setup();
+
     }
 
     @Override

--- a/edc-tests/edc-dataplane-proxy-e2e/src/test/java/org/eclipse/tractusx/edc/dataplane/proxy/e2e/DpfProxyEndToEndTest.java
+++ b/edc-tests/edc-dataplane-proxy-e2e/src/test/java/org/eclipse/tractusx/edc/dataplane/proxy/e2e/DpfProxyEndToEndTest.java
@@ -103,7 +103,7 @@ public class DpfProxyEndToEndTest {
     @AfterEach
     void tearDown() throws IOException {
         if (mockEndpoint != null) {
-            mockEndpoint.close();
+            mockEndpoint.shutdown();
         }
     }
 


### PR DESCRIPTION
## WHAT

this PR attempts to fix some of the flaky e2e tests we saw in the past.
The problem there was that the `MockWebServer` could not be started, due to an "Address already in use" error.

We don't exactly know where this is coming from, so this is really more of an "exploratory" PR

It should be noted that this goes somewhat _against_ the recommended use of the `MockWebServer`, which requires it to be re-instantiated on every test.

## WHY

Flaky e2e tests

## FURTHER NOTES


other solution ideas are
- switching to another mockwebserver. In EDC we use the Netty MockServer, which seems to not have these problems.
- adding a `RetryPolicy` to the instantiation and starting of the mock webserver: this would guard against transient errors such as timing issues
- use randomized ports for _every_ instance: would probably the cleanest solution, but might be difficult to implement, since all in-mem runtimes are instantiated only once, and would need to be re-instantiated.

 
Closes # <-- _insert Issue number if one exists_
