### PR TITLE
build: decrease dependabot frequency to 'weekly'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
       - "dependabot"
       - "dependencies"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   # Github Actions
   -
@@ -40,7 +40,7 @@ updates:
       - "dependabot"
       - "github-actions"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   # Docker
   -
@@ -51,7 +51,7 @@ updates:
       - "dependabot"
       - "docker"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   -
     package-ecosystem: "docker"
     target-branch: main
@@ -60,7 +60,7 @@ updates:
       - "dependabot"
       - "docker"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   -
     package-ecosystem: "docker"
     target-branch: main
@@ -69,7 +69,7 @@ updates:
       - "dependabot"
       - "docker"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   -
     package-ecosystem: "docker"
     target-branch: main
@@ -78,7 +78,7 @@ updates:
       - "dependabot"
       - "docker"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   -
     package-ecosystem: "docker"
     target-branch: main
@@ -87,4 +87,4 @@ updates:
       - "dependabot"
       - "docker"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
## WHAT

Decreases the dependabot frequency to `weekly`

## WHY

there is no point in doing this daily, seeing that we also have update the `DEPENDENCIES` file everytime.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
