### PR TITLE
feat(DataPlaneConsumerProxy): adds support for data plane provider url

### DIFF
--- a/edc-dataplane/edc-dataplane-base/build.gradle.kts
+++ b/edc-dataplane/edc-dataplane-base/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     runtimeOnly(project(":edc-extensions:dataplane-proxy:edc-dataplane-proxy-provider-core"))
 
     runtimeOnly(libs.edc.config.filesystem)
+    runtimeOnly(libs.edc.auth.tokenbased)
     runtimeOnly(libs.edc.dpf.awss3)
     runtimeOnly(libs.edc.dpf.oauth2)
     runtimeOnly(libs.edc.dpf.http)

--- a/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/README.md
+++ b/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/README.md
@@ -17,6 +17,27 @@ The path is `<proxyContext>/aas/request` and the body is something like this exa
 The body should contain the `assetId` or the `transferProcessId` which identify the data that we want to fetch
 and an `endpointUrl` which is the provider gateway on which the data is available. More info [here](../edc-dataplane-proxy-provider-api/README.md) on the gateway.
 
+Alternatively if the `endpointUrl` is not known or the gateway on the provider side is not configured, it can be omitted and the `Edr#endpointUrl`
+will be used. In this scenario if needed users can provide additional properties to the request for composing the final
+url:
+
+- `pathSegments` sub path to append to the base url
+- `queryParams` query parameters to add to the url
+
+Example with base url `http://localhost:8080/test`
+
+```json
+{
+  "assetId": "1",
+  "pathSegments": "/sub",
+  "queryParams": "foo=bar"
+}
+```
+
+The final url will look like `http://localhost:8080/test/sub?foo=bar` composed by the DataPlane manager with the Http request flow,
+
+> Note: the endpoint is not protected with configured `AuthenticationService`, which most likely will be the token based (auth key) one.
+
 ## Configuration
 
 | Key                             | Required | Default       | Description                |

--- a/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/build.gradle.kts
+++ b/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation(libs.edc.dpf.framework)
     implementation(libs.edc.dpf.util)
     implementation(libs.edc.ext.http)
+    implementation(libs.edc.spi.auth)
 
     implementation(project(":spi:edr-spi"))
 

--- a/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/DataPlaneProxyConsumerApiExtension.java
+++ b/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/DataPlaneProxyConsumerApiExtension.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.tractusx.edc.dataplane.proxy.consumer.api;
 
+import org.eclipse.edc.api.auth.spi.AuthenticationRequestFilter;
+import org.eclipse.edc.api.auth.spi.AuthenticationService;
 import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -64,6 +66,9 @@ public class DataPlaneProxyConsumerApiExtension implements ServiceExtension {
     private WebServiceConfigurer configurer;
 
     @Inject
+    private AuthenticationService authenticationService;
+
+    @Inject
     private Monitor monitor;
 
     private ExecutorService executorService;
@@ -80,6 +85,7 @@ public class DataPlaneProxyConsumerApiExtension implements ServiceExtension {
 
         executorService = newFixedThreadPool(context.getSetting(THREAD_POOL_SIZE, DEFAULT_THREAD_POOL));
 
+        webService.registerResource(CONSUMER_API_ALIAS, new AuthenticationRequestFilter(authenticationService));
         webService.registerResource(CONSUMER_API_ALIAS, new ClientErrorExceptionMapper());
         webService.registerResource(CONSUMER_API_ALIAS, new ConsumerAssetRequestController(edrCache, dataPlaneManager, executorService, monitor));
     }

--- a/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/asset/ConsumerAssetRequestController.java
+++ b/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/asset/ConsumerAssetRequestController.java
@@ -25,12 +25,15 @@ import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
 import org.eclipse.edc.connector.dataplane.util.sink.AsyncStreamingDataSink;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.HttpDataAddress;
 import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
 import org.eclipse.tractusx.edc.dataplane.proxy.consumer.api.asset.model.AssetRequest;
 import org.eclipse.tractusx.edc.edr.spi.store.EndpointDataReferenceCache;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -41,15 +44,17 @@ import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static jakarta.ws.rs.core.Response.status;
 import static java.lang.String.format;
 import static java.util.UUID.randomUUID;
+import static org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSchema.PATH;
+import static org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSchema.QUERY_PARAMS;
 
 /**
  * Implements the HTTP proxy API.
  */
 @Path("/aas")
 public class ConsumerAssetRequestController implements ConsumerAssetRequestApi {
+    public static final String BASE_URL = "baseUrl";
     private static final String HTTP_DATA = "HttpData";
     private static final String ASYNC_TYPE = "async";
-    private static final String BASE_URL = "baseUrl";
     private static final String HEADER_AUTHORIZATION = "header:authorization";
     private static final String BEARER_PREFIX = "Bearer ";
 
@@ -76,15 +81,19 @@ public class ConsumerAssetRequestController implements ConsumerAssetRequestApi {
         // resolve the EDR and add it to the request
         var edr = resolveEdr(request);
 
-        var sourceAddress = DataAddress.Builder.newInstance()
-                .type(HTTP_DATA)
-                .property(BASE_URL, request.getEndpointUrl())
-                .property(HEADER_AUTHORIZATION, BEARER_PREFIX + edr.getAuthCode())
-                .build();
+        var sourceAddress = Optional.ofNullable(request.getEndpointUrl())
+                .map(url -> gatewayAddress(url, edr))
+                .orElseGet(() -> dataPlaneAddress(edr));
+
 
         var destinationAddress = DataAddress.Builder.newInstance()
                 .type(ASYNC_TYPE)
                 .build();
+
+
+        var properties = Optional.ofNullable(request.getEndpointUrl())
+                .map((url) -> Map.<String, String>of())
+                .orElseGet(() -> dataPlaneProperties(request));
 
         var flowRequest = DataFlowRequest.Builder.newInstance()
                 .processId(randomUUID().toString())
@@ -92,6 +101,7 @@ public class ConsumerAssetRequestController implements ConsumerAssetRequestApi {
                 .sourceDataAddress(sourceAddress)
                 .destinationDataAddress(destinationAddress)
                 .traceContext(Map.of())
+                .properties(properties)
                 .build();
 
         // transfer the data asynchronously
@@ -102,6 +112,30 @@ public class ConsumerAssetRequestController implements ConsumerAssetRequestApi {
         } catch (Exception e) {
             reportError(response, e);
         }
+    }
+
+
+    private Map<String, String> dataPlaneProperties(AssetRequest request) {
+        var props = new HashMap<String, String>();
+        Optional.ofNullable(request.getQueryParams()).ifPresent((queryParams) -> props.put(QUERY_PARAMS, queryParams));
+        Optional.ofNullable(request.getPathSegments()).ifPresent((path) -> props.put(PATH, path));
+        return props;
+    }
+
+    private DataAddress gatewayAddress(String url, EndpointDataReference edr) {
+        return HttpDataAddress.Builder.newInstance()
+                .baseUrl(url)
+                .property(HEADER_AUTHORIZATION, BEARER_PREFIX + edr.getAuthCode())
+                .build();
+    }
+
+    private DataAddress dataPlaneAddress(EndpointDataReference edr) {
+        return HttpDataAddress.Builder.newInstance()
+                .baseUrl(edr.getEndpoint())
+                .proxyQueryParams("true")
+                .proxyPath("true")
+                .property(HEADER_AUTHORIZATION, edr.getAuthCode())
+                .build();
     }
 
     private EndpointDataReference resolveEdr(AssetRequest request) {

--- a/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/asset/model/AssetRequest.java
+++ b/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/asset/model/AssetRequest.java
@@ -19,8 +19,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * A request for asset data. The request may contain a transfer process ID or asset ID and must specify an endpoint for retrieving the data.
  */
@@ -32,6 +30,10 @@ public class AssetRequest {
 
     private String providerId;
     private String endpointUrl;
+
+    private String queryParams;
+
+    private String pathSegments;
 
     private AssetRequest() {
     }
@@ -50,6 +52,14 @@ public class AssetRequest {
 
     public String getProviderId() {
         return providerId;
+    }
+
+    public String getQueryParams() {
+        return queryParams;
+    }
+
+    public String getPathSegments() {
+        return pathSegments;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -85,11 +95,20 @@ public class AssetRequest {
             return this;
         }
 
+        public Builder queryParams(String queryParams) {
+            request.queryParams = queryParams;
+            return this;
+        }
+
+        public Builder pathSegments(String pathSegments) {
+            request.pathSegments = pathSegments;
+            return this;
+        }
+
         public AssetRequest build() {
             if (request.assetId == null && request.transferProcessId == null) {
                 throw new NullPointerException("An assetId or endpointReferenceId must be set");
             }
-            requireNonNull(request.endpointUrl, "endpointUrl");
             return request;
         }
     }

--- a/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/test/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/asset/model/AssetRequestTest.java
+++ b/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/test/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/asset/model/AssetRequestTest.java
@@ -32,8 +32,10 @@ class AssetRequestTest {
                 .endpointUrl("https://test.com")
                 .providerId("providerId")
                 .transferProcessId("tp1")
+                .queryParams("params")
+                .pathSegments("path")
                 .build();
-        
+
         var serialized = mapper.writeValueAsString(request);
 
         var deserialized = mapper.readValue(serialized, AssetRequest.class);
@@ -42,13 +44,14 @@ class AssetRequestTest {
         assertThat(deserialized.getTransferProcessId()).isEqualTo(request.getTransferProcessId());
         assertThat(deserialized.getEndpointUrl()).isEqualTo(request.getEndpointUrl());
         assertThat(deserialized.getProviderId()).isEqualTo(request.getProviderId());
+        assertThat(deserialized.getPathSegments()).isEqualTo(request.getPathSegments());
+        assertThat(deserialized.getQueryParams()).isEqualTo(request.getQueryParams());
 
     }
 
     @Test
     void verify_NullArguments() {
-        assertThatThrownBy(() -> AssetRequest.Builder.newInstance().endpointUrl("https://test.com").build()).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> AssetRequest.Builder.newInstance().assetId("asset1").build()).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> AssetRequest.Builder.newInstance().build()).isInstanceOf(NullPointerException.class);
     }
 
     @Test

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/lifecycle/Participant.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/lifecycle/Participant.java
@@ -391,6 +391,7 @@ public class Participant {
     private Response proxyRequest(Map<String, String> body) {
         return given()
                 .baseUri(proxyUrl)
+                .header("x-api-key", apiKey)
                 .contentType("application/json")
                 .body(body)
                 .post(PROXY_SUBPATH);

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/lifecycle/Participant.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/lifecycle/Participant.java
@@ -331,6 +331,17 @@ public class Participant {
         return getProxyData(body);
     }
 
+
+    public String pullProviderDataPlaneDataByAssetId(Participant provider, String assetId) {
+        var body = Map.of("assetId", assetId);
+        return getProxyData(body);
+    }
+
+    public String pullProviderDataPlaneDataByAssetIdAndCustomProperties(Participant provider, String assetId, String path, String params) {
+        var body = Map.of("assetId", assetId, "pathSegments", path, "queryParams", params);
+        return getProxyData(body);
+    }
+
     public Response pullProxyDataResponseByAssetId(Participant provider, String assetId) {
         var body = Map.of("assetId", assetId,
                 "endpointUrl", format("%s/aas/test", provider.gatewayEndpoint),
@@ -341,6 +352,12 @@ public class Participant {
     public String pullProxyDataByTransferProcessId(Participant provider, String transferProcessId) {
         var body = Map.of("transferProcessId", transferProcessId,
                 "endpointUrl", format("%s/aas/test", provider.gatewayEndpoint));
+        return getProxyData(body);
+
+    }
+
+    public String pullProviderDataPlaneDataByTransferProcessId(Participant provider, String transferProcessId) {
+        var body = Map.of("transferProcessId", transferProcessId);
         return getProxyData(body);
 
     }

--- a/edc-tests/edc-dataplane-proxy-e2e/build.gradle.kts
+++ b/edc-tests/edc-dataplane-proxy-e2e/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     // test runtime config
     testImplementation(libs.edc.config.filesystem)
     testImplementation(libs.edc.dpf.http)
+    testImplementation(libs.edc.auth.tokenbased)
     testImplementation(project(":spi:edr-spi"))
     testImplementation(project(":core:edr-cache-core"))
     testImplementation(project(":edc-extensions:dataplane-proxy:edc-dataplane-proxy-consumer-api"))

--- a/edc-tests/edc-dataplane-proxy-e2e/src/test/java/org/eclipse/tractusx/edc/dataplane/proxy/e2e/DpfProxyEndToEndTest.java
+++ b/edc-tests/edc-dataplane-proxy-e2e/src/test/java/org/eclipse/tractusx/edc/dataplane/proxy/e2e/DpfProxyEndToEndTest.java
@@ -74,6 +74,7 @@ public class DpfProxyEndToEndTest {
     private static final String REQUEST_TEMPLATE_TP = "{\"transferProcessId\": \"%s\", \"endpointUrl\" : \"http://localhost:%s/api/gateway/aas/test\"}";
     private static final String REQUEST_TEMPLATE_ASSET = "{\"assetId\": \"%s\", \"endpointUrl\" : \"http://localhost:%s/api/gateway/aas/test\"}";
     private static final String MOCK_ENDPOINT_200_BODY = "{\"message\":\"test\"}";
+    private static final String API_KEY = "testkey";
 
     @RegisterExtension
     static EdcRuntimeExtension consumer = new EdcRuntimeExtension(
@@ -81,9 +82,9 @@ public class DpfProxyEndToEndTest {
             "consumer",
             baseConfig(Map.of(
                     "web.http.port", valueOf(CONSUMER_HTTP_PORT),
+                    "edc.api.auth.key", API_KEY,
                     "tx.dpf.consumer.proxy.port", valueOf(CONSUMER_PROXY_PORT)
             )));
-
     @RegisterExtension
     static EdcRuntimeExtension provider = new EdcRuntimeExtension(
             LAUNCHER_MODULE,
@@ -184,6 +185,7 @@ public class DpfProxyEndToEndTest {
         return given()
                 .baseUri("http://localhost:" + CONSUMER_PROXY_PORT)
                 .contentType("application/json")
+                .header("x-api-key", API_KEY)
                 .body(body);
     }
 


### PR DESCRIPTION

## WHAT

The `endpointUrl` in `RequestAsset` can now be omitted and the `Edr#endpointUrl` will be used.

In this scenario additional properties can be used for enriching the asset request.

- `pathSegments` 
- `queryParameters`

Which they will be used for composing the final asset request to the provider dataplane

## WHY

For use case where the asset `endpointUrl` is not known

## Further notes

Also in this PR the APIs under proxy are now protected with the token based authentication 

Closes #625 
