### PR TITLE
chore: run omejdn as nonRoot in chart tractusx-connector-legacy

### DIFF
--- a/charts/tractusx-connector-legacy/subcharts/omejdn/README.md
+++ b/charts/tractusx-connector-legacy/subcharts/omejdn/README.md
@@ -24,7 +24,9 @@ A Helm chart for Kubernetes
 | nameOverride | string | `""` | Overrides the charts name |
 | nodeSelector | object | `{}` | [Node-Selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to constrain the Pod to nodes with specific labels. |
 | podAnnotations | object | `{}` | [Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) added to deployed [pods](https://kubernetes.io/docs/concepts/workloads/pods/) |
-| podSecurityContext | object | `{}` |  |
+| podSecurityContext.runAsGroup | int | `65534` |  |
+| podSecurityContext.runAsNonRoot | bool | `true` |  |
+| podSecurityContext.runAsUser | int | `65534` |  |
 | replicaCount | int | `1` | Specifies how many replicas of a deployed pod shall be created during the deployment Note: If horizontal pod autoscaling is enabled this setting has no effect |
 | resources | object | `{}` | [Resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) applied to the deployed pod |
 | securityContext | object | `{}` |  |

--- a/charts/tractusx-connector-legacy/subcharts/omejdn/templates/deployment.yaml
+++ b/charts/tractusx-connector-legacy/subcharts/omejdn/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
       {{- end }}
       initContainers:
         - name: init-daps-pvc
-          image: alpine
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command:
             - "sh"
             - "-c"
@@ -78,7 +78,6 @@ spec:
               cp /opt/config/clients.yml /etc/daps/clients.yml
               cp /opt/config/plugins.yml /etc/daps/plugins.yml
               cp /opt/config/scope_mapping.yml /etc/daps/scope_mapping.yml
-              apk add --update openssl
               openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout /etc/keys/omejdn/omejdn.key \
                 -subj "/C=DE/ST=Berlin/L=Berlin/O=Tractus-X-EDC-Test, Inc./OU=DE"
           volumeMounts:

--- a/charts/tractusx-connector-legacy/subcharts/omejdn/templates/deployment.yaml
+++ b/charts/tractusx-connector-legacy/subcharts/omejdn/templates/deployment.yaml
@@ -50,8 +50,10 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "omejdn.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- if .Values.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -98,8 +100,10 @@ spec:
               subPath: plugins.yml
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.securityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:

--- a/charts/tractusx-connector-legacy/subcharts/omejdn/values.yaml
+++ b/charts/tractusx-connector-legacy/subcharts/omejdn/values.yaml
@@ -60,7 +60,10 @@ automountServiceAccountToken: false
 podAnnotations: {}
 
 # The [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) defines privilege and access control settings for a Pod within the deployment
-podSecurityContext: {}
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
 
 # The [container security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) defines privilege and access control settings for a Container within a pod
 securityContext: {}


### PR DESCRIPTION
## WHAT

The omejdn / daps server should not be executed with the user root.
Therefore the user nobody (65534) will be set.

Also the securityContext will only be set if configured in the values file.

## WHY

Otherwise deploying the chart will fail if root is permited.

## FURTHER NOTES

This is a requirement for kyverno worflow introduced in eclipse-tractusx/e2e-testing#28.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))