### PR TITLE
fix(helm): remove legacy suffix from legacy Helm chart in cp

### DIFF
--- a/charts/tractusx-connector-legacy/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector-legacy/templates/deployment-controlplane.yaml
@@ -64,7 +64,7 @@ spec:
           {{- if .Values.controlplane.image.repository }}
           image: "{{ .Values.controlplane.image.repository }}:{{ .Values.controlplane.image.tag | default .Chart.AppVersion }}"
           {{- else }}
-          image: "tractusx/edc-controlplane-postgresql-hashicorp-vault-legacy:{{ .Values.controlplane.image.tag | default .Chart.AppVersion }}"
+          image: "tractusx/edc-controlplane-postgresql-hashicorp-vault:{{ .Values.controlplane.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.controlplane.image.pullPolicy }}
           ports:


### PR DESCRIPTION
## WHAT

Currently a wrong / non existent image will be used in the legacy Helm chart.

## WHY

This PR changes the correct image to be choosen:

`tractusx/edc-controlplane-postgresql-hashicorp-vault-legacy`-> `tractusx/edc-controlplane-postgresql-hashicorp-vault-legacy`

Only the `-legacy` suffix will be removed.
Otherwise a ImagePullBackOff error will occur.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))