### PR TITLE
feat: download opentelemetry jar outside of Dockerfile

### DIFF
--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -50,6 +50,14 @@ runs:
   steps:
     - uses: actions/checkout@v3.3.0
 
+    - name: Download OpenTelemetry
+      shell: bash
+      run: |-
+        # "jq -r" removes the quotation marks, that would trip up "wget"
+        URL=$(grep "val openTelemetryAgentUrl = " build.gradle.kts | awk -F'= ' '{print $2}' | jq -r)
+        wget -O ${{ inputs.rootDir }}/opentelemetry-javaagent.jar -q $URL
+        
+
     #####################
     # Login to DockerHub
     #####################
@@ -97,6 +105,7 @@ runs:
         file: ${{ inputs.rootDir }}/src/main/docker/Dockerfile
         build-args: |
           JAR=${{ inputs.rootDir }}/build/libs/${{ inputs.imagename }}.jar
+          OTEL_JAR=${{ inputs.rootDir }}/opentelemetry-javaagent.jar
         push: ${{ inputs.do_push == 'true' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,24 +153,44 @@ subprojects {
                 file("${project.projectDir}/src/main/docker/Dockerfile").exists()
         ) {
 
+            val agentFile = project.buildDir.resolve("opentelemetry-javaagent.jar")
+            // create task to download the opentelemetry agent
+            val downloadOtel = tasks.create("downloadOtel") {
+                // only execute task if the opentelemetry agent does not exist. invoke the "clean" task to force
+                onlyIf {
+                    !agentFile.exists()
+                }
+                // this task could be the first in the graph, so "build/" may not yet exist. Let's be defensive
+                doFirst {
+                    project.buildDir.mkdirs()
+                }
+                // download the jar file
+                doLast {
+                    val download = { url: String, destFile: File -> ant.invokeMethod("get", mapOf("src" to url, "dest" to destFile)) }
+                    logger.lifecycle("Downloading OpenTelemetry Agent")
+                    download("https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.27.0/opentelemetry-javaagent.jar", agentFile)
+                }
+            }
+
             //actually apply the plugin to the (sub-)project
-
             apply(plugin = "com.bmuschko.docker-remote-api")
-
             // configure the "dockerize" task
-            val dockerTask = tasks.create("dockerize", DockerBuildImage::class) {
-                dockerFile.set(file("${project.projectDir}/src/main/docker/Dockerfile"))
+            val dockerTask: DockerBuildImage = tasks.create("dockerize", DockerBuildImage::class) {
+                logger.info("using otel jar {}", agentFile)
+                val dockerContextDir = project.projectDir
+                dockerFile.set(file("$dockerContextDir/src/main/docker/Dockerfile"))
                 images.add("${project.name}:${project.version}")
                 images.add("${project.name}:latest")
                 // specify platform with the -Dplatform flag:
                 if (System.getProperty("platform") != null)
                     platform.set(System.getProperty("platform"))
                 buildArgs.put("JAR", "build/libs/${project.name}.jar")
-                inputDir.set(file(project.projectDir))
+                buildArgs.put("OTEL_JAR", agentFile.relativeTo(dockerContextDir).path)
+                inputDir.set(file(dockerContextDir))
             }
-
-            // make sure "shadowJar" always runs before "dockerize"
-            dockerTask.dependsOn(tasks.findByName(ShadowJavaPlugin.SHADOW_JAR_TASK_NAME))
+            // make sure "shadowJar" always runs before "dockerize" and after "copyOtel"
+            dockerTask.dependsOn(tasks.named(ShadowJavaPlugin.SHADOW_JAR_TASK_NAME))
+                    .dependsOn(downloadOtel)
         }
     }
 }

--- a/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
@@ -19,17 +19,9 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
-FROM alpine:3.18.0 AS otel
-
-ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.12.1/opentelemetry-javaagent.jar"
-
-HEALTHCHECK NONE
-
-RUN apk update && apk add curl=8.2.1-r0 --no-cache
-RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
-
 FROM eclipse-temurin:17.0.6_10-jre-alpine
 ARG JAR
+ARG OTEL_JAR
 
 ARG APP_USER=docker
 ARG APP_UID=10100
@@ -48,8 +40,7 @@ RUN adduser \
 USER "$APP_USER"
 WORKDIR /app
 
-COPY --from=otel /tmp/opentelemetry-javaagent.jar .
-COPY ${JAR} edc-controlplane.jar
+COPY ${OTEL_JAR} opentelemetry-javaagent.jar
 
 HEALTHCHECK NONE
 

--- a/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
@@ -40,6 +40,7 @@ RUN adduser \
 USER "$APP_USER"
 WORKDIR /app
 
+COPY ${JAR} edc-controlplane.jar
 COPY ${OTEL_JAR} opentelemetry-javaagent.jar
 
 HEALTHCHECK NONE

--- a/edc-controlplane/edc-controlplane-postgresql-azure-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql-azure-vault/src/main/docker/Dockerfile
@@ -18,17 +18,9 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-FROM alpine:3.18.2 AS otel
-
-ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.12.1/opentelemetry-javaagent.jar"
-
-HEALTHCHECK NONE
-
-RUN apk update && apk add curl=8.2.1-r0 --no-cache
-RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
-
 FROM eclipse-temurin:17.0.6_10-jre-alpine
 ARG JAR
+ARG OTEL_JAR
 
 ARG APP_USER=docker
 ARG APP_UID=10100
@@ -47,8 +39,8 @@ RUN adduser \
 USER "$APP_USER"
 WORKDIR /app
 
-COPY --from=otel /tmp/opentelemetry-javaagent.jar .
 COPY ${JAR} edc-controlplane.jar
+COPY ${OTEL_JAR} opentelemetry-javaagent.jar
 
 HEALTHCHECK NONE
 

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
@@ -18,17 +18,10 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-FROM alpine:3.18.2 AS otel
-
-ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.12.1/opentelemetry-javaagent.jar"
-
-HEALTHCHECK NONE
-
-RUN apk update && apk add curl=8.2.1-r0 --no-cache
-RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:17.0.6_10-jre-alpine
 ARG JAR
+ARG OTEL_JAR
 
 ARG APP_USER=docker
 ARG APP_UID=10100
@@ -47,8 +40,8 @@ RUN adduser \
 USER "$APP_USER"
 WORKDIR /app
 
-COPY --from=otel /tmp/opentelemetry-javaagent.jar .
 COPY ${JAR} edc-controlplane.jar
+COPY ${OTEL_JAR} opentelemetry-javaagent.jar
 
 HEALTHCHECK NONE
 

--- a/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
@@ -18,17 +18,9 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-FROM alpine:3.18.2 AS otel
-
-ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.12.1/opentelemetry-javaagent.jar"
-
-HEALTHCHECK NONE
-
-RUN apk update && apk add curl=8.2.1-r0 --no-cache
-RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
-
 FROM eclipse-temurin:17.0.6_10-jre-alpine
 ARG JAR
+ARG OTEL_JAR
 
 ARG APP_USER=docker
 ARG APP_UID=10100
@@ -47,8 +39,8 @@ RUN adduser \
 USER "$APP_USER"
 WORKDIR /app
 
-COPY --from=otel /tmp/opentelemetry-javaagent.jar .
 COPY ${JAR} edc-dataplane.jar
+COPY ${OTEL_JAR} opentelemetry-javaagent.jar
 
 HEALTHCHECK NONE
 

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
@@ -18,17 +18,10 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-FROM alpine:3.18.2 AS otel
-
-ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.12.1/opentelemetry-javaagent.jar"
-
-HEALTHCHECK NONE
-
-RUN apk update && apk add curl=8.2.1-r0 --no-cache
-RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:17.0.6_10-jre-alpine
 ARG JAR
+ARG OTEL_JAR
 
 ARG APP_USER=docker
 ARG APP_UID=10100
@@ -47,8 +40,9 @@ RUN adduser \
 USER "$APP_USER"
 WORKDIR /app
 
-COPY --from=otel /tmp/opentelemetry-javaagent.jar .
 COPY ${JAR} edc-dataplane.jar
+COPY ${OTEL_JAR} opentelemetry-javaagent.jar
+
 
 HEALTHCHECK NONE
 


### PR DESCRIPTION
## WHAT

Downloads the OpenTelemetry Agent jar "outside" of the Dockerfile. This is actually done in two locations:
1. the `build.gradle.kts` file: a Gradle task is added for this
2. the `publish-docker-image` action: a GH Actions step is added, because when publishing we don't use the Gradle Docker task

## WHY

Downloading the OTEL Agent inside Docker required adding `curl` first, and due to security restrictions that required a fixed version. APK, Alpine Linux's package manager, seems to not keep older versions around, which caused the build to break whenever a new version of `curl` was released.

## FURTHER NOTES

- Docker can't use resources outside of its build context, that is why the Gradle task downloads the `opentelemetry-javaagent.jar` once per project, directly to each project's `build/` folder. 


Closes #686 
