### PR TITLE
feat(edrs): add init edr request api validator

### DIFF
--- a/edc-extensions/edr/edr-api/build.gradle.kts
+++ b/edc-extensions/edr/edr-api/build.gradle.kts
@@ -25,9 +25,11 @@ dependencies {
 
     implementation(libs.edc.api.management)
     implementation(libs.edc.spi.aggregateservices)
+    implementation(libs.edc.core.validator)
     implementation(libs.jakarta.rsApi)
 
     testImplementation(testFixtures(libs.edc.core.jersey))
     testImplementation(libs.restAssured)
     testImplementation(libs.edc.junit)
+    testImplementation(libs.edc.ext.jersey.providers)
 }

--- a/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/EdrApi.java
+++ b/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/EdrApi.java
@@ -21,14 +21,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.api.model.ApiCoreSchema;
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiSchema;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 import org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto;
 import org.eclipse.tractusx.edc.edr.spi.types.EndpointDataReferenceEntry;
-
-import java.util.List;
 
 @OpenAPIDefinition
 @Tag(name = "Control Plane EDR Api")
@@ -49,9 +48,9 @@ public interface EdrApi {
                     @ApiResponse(responseCode = "200",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = EndpointDataReferenceEntry.class)))),
                     @ApiResponse(responseCode = "400", description = "Request was malformed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))}
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))) }
     )
-    List<JsonObject> queryEdrs(String assetId, String agreementId, String providerId);
+    JsonArray queryEdrs(String assetId, String agreementId, String providerId);
 
     @Operation(description = "Gets an EDR  with the given transfer process ID",
             responses = {

--- a/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/EdrApiExtension.java
+++ b/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/EdrApiExtension.java
@@ -18,15 +18,19 @@ import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfi
 import org.eclipse.edc.connector.api.management.configuration.transform.ManagementApiTypeTransformerRegistry;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.tractusx.edc.api.edr.transform.EndpointDataReferenceToDataAddressTransformer;
 import org.eclipse.tractusx.edc.api.edr.transform.JsonObjectFromEndpointDataReferenceEntryTransformer;
 import org.eclipse.tractusx.edc.api.edr.transform.JsonObjectToNegotiateEdrRequestDtoTransformer;
 import org.eclipse.tractusx.edc.api.edr.transform.NegotiateEdrRequestDtoToNegotiatedEdrRequestTransformer;
+import org.eclipse.tractusx.edc.api.edr.validation.NegotiateEdrRequestDtoValidator;
 import org.eclipse.tractusx.edc.edr.spi.service.EdrService;
 
+import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_TYPE;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_PREFIX;
 
@@ -46,6 +50,12 @@ public class EdrApiExtension implements ServiceExtension {
     @Inject
     private JsonLd jsonLdService;
 
+    @Inject
+    private JsonObjectValidatorRegistry validatorRegistry;
+
+    @Inject
+    private Monitor monitor;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
         jsonLdService.registerNamespace(TX_PREFIX, TX_NAMESPACE);
@@ -53,6 +63,7 @@ public class EdrApiExtension implements ServiceExtension {
         transformerRegistry.register(new JsonObjectToNegotiateEdrRequestDtoTransformer());
         transformerRegistry.register(new JsonObjectFromEndpointDataReferenceEntryTransformer());
         transformerRegistry.register(new EndpointDataReferenceToDataAddressTransformer());
-        webService.registerResource(apiConfig.getContextAlias(), new EdrController(edrService, jsonLdService, transformerRegistry));
+        validatorRegistry.register(EDR_REQUEST_DTO_TYPE, NegotiateEdrRequestDtoValidator.instance());
+        webService.registerResource(apiConfig.getContextAlias(), new EdrController(edrService, transformerRegistry, validatorRegistry, monitor));
     }
 }

--- a/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/validation/NegotiateEdrRequestDtoValidator.java
+++ b/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/validation/NegotiateEdrRequestDtoValidator.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.api.edr.validation;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
+import org.eclipse.edc.validator.jsonobject.validators.MandatoryObject;
+import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
+import org.eclipse.edc.validator.spi.Validator;
+
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.ASSET_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.OFFER_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.POLICY;
+import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_CONNECTOR_ADDRESS;
+import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_OFFER;
+import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_PROTOCOL;
+
+
+public class NegotiateEdrRequestDtoValidator {
+
+    private NegotiateEdrRequestDtoValidator() {
+    }
+
+    public static Validator<JsonObject> instance() {
+        return JsonObjectValidator.newValidator()
+                .verify(EDR_REQUEST_DTO_CONNECTOR_ADDRESS, MandatoryValue::new)
+                .verify(EDR_REQUEST_DTO_PROTOCOL, MandatoryValue::new)
+                .verify(EDR_REQUEST_DTO_OFFER, MandatoryObject::new)
+                .verifyObject(EDR_REQUEST_DTO_OFFER, v -> v
+                        .verify(OFFER_ID, MandatoryValue::new)
+                        .verify(ASSET_ID, MandatoryValue::new)
+                        .verify(POLICY, MandatoryObject::new)
+                )
+                .build();
+    }
+}

--- a/edc-extensions/edr/edr-api/src/test/java/org/eclipse/tractusx/edc/api/edr/validation/NegotiateEdrRequestDtoValidatorTest.java
+++ b/edc-extensions/edr/edr-api/src/test/java/org/eclipse/tractusx/edc/api/edr/validation/NegotiateEdrRequestDtoValidatorTest.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.api.edr.validation;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.validator.spi.ValidationFailure;
+import org.eclipse.edc.validator.spi.Validator;
+import org.eclipse.edc.validator.spi.Violation;
+import org.junit.jupiter.api.Test;
+
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.ASSET_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.OFFER_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.POLICY;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_CONNECTOR_ADDRESS;
+import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_OFFER;
+import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_PROTOCOL;
+import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_PROVIDER_ID;
+
+public class NegotiateEdrRequestDtoValidatorTest {
+
+    private final Validator<JsonObject> validator = NegotiateEdrRequestDtoValidator.instance();
+
+    @Test
+    void shouldSuccess_whenObjectIsValid() {
+        var input = Json.createObjectBuilder()
+                .add(EDR_REQUEST_DTO_CONNECTOR_ADDRESS, value("http://connector-address"))
+                .add(EDR_REQUEST_DTO_PROTOCOL, value("protocol"))
+                .add(EDR_REQUEST_DTO_PROVIDER_ID, value("connector-id"))
+                .add(EDR_REQUEST_DTO_OFFER, createArrayBuilder().add(createObjectBuilder()
+                        .add(OFFER_ID, value("offerId"))
+                        .add(ASSET_ID, value("offerId"))
+                        .add(POLICY, createArrayBuilder().add(createObjectBuilder()))
+                ))
+                .build();
+
+        var result = validator.validate(input);
+
+        assertThat(result).isSucceeded();
+    }
+
+    @Test
+    void shouldFail_whenMandatoryPropertiesAreMissing() {
+        var input = Json.createObjectBuilder().build();
+
+        var result = validator.validate(input);
+
+        assertThat(result).isFailed().extracting(ValidationFailure::getViolations).asInstanceOf(list(Violation.class))
+                .isNotEmpty()
+                .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(EDR_REQUEST_DTO_CONNECTOR_ADDRESS))
+                .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(EDR_REQUEST_DTO_PROTOCOL))
+                .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(EDR_REQUEST_DTO_OFFER));
+    }
+
+    @Test
+    void shouldFail_whenOfferMandatoryPropertiesAreMissing() {
+        var input = Json.createObjectBuilder()
+                .add(EDR_REQUEST_DTO_CONNECTOR_ADDRESS, value("http://connector-address"))
+                .add(EDR_REQUEST_DTO_PROTOCOL, value("protocol"))
+                .add(EDR_REQUEST_DTO_PROVIDER_ID, value("connector-id"))
+                .add(EDR_REQUEST_DTO_OFFER, createArrayBuilder().add(createObjectBuilder()))
+                .build();
+
+        var result = validator.validate(input);
+
+        assertThat(result).isFailed().extracting(ValidationFailure::getViolations).asInstanceOf(list(Violation.class))
+                .isNotEmpty()
+                .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(EDR_REQUEST_DTO_OFFER + "/" + OFFER_ID))
+                .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(EDR_REQUEST_DTO_OFFER + "/" + ASSET_ID))
+                .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(EDR_REQUEST_DTO_OFFER + "/" + POLICY));
+    }
+
+    private JsonArrayBuilder value(String value) {
+        return createArrayBuilder().add(createObjectBuilder().add(VALUE, value));
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,7 @@ edc-core-jetty = { module = "org.eclipse.edc:jetty-core", version.ref = "edc" }
 edc-core-jersey = { module = "org.eclipse.edc:jersey-core", version.ref = "edc" }
 edc-core-api = { module = "org.eclipse.edc:api-core", version.ref = "edc" }
 edc-core-sql = { module = "org.eclipse.edc:sql-core", version.ref = "edc" }
+edc-core-validator = { module = "org.eclipse.edc:validator-core", version.ref = "edc" }
 edc-statemachine = { module = "org.eclipse.edc:state-machine", version.ref = "edc" }
 edc-junit = { module = "org.eclipse.edc:junit", version.ref = "edc" }
 edc-api-management-config = { module = "org.eclipse.edc:management-api-configuration", version.ref = "edc" }
@@ -76,6 +77,7 @@ edc-ext-http = { module = "org.eclipse.edc:http", version.ref = "edc" }
 edc-ext-azure-cosmos-core = { module = "org.eclipse.edc:azure-cosmos-core", version.ref = "edc" }
 edc-ext-azure-test = { module = "org.eclipse.edc:azure-test", version.ref = "edc" }
 edc-ext-jsonld = { module = "org.eclipse.edc:json-ld", version.ref = "edc" }
+edc-ext-jersey-providers = { module = "org.eclipse.edc:jersey-providers", version.ref = "edc" }
 
 # implementations
 edc-sql-assetindex = { module = "org.eclipse.edc:asset-index-sql", version.ref = "edc" }


### PR DESCRIPTION
## WHAT

Adds validator when initiating a new EDR negotiation request

## WHY

consistency

## FURTHER NOTES

In all EDRs api the call to expand/compact where removed, since there is the interceptor that does that already

Closes #702 
