### PR TITLE
feat(helm): add customCaCerts value

### DIFF
--- a/charts/tractusx-connector-azure-vault/README.md
+++ b/charts/tractusx-connector-azure-vault/README.md
@@ -164,6 +164,7 @@ helm install my-release tractusx-edc/tractusx-connector-azure-vault --version 0.
 | controlplane.url.protocol | string | `""` | Explicitly declared url for reaching the dsp api (e.g. if ingresses not used) |
 | controlplane.volumeMounts | list | `[]` | declare where to mount [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) into the container |
 | controlplane.volumes | list | `[]` | [volume](https://kubernetes.io/docs/concepts/storage/volumes/) directories |
+| customCaCerts | object | `{}` | Add custom ca certificates to the truststore |
 | customLabels | object | `{}` | To add some custom labels |
 | dataplane.affinity | object | `{}` |  |
 | dataplane.autoscaling.enabled | bool | `false` | Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |

--- a/charts/tractusx-connector-azure-vault/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/deployment-controlplane.yaml
@@ -53,9 +53,39 @@ spec:
       serviceAccountName: {{ include "txdc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.controlplane.podSecurityContext | nindent 8 }}
-      {{- if .Values.controlplane.initContainers }}
+      {{- if or .Values.controlplane.initContainers .Values.customCaCerts }}
       initContainers:
+        {{- if .Values.controlplane.initContainers }}
         {{- toYaml .Values.controlplane.initContainers | nindent 8 }}
+        {{- end }}
+        {{- if .Values.customCaCerts }}
+        - name: custom-cacerts
+          # either use the specified image, or use the default one
+          {{- if .Values.controlplane.image.repository }}
+          image: "{{ .Values.controlplane.image.repository }}:{{ .Values.controlplane.image.tag | default .Chart.AppVersion }}"
+          {{- else }}
+          image: "tractusx/edc-controlplane-postgresql-azure-vault:{{ .Values.controlplane.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.controlplane.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cp /opt/java/openjdk/lib/security/cacerts /workdir/
+              find /cacerts -type f \( -iname \*.crt -o -iname \*.pem \) -exec echo "{}" \; | while read PEM_FILE_PATH; do
+                PEM_FILE=${PEM_FILE_PATH##*/}
+                ALIAS=${PEM_FILE%.*}
+                echo "adding ${PEM_FILE} with alias ${ALIAS} to cacerts ..."
+                keytool -import -noprompt -trustcacerts -alias ${ALIAS} -file ${PEM_FILE_PATH} -keystore /workdir/cacerts -storepass changeit
+              done
+          securityContext:
+            {{- toYaml .Values.controlplane.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: custom-cacertificates
+              mountPath: /cacerts
+            - name: custom-cacerts
+              mountPath: /workdir
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -349,6 +379,11 @@ spec:
             - name: "configuration"
               mountPath: "/app/logging.properties"
               subPath: "logging.properties"
+            {{- if .Values.customCaCerts }}
+            - name: custom-cacerts
+              mountPath: /opt/java/openjdk/lib/security/cacerts
+              subPath: cacerts
+            {{- end }}
             - name: "tmp"
               mountPath: "/tmp"
       volumes:
@@ -360,6 +395,15 @@ spec:
                 path: "opentelemetry.properties"
               - key: "logging.properties"
                 path: "logging.properties"
+        {{- if .Values.customCaCerts }}
+        - name: custom-cacertificates
+          configMap:
+            name: {{ include "txdc.fullname" . }}-custom-cacerts
+            defaultMode: 0400
+        - name: custom-cacerts
+          emptyDir:
+            sizeLimit: 1Mi
+        {{- end }}
         - name: "tmp"
           emptyDir: { }
       {{- with .Values.controlplane.nodeSelector }}

--- a/charts/tractusx-connector-azure-vault/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/deployment-controlplane.yaml
@@ -53,8 +53,10 @@ spec:
       serviceAccountName: {{ include "txdc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.controlplane.podSecurityContext | nindent 8 }}
+      {{- if .Values.controlplane.initContainers }}
       initContainers:
         {{- toYaml .Values.controlplane.initContainers | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/tractusx-connector-azure-vault/templates/deployment-dataplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/deployment-dataplane.yaml
@@ -53,8 +53,10 @@ spec:
       serviceAccountName: {{ include "txdc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.dataplane.podSecurityContext | nindent 8 }}
+      {{- if .Values.dataplane.initContainers }}
       initContainers:
         {{- toYaml .Values.dataplane.initContainers | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/tractusx-connector-azure-vault/templates/deployment-dataplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/deployment-dataplane.yaml
@@ -53,9 +53,39 @@ spec:
       serviceAccountName: {{ include "txdc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.dataplane.podSecurityContext | nindent 8 }}
-      {{- if .Values.dataplane.initContainers }}
+      {{- if or .Values.dataplane.initContainers .Values.customCaCerts }}
       initContainers:
+        {{- if .Values.dataplane.initContainers }}
         {{- toYaml .Values.dataplane.initContainers | nindent 8 }}
+        {{- end }}
+        {{- if .Values.customCaCerts }}
+        - name: custom-cacerts
+          # either use the specified image, or use the default one
+          {{- if .Values.dataplane.image.repository }}
+          image: "{{ .Values.dataplane.image.repository }}:{{ .Values.dataplane.image.tag | default .Chart.AppVersion }}"
+          {{- else }}
+          image: "tractusx/edc-dataplane-azure-vault:{{ .Values.dataplane.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.dataplane.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cp /opt/java/openjdk/lib/security/cacerts /workdir/
+              find /cacerts -type f \( -iname \*.crt -o -iname \*.pem \) -exec echo "{}" \; | while read PEM_FILE_PATH; do
+                PEM_FILE=${PEM_FILE_PATH##*/}
+                ALIAS=${PEM_FILE%.*}
+                echo "adding ${PEM_FILE} with alias ${ALIAS} to cacerts ..."
+                keytool -import -noprompt -trustcacerts -alias ${ALIAS} -file ${PEM_FILE_PATH} -keystore /workdir/cacerts -storepass changeit
+              done
+          securityContext:
+            {{- toYaml .Values.dataplane.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: custom-cacertificates
+              mountPath: /cacerts
+            - name: custom-cacerts
+              mountPath: /workdir
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -216,6 +246,11 @@ spec:
             - name: "configuration"
               mountPath: "/app/logging.properties"
               subPath: "logging.properties"
+            {{- if .Values.customCaCerts }}
+            - name: custom-cacerts
+              mountPath: /opt/java/openjdk/lib/security/cacerts
+              subPath: cacerts
+            {{- end }}
             - name: "tmp"
               mountPath: "/tmp"
       volumes:
@@ -227,6 +262,15 @@ spec:
                 path: "opentelemetry.properties"
               - key: "logging.properties"
                 path: "logging.properties"
+        {{- if .Values.customCaCerts }}
+        - name: custom-cacertificates
+          configMap:
+            name: {{ include "txdc.fullname" . }}-custom-cacerts
+            defaultMode: 0400
+        - name: custom-cacerts
+          emptyDir:
+            sizeLimit: 1Mi
+        {{- end }}
         - name: "tmp"
           emptyDir: { }
       {{- with .Values.dataplane.nodeSelector }}

--- a/charts/tractusx-connector-azure-vault/values.yaml
+++ b/charts/tractusx-connector-azure-vault/values.yaml
@@ -295,6 +295,9 @@ controlplane:
     # -- Explicitly declared url for reaching the dsp api (e.g. if ingresses not used)
     protocol: ""
 
+# -- Add custom ca certificates to the truststore
+customCaCerts: {}
+
 dataplane:
   image:
     # -- Which derivate of the data plane to use. when left empty the deployment will select the correct image automatically

--- a/charts/tractusx-connector-memory/README.md
+++ b/charts/tractusx-connector-memory/README.md
@@ -53,6 +53,7 @@ helm install my-release tractusx-edc/tractusx-connector-memory --version 0.5.0 \
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | backendService.httpProxyTokenReceiverUrl | string | `""` |  |
+| customCaCerts | object | `{}` | Add custom ca certificates to the truststore |
 | customLabels | object | `{}` | To add some custom labels |
 | daps.clientId | string | `""` |  |
 | daps.connectors[0].attributes.referringConnector | string | `"http://sokrates-controlplane/BPNSOKRATES"` |  |

--- a/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
+++ b/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
@@ -53,8 +53,10 @@ spec:
       serviceAccountName: {{ include "txdc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.runtime.podSecurityContext | nindent 8 }}
+      {{- if .Values.runtime.initContainers }}
       initContainers:
         {{- toYaml .Values.runtime.initContainers | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
+++ b/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
@@ -53,9 +53,39 @@ spec:
       serviceAccountName: {{ include "txdc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.runtime.podSecurityContext | nindent 8 }}
-      {{- if .Values.runtime.initContainers }}
+      {{- if or .Values.runtime.initContainers .Values.customCaCerts }}
       initContainers:
+        {{- if .Values.runtime.initContainers }}
         {{- toYaml .Values.runtime.initContainers | nindent 8 }}
+        {{- end }}
+        {{- if .Values.customCaCerts }}
+        - name: custom-cacerts
+          # either use the specified image, or use the default one
+          {{- if .Values.runtime.image.repository }}
+          image: "{{ .Values.runtime.image.repository }}:{{ .Values.runtime.image.tag | default .Chart.AppVersion }}"
+          {{- else }}
+          image: "tractusx/edc-runtime-memory:{{ .Values.runtime.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.runtime.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cp /opt/java/openjdk/lib/security/cacerts /workdir/
+              find /cacerts -type f \( -iname \*.crt -o -iname \*.pem \) -exec echo "{}" \; | while read PEM_FILE_PATH; do
+                PEM_FILE=${PEM_FILE_PATH##*/}
+                ALIAS=${PEM_FILE%.*}
+                echo "adding ${PEM_FILE} with alias ${ALIAS} to cacerts ..."
+                keytool -import -noprompt -trustcacerts -alias ${ALIAS} -file ${PEM_FILE_PATH} -keystore /workdir/cacerts -storepass changeit
+              done
+          securityContext:
+            {{- toYaml .Values.runtime.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: custom-cacertificates
+              mountPath: /cacerts
+            - name: custom-cacerts
+              mountPath: /workdir
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -278,6 +308,11 @@ spec:
             - name: "configuration"
               mountPath: "/app/logging.properties"
               subPath: "logging.properties"
+            {{- if .Values.customCaCerts }}
+            - name: custom-cacerts
+              mountPath: /opt/java/openjdk/lib/security/cacerts
+              subPath: cacerts
+            {{- end }}
             - name: "tmp"
               mountPath: "/tmp"
       volumes:
@@ -287,6 +322,15 @@ spec:
             items:
               - key: "logging.properties"
                 path: "logging.properties"
+        {{- if .Values.customCaCerts }}
+        - name: custom-cacertificates
+          configMap:
+            name: {{ include "txdc.fullname" . }}-custom-cacerts
+            defaultMode: 0400
+        - name: custom-cacerts
+          emptyDir:
+            sizeLimit: 1Mi
+        {{- end }}
         - name: "tmp"
           emptyDir: { }
       {{- with .Values.runtime.nodeSelector }}

--- a/charts/tractusx-connector-memory/values.yaml
+++ b/charts/tractusx-connector-memory/values.yaml
@@ -34,6 +34,9 @@ participant:
   # -- BPN Number
   id: ""
 
+# -- Add custom ca certificates to the truststore
+customCaCerts: {}
+
 runtime:
   image:
     repository: ""

--- a/charts/tractusx-connector/README.md
+++ b/charts/tractusx-connector/README.md
@@ -158,6 +158,7 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.5.0 \
 | controlplane.url.protocol | string | `""` | Explicitly declared url for reaching the dsp api (e.g. if ingresses not used) |
 | controlplane.volumeMounts | list | `[]` | declare where to mount [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) into the container |
 | controlplane.volumes | list | `[]` | [volume](https://kubernetes.io/docs/concepts/storage/volumes/) directories |
+| customCaCerts | object | `{}` | Add custom ca certificates to the truststore |
 | customLabels | object | `{}` | To add some custom labels |
 | dataplane.affinity | object | `{}` |  |
 | dataplane.autoscaling.enabled | bool | `false` | Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |

--- a/charts/tractusx-connector/templates/configmap-customcacerts.yaml
+++ b/charts/tractusx-connector/templates/configmap-customcacerts.yaml
@@ -1,0 +1,30 @@
+#
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+{{- if .Values.customCaCerts }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "txdc.fullname" . }}-custom-cacerts
+  namespace: {{ .Release.Namespace | default "default" | quote }}
+  labels:
+    {{- include "txdc.labels" . | nindent 4 }}
+data:
+  {{- .Values.customCaCerts | toYaml | nindent 2 }}
+{{- end }}

--- a/charts/tractusx-connector/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-controlplane.yaml
@@ -53,9 +53,39 @@ spec:
       serviceAccountName: {{ include "txdc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.controlplane.podSecurityContext | nindent 8 }}
-      {{- if .Values.controlplane.initContainers }}
+      {{- if or .Values.controlplane.initContainers .Values.customCaCerts }}
       initContainers:
+        {{- if .Values.controlplane.initContainers }}
         {{- toYaml .Values.controlplane.initContainers | nindent 8 }}
+        {{- end }}
+        {{- if .Values.customCaCerts }}
+        - name: custom-cacerts
+          # either use the specified image, or use the default one
+          {{- if .Values.controlplane.image.repository }}
+          image: "{{ .Values.controlplane.image.repository }}:{{ .Values.controlplane.image.tag | default .Chart.AppVersion }}"
+          {{- else }}
+          image: "tractusx/edc-controlplane-postgresql-hashicorp-vault:{{ .Values.controlplane.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.controlplane.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cp /opt/java/openjdk/lib/security/cacerts /workdir/
+              find /cacerts -type f \( -iname \*.crt -o -iname \*.pem \) -exec echo "{}" \; | while read PEM_FILE_PATH; do
+                PEM_FILE=${PEM_FILE_PATH##*/}
+                ALIAS=${PEM_FILE%.*}
+                echo "adding ${PEM_FILE} with alias ${ALIAS} to cacerts ..."
+                keytool -import -noprompt -trustcacerts -alias ${ALIAS} -file ${PEM_FILE_PATH} -keystore /workdir/cacerts -storepass changeit
+              done
+          securityContext:
+            {{- toYaml .Values.controlplane.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: custom-cacertificates
+              mountPath: /cacerts
+            - name: custom-cacerts
+              mountPath: /workdir
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -347,6 +377,11 @@ spec:
             - name: "configuration"
               mountPath: "/app/logging.properties"
               subPath: "logging.properties"
+            {{- if .Values.customCaCerts }}
+            - name: custom-cacerts
+              mountPath: /opt/java/openjdk/lib/security/cacerts
+              subPath: cacerts
+            {{- end }}
             - name: "tmp"
               mountPath: "/tmp"
       volumes:
@@ -358,6 +393,15 @@ spec:
                 path: "opentelemetry.properties"
               - key: "logging.properties"
                 path: "logging.properties"
+        {{- if .Values.customCaCerts }}
+        - name: custom-cacertificates
+          configMap:
+            name: {{ include "txdc.fullname" . }}-custom-cacerts
+            defaultMode: 0400
+        - name: custom-cacerts
+          emptyDir:
+            sizeLimit: 1Mi
+        {{- end }}
         - name: "tmp"
           emptyDir: { }
       {{- with .Values.controlplane.nodeSelector }}

--- a/charts/tractusx-connector/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-controlplane.yaml
@@ -53,8 +53,10 @@ spec:
       serviceAccountName: {{ include "txdc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.controlplane.podSecurityContext | nindent 8 }}
+      {{- if .Values.controlplane.initContainers }}
       initContainers:
         {{- toYaml .Values.controlplane.initContainers | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/tractusx-connector/templates/deployment-dataplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-dataplane.yaml
@@ -53,9 +53,39 @@ spec:
       serviceAccountName: {{ include "txdc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.dataplane.podSecurityContext | nindent 8 }}
-      {{- if .Values.dataplane.initContainers }}
+      {{- if or .Values.dataplane.initContainers .Values.customCaCerts }}
       initContainers:
+        {{- if .Values.dataplane.initContainers }}
         {{- toYaml .Values.dataplane.initContainers | nindent 8 }}
+        {{- end }}
+        {{- if .Values.customCaCerts }}
+        - name: custom-cacerts
+          # either use the specified image, or use the default one
+          {{- if .Values.dataplane.image.repository }}
+          image: "{{ .Values.dataplane.image.repository }}:{{ .Values.dataplane.image.tag | default .Chart.AppVersion }}"
+          {{- else }}
+          image: "tractusx/edc-dataplane-hashicorp-vault:{{ .Values.dataplane.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.dataplane.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cp /opt/java/openjdk/lib/security/cacerts /workdir/
+              find /cacerts -type f \( -iname \*.crt -o -iname \*.pem \) -exec echo "{}" \; | while read PEM_FILE_PATH; do
+                PEM_FILE=${PEM_FILE_PATH##*/}
+                ALIAS=${PEM_FILE%.*}
+                echo "adding ${PEM_FILE} with alias ${ALIAS} to cacerts ..."
+                keytool -import -noprompt -trustcacerts -alias ${ALIAS} -file ${PEM_FILE_PATH} -keystore /workdir/cacerts -storepass changeit
+              done
+          securityContext:
+            {{- toYaml .Values.dataplane.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: custom-cacertificates
+              mountPath: /cacerts
+            - name: custom-cacerts
+              mountPath: /workdir
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -215,6 +245,11 @@ spec:
             - name: "configuration"
               mountPath: "/app/logging.properties"
               subPath: "logging.properties"
+            {{- if .Values.customCaCerts }}
+            - name: custom-cacerts
+              mountPath: /opt/java/openjdk/lib/security/cacerts
+              subPath: cacerts
+            {{- end }}
             - name: "tmp"
               mountPath: "/tmp"
       volumes:
@@ -226,6 +261,15 @@ spec:
                 path: "opentelemetry.properties"
               - key: "logging.properties"
                 path: "logging.properties"
+        {{- if .Values.customCaCerts }}
+        - name: custom-cacertificates
+          configMap:
+            name: {{ include "txdc.fullname" . }}-custom-cacerts
+            defaultMode: 0400
+        - name: custom-cacerts
+          emptyDir:
+            sizeLimit: 1Mi
+        {{- end }}
         - name: "tmp"
           emptyDir: { }
       {{- with .Values.dataplane.nodeSelector }}

--- a/charts/tractusx-connector/templates/deployment-dataplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-dataplane.yaml
@@ -53,8 +53,10 @@ spec:
       serviceAccountName: {{ include "txdc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.dataplane.podSecurityContext | nindent 8 }}
+      {{- if .Values.dataplane.initContainers }}
       initContainers:
         {{- toYaml .Values.dataplane.initContainers | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -292,6 +292,10 @@ controlplane:
   url:
     # -- Explicitly declared url for reaching the dsp api (e.g. if ingresses not used)
     protocol: ""
+
+# -- Add custom ca certificates to the truststore
+customCaCerts: {}
+
 dataplane:
   image:
     # -- Which derivate of the data plane to use. when left empty the deployment will select the correct image automatically


### PR DESCRIPTION
## WHAT

Add Helm chart value (`customCaCerts`) to support adding additional custom ca-certs to the control- and dataplane pods.

## WHY

If your company is using a certificate authority which is not inside the common `/opt/java/openjdk/lib/security/cacerts` file connections will not be trusted.
A connection in between will then fail in lack of trusted certificates.
When only using public signed certificate you will not need this value.

## HOW

With this change you will be able to specify additional custom certificates as follows in your values file:

```yaml
customCaCerts:
  YourCompany.pem: |
    -----BEGIN CERTIFICATE-----
    MIICuzCCAaMCAQAwMzELMAkGA1UEBhMCREUxEDAOBgNVBAgMB0JhdmFyaWExEjAQ
    ...
    -----END CERTIFICATE-----
```

When one or more certificates are added to the dict they will be each added via a initContainer and emptyDir to both cp and dp.

To view the added certificates you can run the keytool with following command:

`keytool -list -keystore /opt/java/openjdk/lib/security/cacerts -storepass changeit | grep -i your-cert-name`


<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))
