### PR TITLE
Fix: Add missing OpenAPI parameter

### DIFF
--- a/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/EdrApi.java
+++ b/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/EdrApi.java
@@ -44,7 +44,7 @@ public interface EdrApi {
 
     @Operation(description = "Returns all EndpointDataReference entry according to a query",
             responses = {
-                    @ApiResponse(responseCode = "200",
+                    @ApiResponse(responseCode = "200", description = "The ERD cache was retrieved",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = EdrSchema.EndpointDataReferenceEntrySchema.class)))),
                     @ApiResponse(responseCode = "400", description = "Request was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))) }


### PR DESCRIPTION
## WHAT

Fix missing openapi parameter. The rest of the issues are from upstream. Will look at them next.

## WHY

Our openapi documentation has errors and cannot be parsed right now.