### PR TITLE
fix: add binding to tx namespace for credential policy

### DIFF
--- a/core/json-ld-core/build.gradle.kts
+++ b/core/json-ld-core/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":spi:core-spi"))
     implementation(libs.edc.spi.core)
     implementation(libs.edc.spi.jsonld)
     testImplementation(testFixtures(libs.edc.junit))

--- a/core/json-ld-core/src/main/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtension.java
+++ b/core/json-ld-core/src/main/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtension.java
@@ -29,10 +29,15 @@ import java.util.Map;
 
 import static java.lang.String.format;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.EDC_CONTEXT;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_CONTEXT;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_PREFIX;
 
 public class JsonLdExtension implements ServiceExtension {
 
     public static final String CREDENTIALS_V_1 = "https://www.w3.org/2018/credentials/v1";
+
     public static final String CREDENTIALS_SUMMARY_V_1 = "https://w3id.org/2023/catenax/credentials/summary/v1";
     public static final String CREDENTIALS_SUMMARY_V_1_FALLBACK = "https://catenax-ng.github.io/product-core-schemas/SummaryVC.json";
     public static final String SECURITY_JWS_V1 = "https://w3id.org/security/suites/jws-2020/v1";
@@ -43,7 +48,9 @@ public class JsonLdExtension implements ServiceExtension {
             CREDENTIALS_SUMMARY_V_1, PREFIX + "summary-vc-context-v1.jsonld",
             CREDENTIALS_SUMMARY_V_1_FALLBACK, PREFIX + "summary-vc-context-v1.jsonld",
             SECURITY_JWS_V1, PREFIX + "security-jws-2020.jsonld",
-            SECURITY_ED25519_V1, PREFIX + "security-ed25519-2020.jsonld");
+            SECURITY_ED25519_V1, PREFIX + "security-ed25519-2020.jsonld",
+            TX_CONTEXT, PREFIX + "tx-v1.jsonld",
+            EDC_CONTEXT, PREFIX + "edc-v1.jsonld");
     @Inject
     private JsonLd jsonLdService;
 
@@ -52,6 +59,7 @@ public class JsonLdExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
+        jsonLdService.registerNamespace(TX_PREFIX, TX_NAMESPACE);
         FILES.entrySet().stream().map(this::mapToFile)
                 .forEach(result -> result.onSuccess(entry -> jsonLdService.registerCachedDocument(entry.getKey(), entry.getValue()))
                         .onFailure(failure -> monitor.warning("Failed to register cached json-ld document: " + failure.getFailureDetail())));

--- a/core/json-ld-core/src/main/resources/document/edc-v1.jsonld
+++ b/core/json-ld-core/src/main/resources/document/edc-v1.jsonld
@@ -1,0 +1,47 @@
+{
+  "@context": {
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+    "schema": "http://schema.org/",
+    "PolicyDefinition": "edc:PolicyDefinition",
+    "AssetEntryNewDto": "edc:AssetEntryNewDto",
+    "DataAddress": "edc:DataAddress",
+    "NegotiationState": "edc:NegotiationState",
+    "TerminateNegotiation": "edc:TerminateNegotiation",
+    "ContractRequest": "edc:ContractRequest",
+    "policy": {
+      "@id": "edc:policy",
+      "@type": "@id",
+      "@context": [
+        "http://www.w3.org/ns/odrl.jsonld"
+      ]
+    },
+    "createdAt": "edc:createdAt",
+    "properties": "edc:properties",
+    "privateProperties": "edc:privateProperties",
+    "dataAddress": "edc:dataAddress",
+    "type": "edc:type",
+    "counterPartyAddress": "edc:counterPartyAddress",
+    "protocol": "edc:protocol",
+    "querySpec": "edc:querySpec",
+    "accessPolicyId": "edc:accessPolicyId",
+    "contractPolicyId": "edc:contractPolicyId",
+    "assetsSelector": "edc:assetsSelector",
+    "state": "edc:state",
+    "reason": "edc:reason",
+    "connectorAddress": "edc:connectorAddress",
+    "offer": "edc:offer",
+    "asset": "edc:asset",
+    "offerId": "edc:offerId",
+    "assetId": "edc:assetId",
+    "contractId": "edc:contractId",
+    "connectorId": "edc:connectorId",
+    "callbackAddresses": "edc:callbackAddresses",
+    "dataDestination": "edc:dataDestination",
+    "baseUrl": "edc:baseUrl",
+    "providerId": "edc:providerId",
+    "uri": "edc:uri",
+    "events": "edc:events",
+    "transactional": "edc:transactional"
+  }
+}

--- a/core/json-ld-core/src/main/resources/document/tx-v1.jsonld
+++ b/core/json-ld-core/src/main/resources/document/tx-v1.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "BusinessPartnerNumber": "tx:BusinessPartnerNumber",
+    "NegotiationInitiateRequestDto": "tx:NegotiationInitiateRequestDto",
+    "BusinessPartnerGroup": "tx:BusinessPartnerGroup",
+    "EndpointDataReferenceEntry": "tx:EndpointDataReferenceEntry",
+    "Membership": "tx:Membership",
+    "Dismantler": "tx:Dismantler",
+    "FrameworkAgreement.pcf": "tx:FrameworkAgreement.pcf",
+    "FrameworkAgreement.sustainability": "tx:FrameworkAgreement.sustainability",
+    "FrameworkAgreement.quality": "tx:FrameworkAgreement.quality",
+    "FrameworkAgreement.traceability": "tx:FrameworkAgreement.traceability",
+    "FrameworkAgreement.behavioraltwin": "tx:FrameworkAgreement.behavioraltwin",
+    "BPN": "tx:BPN",
+    "expirationDate": "tx:expirationDate",
+    "edrState": "tx:edrState"
+  }
+}

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/BusinessPartnerValidationExtension.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/BusinessPartnerValidationExtension.java
@@ -27,6 +27,7 @@ import org.eclipse.tractusx.edc.validation.businesspartner.spi.BusinessPartnerSt
 import static org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver.CATALOGING_SCOPE;
 import static org.eclipse.edc.connector.contract.spi.validation.ContractValidationService.NEGOTIATION_SCOPE;
 import static org.eclipse.edc.connector.contract.spi.validation.ContractValidationService.TRANSFER_SCOPE;
+import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
 
 /**
  * Registers a {@link org.eclipse.tractusx.edc.validation.businesspartner.functions.BusinessPartnerGroupFunction} for the following scopes:
@@ -49,7 +50,7 @@ import static org.eclipse.edc.connector.contract.spi.validation.ContractValidati
  * <p>
  * Note that the {@link BusinessPartnerGroupFunction} is an {@link org.eclipse.edc.policy.engine.spi.AtomicConstraintFunction}, thus it is registered with the {@link PolicyEngine}  for the {@link Permission} class.
  */
-@Extension(value = "Registers a function to evaluate whether a BPN number is covered by a certain policy or not", categories = {"policy", "contract"})
+@Extension(value = "Registers a function to evaluate whether a BPN number is covered by a certain policy or not", categories = { "policy", "contract" })
 public class BusinessPartnerValidationExtension implements ServiceExtension {
 
     private static final String USE = "USE";
@@ -71,6 +72,7 @@ public class BusinessPartnerValidationExtension implements ServiceExtension {
 
     private void bindToScope(BusinessPartnerGroupFunction function, String scope) {
         ruleBindingRegistry.bind(USE, scope);
+        ruleBindingRegistry.bind(ODRL_SCHEMA + "use", scope);
         ruleBindingRegistry.bind(BusinessPartnerGroupFunction.BUSINESS_PARTNER_CONSTRAINT_KEY, scope);
 
         policyEngine.registerFunction(scope, Permission.class, BusinessPartnerGroupFunction.BUSINESS_PARTNER_CONSTRAINT_KEY, function);

--- a/edc-extensions/cx-policy/build.gradle.kts
+++ b/edc-extensions/cx-policy/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":spi:core-spi"))
     implementation(project(":spi:ssi-spi"))
     implementation(libs.edc.spi.policyengine)
     implementation(libs.jakartaJson)

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/summary/SummaryConstraintFunctionsProvider.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/summary/SummaryConstraintFunctionsProvider.java
@@ -18,8 +18,12 @@ import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.policy.engine.spi.RuleBindingRegistry;
 import org.eclipse.edc.policy.model.Permission;
 
+import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Collections.unmodifiableMap;
+import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
 import static org.eclipse.tractusx.edc.policy.cx.common.PolicyScopes.CATALOG_REQUEST_SCOPE;
 import static org.eclipse.tractusx.edc.policy.cx.common.PolicyScopes.CATALOG_SCOPE;
 import static org.eclipse.tractusx.edc.policy.cx.common.PolicyScopes.NEGOTIATION_REQUEST_SCOPE;
@@ -35,16 +39,26 @@ public class SummaryConstraintFunctionsProvider {
     /**
      * Mappings from policy constraint left operand values to the corresponding item value in the summary VP.
      */
-    static final Map<String, String> CREDENTIAL_MAPPINGS = Map.of(
-            "Membership", "MembershipCredential",
-            "Dismantler", "DismantlerCredential",
-            "FrameworkAgreement.pcf", "PcfCredential",
-            "FrameworkAgreement.sustainability", "SustainabilityCredential",
-            "FrameworkAgreement.quality", "QualityCredential",
-            "FrameworkAgreement.traceability", "TraceabilityCredential",
-            "FrameworkAgreement.behavioraltwin", "BehaviorTwinCredential",
-            "BPN", "BpnCredential"
-    );
+    static final Map<String, String> CREDENTIAL_MAPPINGS;
+
+
+    static {
+        var initialMappings = Map.of(
+                "Membership", "MembershipCredential",
+                "Dismantler", "DismantlerCredential",
+                "FrameworkAgreement.pcf", "PcfCredential",
+                "FrameworkAgreement.sustainability", "SustainabilityCredential",
+                "FrameworkAgreement.quality", "QualityCredential",
+                "FrameworkAgreement.traceability", "TraceabilityCredential",
+                "FrameworkAgreement.behavioraltwin", "BehaviorTwinCredential",
+                "BPN", "BpnCredential"
+        );
+        var mappings = new HashMap<>(initialMappings);
+        initialMappings.forEach((credentialName, summaryType) -> {
+            mappings.put(TX_NAMESPACE + credentialName, summaryType);
+        });
+        CREDENTIAL_MAPPINGS = unmodifiableMap(mappings);
+    }
 
     /**
      * Configures and registers required summary functions with the policy engine.
@@ -84,6 +98,11 @@ public class SummaryConstraintFunctionsProvider {
             registry.bind(constraintName, NEGOTIATION_SCOPE);
             registry.bind(constraintName, TRANSFER_PROCESS_SCOPE);
         });
+
+        registry.bind(ODRL_SCHEMA + "use", CATALOG_SCOPE);
+        registry.bind(ODRL_SCHEMA + "use", NEGOTIATION_SCOPE);
+        registry.bind(ODRL_SCHEMA + "use", TRANSFER_PROCESS_SCOPE);
+
     }
 
 }

--- a/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/dto/NegotiateEdrRequestDto.java
+++ b/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/dto/NegotiateEdrRequestDto.java
@@ -25,7 +25,8 @@ import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
 
 public class NegotiateEdrRequestDto {
 
-    public static final String EDR_REQUEST_DTO_TYPE = TX_NAMESPACE + "NegotiateEdrRequestDto";
+    public static final String EDR_REQUEST_SIMPLE_DTO_TYPE = "NegotiateEdrRequestDto";
+    public static final String EDR_REQUEST_DTO_TYPE = TX_NAMESPACE + EDR_REQUEST_SIMPLE_DTO_TYPE;
     public static final String EDR_REQUEST_DTO_CONNECTOR_ADDRESS = EDC_NAMESPACE + "connectorAddress";
     public static final String EDR_REQUEST_DTO_PROTOCOL = EDC_NAMESPACE + "protocol";
     public static final String EDR_REQUEST_DTO_CONNECTOR_ID = EDC_NAMESPACE + "connectorId";

--- a/edc-tests/e2e-tests/src/test/resources/framework-policy.json
+++ b/edc-tests/e2e-tests/src/test/resources/framework-policy.json
@@ -1,0 +1,24 @@
+{
+  "@context": [
+    "https://w3id.org/edc/v0.0.1",
+    "https://w3id.org/tractusx/edc/v0.0.1",
+    "http://www.w3.org/ns/odrl.jsonld"
+  ],
+  "@type": "PolicyDefinitionRequest",
+  "@id": "${POLICY_ID}",
+  "policy": {
+    "@type": "Set",
+    "permission": [
+      {
+        "action": "use",
+        "constraint": [
+          {
+            "leftOperand": "${FRAMEWORK_CREDENTIAL}",
+            "operator": "eq",
+            "rightOperand": "active"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/spi/core-spi/src/main/java/org/eclipse/tractusx/edc/edr/spi/CoreConstants.java
+++ b/spi/core-spi/src/main/java/org/eclipse/tractusx/edc/edr/spi/CoreConstants.java
@@ -18,7 +18,10 @@ public final class CoreConstants {
 
     public static final String TX_PREFIX = "tx";
     public static final String TX_NAMESPACE = "https://w3id.org/tractusx/v0.0.1/ns/";
-    
+    public static final String TX_CONTEXT = "https://w3id.org/tractusx/edc/v0.0.1";
+    public static final String EDC_CONTEXT = "https://w3id.org/edc/v0.0.1";
+
+
     private CoreConstants() {
     }
 }


### PR DESCRIPTION
## WHAT

Add fix for `leftOperand` when using `@context` of odrl which get expanded with wrong namespace.

to fix this the functions are registered also in the `tx` namespace and the final usage will be 

```json
{
  "@context": {
    "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
    "tx" : "https://w3id.org/tractusx/v0.0.1/ns/"
  },
  "@type": "PolicyDefinition",
  "@id": "{{policy-id'}}",
  "policy": {
    "@context": "http://www.w3.org/ns/odrl.jsonld",
    "permission": {
      "action": "use",
      "constraint": {
        "leftOperand": "tx:Dismantler",
        "operator": "eq",
        "rightOperand": "active"
      }
    }
  }
}
```

## WHY

bugfix

## FURTHER NOTES

In addition in order to simplify policy expressions 2 context where drafted and added in the cache:

- tractusx 
- edc 

This two for the moment are just an exploration, once we decided that they works well we can proceed to upstream the
edc one and fetch the two persistent id in `https://w3id.org`

Here an example on how it will look like with `@context`

```json
{
  "@context": [
    "https://w3id.org/edc/v0.0.1",
    "https://w3id.org/tractusx/edc/v0.0.1",
    "http://www.w3.org/ns/odrl.jsonld"
  ],
  "@type": "PolicyDefinitionRequest",
  "@id": "${POLICY_ID}",
  "policy": {
    "@type": "Set",
    "permission": [
      {
        "action": "use",
        "constraint": [
          {
            "leftOperand": "Dismantler",
            "operator": "eq",
            "rightOperand": "active"
          }
        ]
      }
    ]
  }
}

```

Closes #616 