### PR TITLE
chore: update to EDC 0.2.1

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -149,17 +149,10 @@ jobs:
           POSTGRES_PASSWORD: password
 
     steps:
-      - name: Issue warning
-        run: |
-          echo "::warning file=verify.yaml,line=138,title=Deactivated PostgreSQL tests::Deactivated the PostgreSQL tests until https://github.com/eclipse-edc/Connector/pull/3336 is merged and packaged in a version"
-
       - uses: actions/checkout@v3
-        if: ${{ false }}  # disabled until https://github.com/eclipse-edc/Connector/pull/3336 is merged and packaged in a version
       - uses: ./.github/actions/setup-java
-        if: ${{ false }}  # disabled until https://github.com/eclipse-edc/Connector/pull/3336 is merged and packaged in a version
 
       - name: Run Postgresql E2E tests
-        if: ${{ false }}  # disabled until https://github.com/eclipse-edc/Connector/pull/3336 is merged and packaged in a version
         run: ./gradlew test -DincludeTags="PostgresqlIntegrationTest" -PverboseTest=true
 
   miw-integration-tests:

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -6,8 +6,8 @@ maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.2, Apache-2.0, approved, 
 maven/mavencentral/com.azure/azure-core-http-netty/1.13.5, MIT AND Apache-2.0, approved, #7948
 maven/mavencentral/com.azure/azure-core-http-netty/1.13.6, MIT AND Apache-2.0, approved, #7948
 maven/mavencentral/com.azure/azure-core/1.41.0, MIT AND Apache-2.0, approved, #9648
-maven/mavencentral/com.azure/azure-core/1.42.0, , restricted, clearlydefined
-maven/mavencentral/com.azure/azure-identity/1.10.0, , restricted, clearlydefined
+maven/mavencentral/com.azure/azure-core/1.42.0, MIT AND Apache-2.0, approved, #10089
+maven/mavencentral/com.azure/azure-identity/1.10.0, MIT AND Apache-2.0, approved, #10086
 maven/mavencentral/com.azure/azure-identity/1.9.2, MIT AND Apache-2.0, approved, #9686
 maven/mavencentral/com.azure/azure-json/1.0.1, MIT AND Apache-2.0, approved, #7933
 maven/mavencentral/com.azure/azure-security-keyvault-secrets/4.6.4, MIT, approved, #7940
@@ -126,9 +126,9 @@ maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.93.Final, Apa
 maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.29.0, , restricted, clearlydefined
-maven/mavencentral/io.opentelemetry/opentelemetry-api/1.29.0, , restricted, clearlydefined
-maven/mavencentral/io.opentelemetry/opentelemetry-context/1.29.0, , restricted, clearlydefined
+maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.29.0, Apache-2.0, approved, #10087
+maven/mavencentral/io.opentelemetry/opentelemetry-api/1.29.0, Apache-2.0, approved, #10088
+maven/mavencentral/io.opentelemetry/opentelemetry-context/1.29.0, Apache-2.0, approved, #10090
 maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.0.33, Apache-2.0, approved, #9687
 maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.0.33, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.projectreactor/reactor-core/3.4.30, Apache-2.0, approved, #7517

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -3,16 +3,13 @@ maven/mavencentral/com.apicatalog/iron-verifiable-credentials/0.8.1, Apache-2.0,
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.1, Apache-2.0, approved, #8912
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.2, Apache-2.0, approved, #8912
-maven/mavencentral/com.azure/azure-core-http-netty/1.13.4, MIT AND Apache-2.0, approved, #7948
 maven/mavencentral/com.azure/azure-core-http-netty/1.13.5, MIT AND Apache-2.0, approved, #7948
 maven/mavencentral/com.azure/azure-core-http-netty/1.13.6, MIT AND Apache-2.0, approved, #7948
-maven/mavencentral/com.azure/azure-core/1.40.0, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-core/1.41.0, MIT AND Apache-2.0, approved, #9648
 maven/mavencentral/com.azure/azure-core/1.42.0, , restricted, clearlydefined
 maven/mavencentral/com.azure/azure-identity/1.10.0, , restricted, clearlydefined
 maven/mavencentral/com.azure/azure-identity/1.9.2, MIT AND Apache-2.0, approved, #9686
 maven/mavencentral/com.azure/azure-json/1.0.1, MIT AND Apache-2.0, approved, #7933
-maven/mavencentral/com.azure/azure-security-keyvault-secrets/4.6.3, MIT, approved, #7940
 maven/mavencentral/com.azure/azure-security-keyvault-secrets/4.6.4, MIT, approved, #7940
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.10.3, Apache-2.0, approved, CQ21280
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.13.3, Apache-2.0, approved, clearlydefined
@@ -94,54 +91,44 @@ maven/mavencentral/dev.failsafe/failsafe/3.3.2, Apache-2.0, approved, #9268
 maven/mavencentral/info.picocli/picocli/4.6.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.github.classgraph/classgraph/4.8.138, MIT, approved, CQ22530
 maven/mavencentral/io.github.classgraph/classgraph/4.8.154, MIT, approved, CQ22530
-maven/mavencentral/io.micrometer/micrometer-commons/1.11.2, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9243
-maven/mavencentral/io.micrometer/micrometer-core/1.11.2, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9238
-maven/mavencentral/io.micrometer/micrometer-observation/1.11.2, Apache-2.0, approved, #9242
-maven/mavencentral/io.netty/netty-buffer/4.1.86.Final, Apache-2.0, approved, CQ21842
+maven/mavencentral/io.micrometer/micrometer-commons/1.11.3, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9243
+maven/mavencentral/io.micrometer/micrometer-core/1.11.3, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9238
+maven/mavencentral/io.micrometer/micrometer-observation/1.11.3, Apache-2.0, approved, #9242
 maven/mavencentral/io.netty/netty-buffer/4.1.93.Final, Apache-2.0, approved, CQ21842
 maven/mavencentral/io.netty/netty-buffer/4.1.94.Final, Apache-2.0, approved, CQ21842
 maven/mavencentral/io.netty/netty-codec-dns/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-http/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-codec-http/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-codec-http/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-http2/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-codec-http2/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-codec-http2/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-codec-socks/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-codec/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-codec/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-common/4.1.86.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
 maven/mavencentral/io.netty/netty-common/4.1.93.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
 maven/mavencentral/io.netty/netty-common/4.1.94.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
 maven/mavencentral/io.netty/netty-handler-proxy/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-handler-proxy/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-handler/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-handler/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-handler/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.1.93.Final, Apache-2.0, approved, #6367
 maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.1.93.Final, Apache-2.0, approved, #7004
 maven/mavencentral/io.netty/netty-resolver-dns/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-resolver/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-resolver/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-resolver/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-tcnative-boringssl-static/2.0.61.Final, Apache-2.0 OR LicenseRef-Public-Domain OR BSD-2-Clause OR MIT, approved, CQ15280
 maven/mavencentral/io.netty/netty-tcnative-classes/2.0.61.Final, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.86.Final, Apache-2.0, approved, #6366
 maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.94.Final, Apache-2.0, approved, #6366
 maven/mavencentral/io.netty/netty-transport-classes-kqueue/4.1.94.Final, Apache-2.0, approved, #4107
 maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport-native-kqueue/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.93.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.28.0, Apache-2.0, approved, #9662
-maven/mavencentral/io.opentelemetry/opentelemetry-api/1.28.0, Apache-2.0, approved, #9661
-maven/mavencentral/io.opentelemetry/opentelemetry-context/1.28.0, Apache-2.0, approved, #9663
+maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.29.0, , restricted, clearlydefined
+maven/mavencentral/io.opentelemetry/opentelemetry-api/1.29.0, , restricted, clearlydefined
+maven/mavencentral/io.opentelemetry/opentelemetry-context/1.29.0, , restricted, clearlydefined
 maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.0.33, Apache-2.0, approved, #9687
 maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.0.33, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.projectreactor/reactor-core/3.4.30, Apache-2.0, approved, #7517
@@ -206,126 +193,123 @@ maven/mavencentral/org.apache.sshd/sshd-sftp/2.10.0, Apache-2.0, approved, #8457
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
 maven/mavencentral/org.awaitility/awaitility/4.2.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.75, MIT, approved, #9166
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.76, MIT, approved, #9825
-maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.75, MIT AND CC0-1.0, approved, #9167
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.76, MIT AND CC0-1.0, approved, #9827
-maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.75, MIT, approved, #9170
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.76, MIT, approved, #9828
 maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.31.0, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.woodstox/stax2-api/4.2.1, BSD-2-Clause, approved, #2670
-maven/mavencentral/org.eclipse.edc/aggregate-service-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/api-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/api-observability/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/asset-api/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/asset-index-sql/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/asset-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/auth-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/auth-tokenbased/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/autodoc-processor/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/aws-s3-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/boot/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/callback-event-dispatcher/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/callback-http-dispatcher/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/catalog-api/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/catalog-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/catalog-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/configuration-filesystem/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/connector-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/contract-agreement-api/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/contract-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/contract-definition-api/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/contract-definition-store-sql/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/contract-negotiation-api/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/contract-negotiation-store-sql/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/contract-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/control-api-configuration/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/control-plane-aggregate-services/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/control-plane-api-client-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/control-plane-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/control-plane-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/core-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-api/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-aws-s3/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-client/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-framework/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-http-oauth2-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-http-oauth2/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-http-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-http/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-selector-client/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-selector-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-selector-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-util/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-api-configuration/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-catalog-api/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-catalog-http-dispatcher/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-catalog-transform/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-catalog/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-http-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-http-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-negotiation-api/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-negotiation-http-dispatcher/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-negotiation-transform/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-negotiation/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-transfer-process-api/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-transfer-process-http-dispatcher/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-transfer-process-transform/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp-transfer-process/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/dsp/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/http-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/http/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/iam-mock/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jersey-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jersey-micrometer/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jersey-providers/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jetty-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jetty-micrometer/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/json-ld-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/json-ld/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/junit/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jwt-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/jwt-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/management-api-configuration/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/management-api/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/micrometer-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/oauth2-client/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/oauth2-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-definition-api/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-definition-store-sql/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-engine-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-engine/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-evaluator/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-model/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/sql-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/sql-lease/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/sql-pool-apache-commons/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/state-machine/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transaction-datasource-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transaction-local/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transaction-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transfer-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transfer-data-plane-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transfer-data-plane/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transfer-process-api/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transfer-process-store-sql/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transfer-pull-http-dynamic-receiver/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transfer-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transform-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transform-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/util/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/validator-core/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/validator-spi/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/vault-azure/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/vault-hashicorp/0.2.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/web-spi/0.2.0, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/aggregate-service-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/api-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/api-observability/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/asset-api/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/asset-index-sql/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/asset-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/auth-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/auth-tokenbased/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/autodoc-processor/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/aws-s3-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/boot/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/callback-event-dispatcher/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/callback-http-dispatcher/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/catalog-api/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/catalog-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/catalog-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/configuration-filesystem/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/connector-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/contract-agreement-api/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/contract-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/contract-definition-api/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/contract-definition-store-sql/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/contract-negotiation-api/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/contract-negotiation-store-sql/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/contract-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/control-api-configuration/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/control-plane-aggregate-services/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/control-plane-api-client-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/control-plane-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/control-plane-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/core-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-api/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-aws-s3/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-client/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-framework/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-http-oauth2-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-http-oauth2/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-http-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-http/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-selector-client/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-selector-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-selector-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-util/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-api-configuration/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-catalog-api/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-catalog-http-dispatcher/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-catalog-transform/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-catalog/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-http-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-http-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-negotiation-api/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-negotiation-http-dispatcher/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-negotiation-transform/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-negotiation/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-transfer-process-api/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-transfer-process-http-dispatcher/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-transfer-process-transform/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp-transfer-process/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/dsp/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/http-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/http/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/iam-mock/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jersey-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jersey-micrometer/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jersey-providers/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jetty-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jetty-micrometer/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/json-ld-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/json-ld/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/junit/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jwt-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jwt-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/management-api-configuration/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/management-api/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/micrometer-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/oauth2-client/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/oauth2-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-definition-api/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-definition-store-sql/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-engine-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-engine/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-evaluator/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-model/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/sql-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/sql-lease/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/sql-pool-apache-commons/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/state-machine/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transaction-datasource-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transaction-local/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transaction-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transfer-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transfer-data-plane-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transfer-data-plane/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transfer-process-api/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transfer-process-store-sql/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transfer-pull-http-dynamic-receiver/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transfer-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transform-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transform-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/util/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/validator-core/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/validator-spi/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/vault-azure/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/vault-hashicorp/0.2.1, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/web-spi/0.2.1, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api/5.0.2, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-websocket-api/2.0.0, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty.websocket/websocket-core-client/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
@@ -354,15 +338,15 @@ maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.4, EPL-2.0 OR GPL-2.0-only with
 maven/mavencentral/org.glassfish.hk2/hk2-locator/3.0.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-utils/3.0.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/osgi-resource-locator/1.0.3, CDDL-1.0, approved, CQ10889
-maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet-core/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-client/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-common/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-server/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/3.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet-core/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-client/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-common/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-server/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
 maven/mavencentral/org.glassfish/jakarta.json/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsonp
 maven/mavencentral/org.hamcrest/hamcrest-core/1.3, BSD-2-Clause, approved, CQ11429
 maven/mavencentral/org.hamcrest/hamcrest/2.1, BSD-3-Clause, approved, clearlydefined
@@ -374,7 +358,6 @@ maven/mavencentral/org.jacoco/org.jacoco.core/0.8.8, EPL-2.0, approved, CQ23283
 maven/mavencentral/org.jacoco/org.jacoco.report/0.8.8, EPL-2.0 AND Apache-2.0, approved, CQ23284
 maven/mavencentral/org.javassist/javassist/3.25.0-GA, MPL-1.1 OR LGPL-2.1-or-later OR Apache-2.0, approved, CQ19885
 maven/mavencentral/org.javassist/javassist/3.28.0-GA, Apache-2.0 OR LGPL-2.1-or-later OR MPL-1.1, approved, #327
-maven/mavencentral/org.javassist/javassist/3.29.0-GA, Apache-2.0 AND LGPL-2.1-or-later AND MPL-1.1, approved, #6023
 maven/mavencentral/org.javassist/javassist/3.29.2-GA, Apache-2.0 AND LGPL-2.1-or-later AND MPL-1.1, approved, #6023
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-common/1.6.20, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-common/1.7.10, Apache-2.0, approved, clearlydefined
@@ -390,26 +373,18 @@ maven/mavencentral/org.jetbrains/annotations/17.0.0, Apache-2.0, approved, clear
 maven/mavencentral/org.jetbrains/annotations/24.0.1, Apache-2.0, approved, #7417
 maven/mavencentral/org.junit-pioneer/junit-pioneer/2.0.1, EPL-2.0, approved, clearlydefined
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.0, EPL-2.0, approved, #9714
-maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.9.3, EPL-2.0, approved, #3133
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.10.0, EPL-2.0, approved, #9711
-maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.9.3, EPL-2.0, approved, #3125
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.10.0, EPL-2.0, approved, #9708
-maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.9.3, EPL-2.0, approved, #3134
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.10.0, EPL-2.0, approved, #9715
-maven/mavencentral/org.junit.platform/junit-platform-commons/1.9.3, EPL-2.0, approved, #3130
 maven/mavencentral/org.junit.platform/junit-platform-engine/1.10.0, EPL-2.0, approved, #9709
-maven/mavencentral/org.junit.platform/junit-platform-engine/1.9.3, EPL-2.0, approved, #3128
 maven/mavencentral/org.junit.platform/junit-platform-launcher/1.10.0, EPL-2.0, approved, #9704
-maven/mavencentral/org.junit.platform/junit-platform-launcher/1.9.3, EPL-2.0, approved, #3132
 maven/mavencentral/org.junit/junit-bom/5.10.0, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.9.2, EPL-2.0, approved, #4711
-maven/mavencentral/org.junit/junit-bom/5.9.3, EPL-2.0, approved, #4711
 maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ21484
 maven/mavencentral/org.latencyutils/LatencyUtils/2.0.3, BSD-2-Clause, approved, CQ17408
 maven/mavencentral/org.mockito/mockito-core/5.2.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #7401
 maven/mavencentral/org.mockito/mockito-inline/5.2.0, MIT, approved, clearlydefined
 maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.opentest4j/opentest4j/1.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.opentest4j/opentest4j/1.3.0, Apache-2.0, approved, #9713
 maven/mavencentral/org.ow2.asm/asm-analysis/9.2, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.ow2.asm/asm-commons/9.2, BSD-3-Clause, approved, clearlydefined
@@ -441,46 +416,46 @@ maven/mavencentral/org.testcontainers/testcontainers/1.18.3, MIT, approved, #793
 maven/mavencentral/org.yaml/snakeyaml/1.33, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275
 maven/mavencentral/org.yaml/snakeyaml/2.1, Apache-2.0, approved, #9847
+maven/mavencentral/software.amazon.awssdk/annotations/2.20.123, Apache-2.0, approved, #8598
 maven/mavencentral/software.amazon.awssdk/annotations/2.20.125, Apache-2.0, approved, #8598
-maven/mavencentral/software.amazon.awssdk/annotations/2.20.91, Apache-2.0, approved, #8598
+maven/mavencentral/software.amazon.awssdk/apache-client/2.20.123, Apache-2.0, approved, #8609
 maven/mavencentral/software.amazon.awssdk/apache-client/2.20.125, Apache-2.0, approved, #8609
-maven/mavencentral/software.amazon.awssdk/apache-client/2.20.91, Apache-2.0, approved, #8609
+maven/mavencentral/software.amazon.awssdk/arns/2.20.123, Apache-2.0, approved, #8616
 maven/mavencentral/software.amazon.awssdk/arns/2.20.125, Apache-2.0, approved, #8616
-maven/mavencentral/software.amazon.awssdk/arns/2.20.91, Apache-2.0, approved, #8616
+maven/mavencentral/software.amazon.awssdk/auth/2.20.123, Apache-2.0, approved, #8602
 maven/mavencentral/software.amazon.awssdk/auth/2.20.125, Apache-2.0, approved, #8602
-maven/mavencentral/software.amazon.awssdk/auth/2.20.91, Apache-2.0, approved, #8602
+maven/mavencentral/software.amazon.awssdk/aws-core/2.20.123, Apache-2.0, approved, #8612
 maven/mavencentral/software.amazon.awssdk/aws-core/2.20.125, Apache-2.0, approved, #8612
-maven/mavencentral/software.amazon.awssdk/aws-core/2.20.91, Apache-2.0, approved, #8612
+maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.20.123, Apache-2.0, approved, #8629
 maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.20.125, Apache-2.0, approved, #8629
-maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.20.91, Apache-2.0, approved, #8629
+maven/mavencentral/software.amazon.awssdk/aws-xml-protocol/2.20.123, Apache-2.0, approved, #8624
 maven/mavencentral/software.amazon.awssdk/aws-xml-protocol/2.20.125, Apache-2.0, approved, #8624
-maven/mavencentral/software.amazon.awssdk/aws-xml-protocol/2.20.91, Apache-2.0, approved, #8624
+maven/mavencentral/software.amazon.awssdk/crt-core/2.20.123, Apache-2.0, approved, #8627
 maven/mavencentral/software.amazon.awssdk/crt-core/2.20.125, Apache-2.0, approved, #8627
-maven/mavencentral/software.amazon.awssdk/crt-core/2.20.91, Apache-2.0, approved, #8627
+maven/mavencentral/software.amazon.awssdk/endpoints-spi/2.20.123, Apache-2.0, approved, #8604
 maven/mavencentral/software.amazon.awssdk/endpoints-spi/2.20.125, Apache-2.0, approved, #8604
-maven/mavencentral/software.amazon.awssdk/endpoints-spi/2.20.91, Apache-2.0, approved, #8604
+maven/mavencentral/software.amazon.awssdk/http-client-spi/2.20.123, Apache-2.0, approved, #8608
 maven/mavencentral/software.amazon.awssdk/http-client-spi/2.20.125, Apache-2.0, approved, #8608
-maven/mavencentral/software.amazon.awssdk/http-client-spi/2.20.91, Apache-2.0, approved, #8608
-maven/mavencentral/software.amazon.awssdk/iam/2.20.91, Apache-2.0, approved, #9271
+maven/mavencentral/software.amazon.awssdk/iam/2.20.123, Apache-2.0, approved, #9271
+maven/mavencentral/software.amazon.awssdk/json-utils/2.20.123, Apache-2.0, approved, #8614
 maven/mavencentral/software.amazon.awssdk/json-utils/2.20.125, Apache-2.0, approved, #8614
-maven/mavencentral/software.amazon.awssdk/json-utils/2.20.91, Apache-2.0, approved, #8614
+maven/mavencentral/software.amazon.awssdk/metrics-spi/2.20.123, Apache-2.0, approved, #8636
 maven/mavencentral/software.amazon.awssdk/metrics-spi/2.20.125, Apache-2.0, approved, #8636
-maven/mavencentral/software.amazon.awssdk/metrics-spi/2.20.91, Apache-2.0, approved, #8636
+maven/mavencentral/software.amazon.awssdk/netty-nio-client/2.20.123, Apache-2.0, approved, #8613
 maven/mavencentral/software.amazon.awssdk/netty-nio-client/2.20.125, Apache-2.0, approved, #8613
-maven/mavencentral/software.amazon.awssdk/netty-nio-client/2.20.91, Apache-2.0, approved, #8613
+maven/mavencentral/software.amazon.awssdk/profiles/2.20.123, Apache-2.0, approved, #8600
 maven/mavencentral/software.amazon.awssdk/profiles/2.20.125, Apache-2.0, approved, #8600
-maven/mavencentral/software.amazon.awssdk/profiles/2.20.91, Apache-2.0, approved, #8600
+maven/mavencentral/software.amazon.awssdk/protocol-core/2.20.123, Apache-2.0, approved, #8635
 maven/mavencentral/software.amazon.awssdk/protocol-core/2.20.125, Apache-2.0, approved, #8635
-maven/mavencentral/software.amazon.awssdk/protocol-core/2.20.91, Apache-2.0, approved, #8635
+maven/mavencentral/software.amazon.awssdk/regions/2.20.123, Apache-2.0, approved, #8632
 maven/mavencentral/software.amazon.awssdk/regions/2.20.125, Apache-2.0, approved, #8632
-maven/mavencentral/software.amazon.awssdk/regions/2.20.91, Apache-2.0, approved, #8632
+maven/mavencentral/software.amazon.awssdk/s3/2.20.123, Apache-2.0, approved, #8623
 maven/mavencentral/software.amazon.awssdk/s3/2.20.125, Apache-2.0, approved, #8623
-maven/mavencentral/software.amazon.awssdk/s3/2.20.91, Apache-2.0, approved, #8623
+maven/mavencentral/software.amazon.awssdk/sdk-core/2.20.123, Apache-2.0, approved, #8611
 maven/mavencentral/software.amazon.awssdk/sdk-core/2.20.125, Apache-2.0, approved, #8611
-maven/mavencentral/software.amazon.awssdk/sdk-core/2.20.91, Apache-2.0, approved, #8611
-maven/mavencentral/software.amazon.awssdk/sts/2.20.91, Apache-2.0, approved, #9269
+maven/mavencentral/software.amazon.awssdk/sts/2.20.123, Apache-2.0, approved, #9269
+maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.20.123, Apache-2.0, approved, #8622
 maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.20.125, Apache-2.0, approved, #8622
-maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.20.91, Apache-2.0, approved, #8622
+maven/mavencentral/software.amazon.awssdk/utils/2.20.123, Apache-2.0, approved, #8625
 maven/mavencentral/software.amazon.awssdk/utils/2.20.125, Apache-2.0, approved, #8625
-maven/mavencentral/software.amazon.awssdk/utils/2.20.91, Apache-2.0, approved, #8625
 maven/mavencentral/software.amazon.eventstream/eventstream/1.0.1, Apache-2.0, approved, clearlydefined

--- a/core/edr-cache-core/build.gradle.kts
+++ b/core/edr-cache-core/build.gradle.kts
@@ -20,7 +20,6 @@ dependencies {
     implementation(libs.edc.spi.core)
     implementation(libs.edc.config.filesystem)
     implementation(libs.edc.util)
-    implementation(libs.edc.core.controlplane)
 
     implementation(project(":spi:edr-spi"))
 

--- a/core/edr-cache-core/build.gradle.kts
+++ b/core/edr-cache-core/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(libs.edc.spi.core)
     implementation(libs.edc.config.filesystem)
     implementation(libs.edc.util)
+    implementation(libs.edc.core.controlplane)
 
     implementation(project(":spi:edr-spi"))
 

--- a/core/edr-cache-core/src/main/java/org/eclipse/tractusx/edc/edr/core/defaults/EdrCacheEntryPredicateConverter.java
+++ b/core/edr-cache-core/src/main/java/org/eclipse/tractusx/edc/edr/core/defaults/EdrCacheEntryPredicateConverter.java
@@ -14,12 +14,110 @@
 
 package org.eclipse.tractusx.edc.edr.core.defaults;
 
-import org.eclipse.edc.connector.defaults.storage.CriterionToPredicateConverterImpl;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.CriterionToPredicateConverter;
 import org.eclipse.tractusx.edc.edr.spi.types.EndpointDataReferenceEntry;
+import org.jetbrains.annotations.NotNull;
 
-public class EdrCacheEntryPredicateConverter extends CriterionToPredicateConverterImpl {
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import static java.lang.String.format;
+
+/**
+ * This class is almost a 1:1 copy of the {@code CriterionToPredicateConverterImpl} (except for the {@code property()} method) from the {@code control-plane-core} module.
+ * Pulling in that module is not possible, because that would pull in almost the entire Control Plane
+ */
+public class EdrCacheEntryPredicateConverter implements CriterionToPredicateConverter {
 
     @Override
+    public <T> Predicate<T> convert(Criterion criterion) {
+        var operator = criterion.getOperator().toLowerCase();
+
+        return switch (operator) {
+            case "=" -> equalPredicate(criterion);
+            case "in" -> inPredicate(criterion);
+            case "like" -> likePredicate(criterion);
+            default -> throw new IllegalArgumentException(format("Operator [%s] is not supported by this converter!", criterion.getOperator()));
+        };
+    }
+
+    @NotNull
+    private <T> Predicate<T> equalPredicate(Criterion criterion) {
+        return t -> {
+            var operandLeft = (String) criterion.getOperandLeft();
+            var property = property(operandLeft, t);
+            if (property == null) {
+                return false;
+            }
+
+            if (property.getClass().isEnum() && criterion.getOperandRight() instanceof String) {
+                var enumProperty = (Enum<?>) property;
+                return Objects.equals(enumProperty.name(), criterion.getOperandRight());
+            }
+
+            if (property instanceof Number c1 && criterion.getOperandRight() instanceof Number c2) {
+                // interpret as double to not lose any precision
+                return Double.compare(c1.doubleValue(), c2.doubleValue()) == 0;
+            }
+
+            if (property instanceof List<?> list) {
+                return list.stream().anyMatch(it -> Objects.equals(it, criterion.getOperandRight()));
+            }
+
+            return Objects.equals(property, criterion.getOperandRight());
+        };
+    }
+
+    @NotNull
+    private <T> Predicate<T> inPredicate(Criterion criterion) {
+        return t -> {
+            var operandLeft = (String) criterion.getOperandLeft();
+            var property = property(operandLeft, t);
+            if (property == null) {
+                return false;
+            }
+
+            if (criterion.getOperandRight() instanceof Iterable<?> iterable) {
+                for (var value : iterable) {
+                    if (value.equals(property)) {
+                        return true;
+                    }
+                }
+                return false;
+            } else {
+                throw new IllegalArgumentException("Operator IN requires the right-hand operand to be an " + Iterable.class.getName() + " but was " + criterion.getOperandRight().getClass().getName());
+            }
+
+
+        };
+    }
+
+    @NotNull
+    private <T> Predicate<T> likePredicate(Criterion criterion) {
+        return t -> {
+            var operandLeft = (String) criterion.getOperandLeft();
+            var property = property(operandLeft, t);
+            if (property == null) {
+                return false;
+            }
+
+            if (criterion.getOperandRight() instanceof String operandRight) {
+                var regexPattern = Pattern.quote(operandRight)
+                        .replace("%", "\\E.*\\Q")
+                        .replace("_", "\\E.\\Q");
+
+                regexPattern = "^" + regexPattern + "$";
+
+                return Pattern.compile(regexPattern).matcher(property.toString()).matches();
+            }
+
+            return false;
+        };
+    }
+
     protected Object property(String key, Object object) {
         if (object instanceof EndpointDataReferenceEntry entry) {
             return switch (key) {

--- a/core/edr-cache-core/src/main/java/org/eclipse/tractusx/edc/edr/core/defaults/EdrCacheEntryPredicateConverter.java
+++ b/core/edr-cache-core/src/main/java/org/eclipse/tractusx/edc/edr/core/defaults/EdrCacheEntryPredicateConverter.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.tractusx.edc.edr.core.defaults;
 
-import org.eclipse.edc.spi.query.BaseCriterionToPredicateConverter;
+import org.eclipse.edc.connector.defaults.storage.CriterionToPredicateConverterImpl;
 import org.eclipse.tractusx.edc.edr.spi.types.EndpointDataReferenceEntry;
 
-public class EdrCacheEntryPredicateConverter extends BaseCriterionToPredicateConverter<EndpointDataReferenceEntry> {
+public class EdrCacheEntryPredicateConverter extends CriterionToPredicateConverterImpl {
 
     @Override
     protected Object property(String key, Object object) {

--- a/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/test/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/asset/model/ConsumerAssetRequestControllerTest.java
+++ b/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/test/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/asset/model/ConsumerAssetRequestControllerTest.java
@@ -297,7 +297,7 @@ public class ConsumerAssetRequestControllerTest extends RestControllerTestBase {
 
         var flowRequest = captor.getValue();
 
-        assertThat(flowRequest.getSourceDataAddress().getProperty(BASE_URL)).isEqualTo(edr.getEndpoint());
+        assertThat(flowRequest.getSourceDataAddress().getStringProperty(BASE_URL)).isEqualTo(edr.getEndpoint());
 
         assertThat(flowRequest.getProperties().get(QUERY_PARAMS)).isEqualTo(request.get(QUERY_PARAMS));
         assertThat(flowRequest.getProperties().get(PATH)).isEqualTo(request.get(PATH));

--- a/edc-extensions/edr/edr-api/src/test/java/org/eclipse/tractusx/edc/api/edr/transform/EndpointDataReferenceToDataAddressTransformerTest.java
+++ b/edc-extensions/edr/edr-api/src/test/java/org/eclipse/tractusx/edc/api/edr/transform/EndpointDataReferenceToDataAddressTransformerTest.java
@@ -51,10 +51,10 @@ public class EndpointDataReferenceToDataAddressTransformerTest {
 
         assertThat(dataAddress).isNotNull();
         assertThat(dataAddress.getType()).isEqualTo(EDR_SIMPLE_TYPE);
-        assertThat(dataAddress.getProperty(ID)).isEqualTo(dto.getId());
-        assertThat(dataAddress.getProperty(ENDPOINT)).isEqualTo(dto.getEndpoint());
-        assertThat(dataAddress.getProperty(AUTH_KEY)).isEqualTo(dto.getAuthKey());
-        assertThat(dataAddress.getProperty(AUTH_CODE)).isEqualTo(dto.getAuthCode());
+        assertThat(dataAddress.getStringProperty(ID)).isEqualTo(dto.getId());
+        assertThat(dataAddress.getStringProperty(ENDPOINT)).isEqualTo(dto.getEndpoint());
+        assertThat(dataAddress.getStringProperty(AUTH_KEY)).isEqualTo(dto.getAuthKey());
+        assertThat(dataAddress.getStringProperty(AUTH_CODE)).isEqualTo(dto.getAuthCode());
 
     }
 }

--- a/edc-extensions/edr/edr-callback/src/test/java/org/eclipse/tractusx/edc/callback/ContractNegotiationCallbackTest.java
+++ b/edc-extensions/edr/edr-callback/src/test/java/org/eclipse/tractusx/edc/callback/ContractNegotiationCallbackTest.java
@@ -17,14 +17,17 @@ package org.eclipse.tractusx.edc.callback;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationAccepted;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationAgreed;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationEvent;
+import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationFinalized;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationInitiated;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationOffered;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationRequested;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationTerminated;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationVerified;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.transfer.spi.types.TransferRequest;
+import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
@@ -59,6 +62,16 @@ public class ContractNegotiationCallbackTest {
     Monitor monitor = mock(Monitor.class);
 
     ContractNegotiationCallback callback;
+
+    private static <T extends ContractNegotiationEvent, B extends ContractNegotiationEvent.Builder<T, B>> B baseBuilder(B builder) {
+        var callbacks = List.of(CallbackAddress.Builder.newInstance().uri("http://local").events(Set.of("test")).build());
+        return builder
+                .contractNegotiationId("id")
+                .protocol("test")
+                .callbackAddresses(callbacks)
+                .counterPartyAddress("addr")
+                .counterPartyId("provider");
+    }
 
     @BeforeEach
     void setup() {
@@ -120,6 +133,23 @@ public class ContractNegotiationCallbackTest {
         verifyNoInteractions(transferProcessService);
     }
 
+    @Test
+    void invoke_whenFinalized() {
+        var evt = baseBuilder(ContractNegotiationFinalized.Builder.newInstance().contractAgreement(
+                ContractAgreement.Builder.newInstance()
+                        .providerId("test-provider")
+                        .assetId("test-asset")
+                        .policy(Policy.Builder.newInstance().build())
+                        .id("test-id")
+                        .consumerId("test-consumer")
+                        .build())).build();
+        var message = remoteMessage(evt);
+        when(transferProcessService.initiateTransfer(any())).thenReturn(ServiceResult.success(null));
+
+        callback.invoke(message);
+        verify(transferProcessService).initiateTransfer(any(TransferRequest.class));
+    }
+
     private static class EventInstances implements ArgumentsProvider {
 
         @Override
@@ -127,7 +157,6 @@ public class ContractNegotiationCallbackTest {
             return Stream.of(
                     baseBuilder(ContractNegotiationAccepted.Builder.newInstance()).build(),
                     baseBuilder(ContractNegotiationAgreed.Builder.newInstance()).build(),
-                    // baseBuilder(ContractNegotiationFinalized.Builder.newInstance()).build(),
                     baseBuilder(ContractNegotiationVerified.Builder.newInstance()).build(),
                     baseBuilder(ContractNegotiationInitiated.Builder.newInstance()).build(),
                     baseBuilder(ContractNegotiationOffered.Builder.newInstance()).build(),
@@ -137,14 +166,6 @@ public class ContractNegotiationCallbackTest {
 
         }
 
-        private <T extends ContractNegotiationEvent, B extends ContractNegotiationEvent.Builder<T, B>> B baseBuilder(B builder) {
-            var callbacks = List.of(CallbackAddress.Builder.newInstance().uri("http://local").events(Set.of("test")).build());
-            return builder
-                    .contractNegotiationId("id")
-                    .protocol("test")
-                    .callbackAddresses(callbacks)
-                    .counterPartyAddress("addr")
-                    .counterPartyId("provider");
-        }
+
     }
 }

--- a/edc-extensions/edr/edr-callback/src/test/java/org/eclipse/tractusx/edc/callback/ContractNegotiationCallbackTest.java
+++ b/edc-extensions/edr/edr-callback/src/test/java/org/eclipse/tractusx/edc/callback/ContractNegotiationCallbackTest.java
@@ -15,14 +15,13 @@
 package org.eclipse.tractusx.edc.callback;
 
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationAccepted;
-import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationConfirmed;
-import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationDeclined;
+import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationAgreed;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationEvent;
-import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationFailed;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationInitiated;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationOffered;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationRequested;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationTerminated;
+import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationVerified;
 import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.transfer.spi.types.TransferRequest;
@@ -127,9 +126,9 @@ public class ContractNegotiationCallbackTest {
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(
                     baseBuilder(ContractNegotiationAccepted.Builder.newInstance()).build(),
-                    baseBuilder(ContractNegotiationConfirmed.Builder.newInstance()).build(),
-                    baseBuilder(ContractNegotiationDeclined.Builder.newInstance()).build(),
-                    baseBuilder(ContractNegotiationFailed.Builder.newInstance()).build(),
+                    baseBuilder(ContractNegotiationAgreed.Builder.newInstance()).build(),
+                    // baseBuilder(ContractNegotiationFinalized.Builder.newInstance()).build(),
+                    baseBuilder(ContractNegotiationVerified.Builder.newInstance()).build(),
                     baseBuilder(ContractNegotiationInitiated.Builder.newInstance()).build(),
                     baseBuilder(ContractNegotiationOffered.Builder.newInstance()).build(),
                     baseBuilder(ContractNegotiationRequested.Builder.newInstance()).build(),

--- a/edc-extensions/postgresql-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/contractnegotiation/V0_0_7__Alter_ContractNegotiation_AddPendingField.sql
+++ b/edc-extensions/postgresql-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/contractnegotiation/V0_0_7__Alter_ContractNegotiation_AddPendingField.sql
@@ -1,0 +1,16 @@
+--
+--  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+--
+--  This program and the accompanying materials are made available under the
+--  terms of the Apache License, Version 2.0 which is available at
+--  https://www.apache.org/licenses/LICENSE-2.0
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+--  Contributors:
+--       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+--
+
+-- alter type of column "type"
+ALTER TABLE edc_contract_negotiation
+    ADD COLUMN pending BOOLEAN DEFAULT FALSE;

--- a/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSinkFactory.java
+++ b/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSinkFactory.java
@@ -37,15 +37,6 @@ public class SftpDataSinkFactory implements DataSinkFactory {
     }
 
     @Override
-    public @NotNull Result<Boolean> validate(DataFlowRequest request) {
-        if (!canHandle(request)) {
-            return Result.failure(String.format("Invalid DataFlowRequest: %s", request.getId()));
-        }
-
-        return VALID;
-    }
-
-    @Override
     public DataSink createSink(DataFlowRequest request) {
         if (!canHandle(request)) {
             return null;
@@ -64,5 +55,14 @@ public class SftpDataSinkFactory implements DataSinkFactory {
         SftpClientWrapper sftpClientWrapper = new SftpClientWrapperImpl(sftpClientConfig);
 
         return new SftpDataSink(sftpClientWrapper);
+    }
+
+    @Override
+    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
+        if (!canHandle(request)) {
+            return Result.failure(String.format("Invalid DataFlowRequest: %s", request.getId()));
+        }
+
+        return Result.success();
     }
 }

--- a/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSourceFactory.java
+++ b/edc-extensions/transferprocess-sftp-client/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSourceFactory.java
@@ -34,15 +34,6 @@ public class SftpDataSourceFactory implements DataSourceFactory {
     }
 
     @Override
-    public @NotNull Result<Boolean> validate(DataFlowRequest request) {
-        if (!canHandle(request)) {
-            return Result.failure(String.format("Invalid DataFlowRequest: %s", request.getId()));
-        }
-
-        return VALID;
-    }
-
-    @Override
     public DataSource createSource(DataFlowRequest request) {
         if (!canHandle(request)) {
             return null;
@@ -58,5 +49,13 @@ public class SftpDataSourceFactory implements DataSourceFactory {
 
         SftpClientWrapper sftpClientWrapper = new SftpClientWrapperImpl(sftpClientConfig);
         return new SftpDataSource(sftpClientWrapper);
+    }
+
+    @Override
+    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
+        if (!canHandle(request)) {
+            return Result.failure(String.format("Invalid DataFlowRequest: %s", request.getId()));
+        }
+        return Result.success();
     }
 }

--- a/edc-extensions/transferprocess-sftp-client/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSinkFactoryTest.java
+++ b/edc-extensions/transferprocess-sftp-client/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSinkFactoryTest.java
@@ -28,7 +28,6 @@ import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpLocation;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpUser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.List;
@@ -38,32 +37,32 @@ class SftpDataSinkFactoryTest {
 
     @Test
     void validate_valid() {
-        SftpDataSinkFactory dataSinkFactory = new SftpDataSinkFactory();
-        SftpUser sftpUser = SftpUser.Builder.newInstance().name("name").build();
-        SftpLocation sftpLocation = SftpLocation.Builder.newInstance().host("host").port(22).path("path").build();
+        var dataSinkFactory = new SftpDataSinkFactory();
+        var sftpUser = SftpUser.Builder.newInstance().name("name").build();
+        var sftpLocation = SftpLocation.Builder.newInstance().host("host").port(22).path("path").build();
 
-        SftpDataAddress sftpDataAddress =
+        var sftpDataAddress =
                 SftpDataAddress.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
-        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
+        var request = Mockito.mock(DataFlowRequest.class);
         Mockito.when(request.getDestinationDataAddress()).thenReturn(sftpDataAddress);
 
-        Assertions.assertTrue(dataSinkFactory.validate(request).succeeded());
+        Assertions.assertTrue(dataSinkFactory.validateRequest(request).succeeded());
     }
 
     @Test
     void validate_invalidDataAddressType() {
-        SftpDataSinkFactory dataSinkFactory = new SftpDataSinkFactory();
-        DataAddress dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
-        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
+        var dataSinkFactory = new SftpDataSinkFactory();
+        var dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
+        var request = Mockito.mock(DataFlowRequest.class);
         Mockito.when(request.getDestinationDataAddress()).thenReturn(dataAddress);
 
-        Assertions.assertTrue(dataSinkFactory.validate(request).failed());
+        Assertions.assertTrue(dataSinkFactory.validateRequest(request).failed());
     }
 
     @Test
     void validate_invalidDataAddressParameters() {
-        SftpDataSinkFactory dataSinkFactory = new SftpDataSinkFactory();
-        final Map<String, String> properties =
+        var dataSinkFactory = new SftpDataSinkFactory();
+        Map<String, Object> properties =
                 Map.of(
                         "type", "sftp",
                         "locationHost", "localhost",
@@ -72,33 +71,33 @@ class SftpDataSinkFactoryTest {
                         "userName", "name",
                         "userPassword", "password");
 
-        final DataAddress dataAddress =
+        final var dataAddress =
                 DataAddress.Builder.newInstance().properties(properties).build();
-        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
+        var request = Mockito.mock(DataFlowRequest.class);
         Mockito.when(request.getDestinationDataAddress()).thenReturn(dataAddress);
 
-        Assertions.assertTrue(dataSinkFactory.validate(request).failed());
+        Assertions.assertTrue(dataSinkFactory.validateRequest(request).failed());
     }
 
     @Test
     void createSink_successful() {
-        SftpDataSinkFactory dataSinkFactory = new SftpDataSinkFactory();
-        SftpUser sftpUser = SftpUser.Builder.newInstance().name("name").build();
-        SftpLocation sftpLocation =
+        var dataSinkFactory = new SftpDataSinkFactory();
+        var sftpUser = SftpUser.Builder.newInstance().name("name").build();
+        var sftpLocation =
                 SftpLocation.Builder.newInstance().host("127.0.0.1").port(22).path("path").build();
-        SftpClientConfig sftpClientConfig =
+        var sftpClientConfig =
                 SftpClientConfig.Builder.newInstance()
                         .writeOpenModes(List.of(SftpClient.OpenMode.Create, SftpClient.OpenMode.Append))
                         .sftpUser(sftpUser)
                         .sftpLocation(sftpLocation)
                         .build();
 
-        SftpDataAddress sftpDataAddress =
+        var sftpDataAddress =
                 SftpDataAddress.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
-        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
+        var request = Mockito.mock(DataFlowRequest.class);
         Mockito.when(request.getDestinationDataAddress()).thenReturn(sftpDataAddress);
 
-        try (MockedStatic<SftpClientWrapperImpl> staticWrapper =
+        try (var staticWrapper =
                      Mockito.mockStatic(SftpClientWrapperImpl.class)) {
             staticWrapper
                     .when(() -> SftpClientWrapperImpl.getSftpClient(sftpClientConfig))
@@ -112,9 +111,9 @@ class SftpDataSinkFactoryTest {
 
     @Test
     void createSink_invalidDataAddressType() {
-        SftpDataSinkFactory dataSinkFactory = new SftpDataSinkFactory();
-        DataAddress dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
-        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
+        var dataSinkFactory = new SftpDataSinkFactory();
+        var dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
+        var request = Mockito.mock(DataFlowRequest.class);
         Mockito.when(request.getDestinationDataAddress()).thenReturn(dataAddress);
 
         Assertions.assertNull(dataSinkFactory.createSink(request));

--- a/edc-extensions/transferprocess-sftp-client/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSourceFactoryTest.java
+++ b/edc-extensions/transferprocess-sftp-client/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/client/SftpDataSourceFactoryTest.java
@@ -28,41 +28,45 @@ import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpLocation;
 import org.eclipse.tractusx.edc.transferprocess.sftp.common.SftpUser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import java.util.Map;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 
 class SftpDataSourceFactoryTest {
 
     @Test
     void validate_valid() {
-        SftpDataSourceFactory dataSourceFactory = new SftpDataSourceFactory();
-        SftpUser sftpUser = SftpUser.Builder.newInstance().name("name").build();
-        SftpLocation sftpLocation = SftpLocation.Builder.newInstance().host("host").port(22).path("path").build();
+        var dataSourceFactory = new SftpDataSourceFactory();
+        var sftpUser = SftpUser.Builder.newInstance().name("name").build();
+        var sftpLocation = SftpLocation.Builder.newInstance().host("host").port(22).path("path").build();
 
-        SftpDataAddress sftpDataAddress =
+        var sftpDataAddress =
                 SftpDataAddress.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
-        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
-        Mockito.when(request.getSourceDataAddress()).thenReturn(sftpDataAddress);
+        var request = mock(DataFlowRequest.class);
+        when(request.getSourceDataAddress()).thenReturn(sftpDataAddress);
 
-        Assertions.assertTrue(dataSourceFactory.validate(request).succeeded());
+        Assertions.assertTrue(dataSourceFactory.validateRequest(request).succeeded());
     }
 
     @Test
     void validate_invalidDataAddressType() {
-        SftpDataSourceFactory dataSourceFactory = new SftpDataSourceFactory();
-        DataAddress dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
-        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
-        Mockito.when(request.getSourceDataAddress()).thenReturn(dataAddress);
+        var dataSourceFactory = new SftpDataSourceFactory();
+        var dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
+        var request = mock(DataFlowRequest.class);
+        when(request.getSourceDataAddress()).thenReturn(dataAddress);
 
-        Assertions.assertTrue(dataSourceFactory.validate(request).failed());
+        Assertions.assertTrue(dataSourceFactory.validateRequest(request).failed());
     }
 
     @Test
     void validate_invalidDataAddressParameters() {
-        SftpDataSourceFactory dataSourceFactory = new SftpDataSourceFactory();
-        final Map<String, String> properties =
+        var dataSourceFactory = new SftpDataSourceFactory();
+        Map<String, Object> properties =
                 Map.of(
                         "type", "sftp",
                         "locationHost", "localhost",
@@ -71,45 +75,45 @@ class SftpDataSourceFactoryTest {
                         "userName", "name",
                         "userPassword", "password");
 
-        DataAddress dataAddress = DataAddress.Builder.newInstance().properties(properties).build();
-        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
-        Mockito.when(request.getSourceDataAddress()).thenReturn(dataAddress);
+        var dataAddress = DataAddress.Builder.newInstance().properties(properties).build();
+        var request = mock(DataFlowRequest.class);
+        when(request.getSourceDataAddress()).thenReturn(dataAddress);
 
-        Assertions.assertTrue(dataSourceFactory.validate(request).failed());
+        Assertions.assertTrue(dataSourceFactory.validateRequest(request).failed());
     }
 
     @Test
     void createSink_successful() {
-        SftpDataSourceFactory dataSourceFactory = new SftpDataSourceFactory();
-        SftpUser sftpUser = SftpUser.Builder.newInstance().name("name").build();
-        SftpLocation sftpLocation =
+        var dataSourceFactory = new SftpDataSourceFactory();
+        var sftpUser = SftpUser.Builder.newInstance().name("name").build();
+        var sftpLocation =
                 SftpLocation.Builder.newInstance().host("127.0.0.1").port(22).path("path").build();
-        SftpClientConfig sftpClientConfig =
+        var sftpClientConfig =
                 SftpClientConfig.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
 
-        SftpDataAddress sftpDataAddress =
+        var sftpDataAddress =
                 SftpDataAddress.Builder.newInstance().sftpUser(sftpUser).sftpLocation(sftpLocation).build();
-        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
-        Mockito.when(request.getSourceDataAddress()).thenReturn(sftpDataAddress);
+        var request = mock(DataFlowRequest.class);
+        when(request.getSourceDataAddress()).thenReturn(sftpDataAddress);
 
-        try (MockedStatic<SftpClientWrapperImpl> staticWrapper =
-                     Mockito.mockStatic(SftpClientWrapperImpl.class)) {
+        try (var staticWrapper =
+                     mockStatic(SftpClientWrapperImpl.class)) {
             staticWrapper
                     .when(() -> SftpClientWrapperImpl.getSftpClient(sftpClientConfig))
-                    .thenReturn(Mockito.mock(SftpClient.class));
+                    .thenReturn(mock(SftpClient.class));
             Assertions.assertNotNull(dataSourceFactory.createSource(request));
 
             staticWrapper.verify(
-                    () -> SftpClientWrapperImpl.getSftpClient(Mockito.any()), Mockito.times(1));
+                    () -> SftpClientWrapperImpl.getSftpClient(any()), times(1));
         }
     }
 
     @Test
     void createSink_invalidDataAddressType() {
-        SftpDataSourceFactory dataSourceFactory = new SftpDataSourceFactory();
-        DataAddress dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
-        DataFlowRequest request = Mockito.mock(DataFlowRequest.class);
-        Mockito.when(request.getSourceDataAddress()).thenReturn(dataAddress);
+        var dataSourceFactory = new SftpDataSourceFactory();
+        var dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
+        var request = mock(DataFlowRequest.class);
+        when(request.getSourceDataAddress()).thenReturn(dataAddress);
 
         Assertions.assertNull(dataSourceFactory.createSource(request));
     }

--- a/edc-extensions/transferprocess-sftp-common/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/common/SftpDataAddress.java
+++ b/edc-extensions/transferprocess-sftp-common/src/main/java/org/eclipse/tractusx/edc/transferprocess/sftp/common/SftpDataAddress.java
@@ -57,25 +57,25 @@ public class SftpDataAddress extends DataAddress {
         } catch (NullPointerException e) {
             throw new EdcSftpException(e.getMessage(), e);
         } catch (NumberFormatException e) {
-            throw new EdcSftpException(format("Port for SftpLocation %s/%s not a number", dataAddress.getProperty(LOCATION_HOST), dataAddress.getProperty(LOCATION_PATH)), e);
+            throw new EdcSftpException(format("Port for SftpLocation %s/%s not a number", dataAddress.getStringProperty(LOCATION_HOST), dataAddress.getStringProperty(LOCATION_PATH)), e);
         }
     }
 
     private static SftpLocation createSftpLocation(DataAddress dataAddress) {
         return SftpLocation.Builder.newInstance()
-                .host(dataAddress.getProperty(LOCATION_HOST))
-                .port(Integer.parseInt(dataAddress.getProperty(LOCATION_PORT, "22")))
-                .path(dataAddress.getProperty(LOCATION_PATH))
+                .host(dataAddress.getStringProperty(LOCATION_HOST))
+                .port(Integer.parseInt(dataAddress.getStringProperty(LOCATION_PORT, "22")))
+                .path(dataAddress.getStringProperty(LOCATION_PATH))
                 .build();
     }
 
     private static SftpUser createSftpUser(DataAddress dataAddress) {
         return SftpUser.Builder.newInstance()
-                .name(dataAddress.getProperty(USER_NAME))
-                .password(dataAddress.getProperty(USER_PASSWORD))
+                .name(dataAddress.getStringProperty(USER_NAME))
+                .password(dataAddress.getStringProperty(USER_PASSWORD))
                 .keyPair(SftpUserKeyPairGenerator.getKeyPairFromPrivateKey(
-                        dataAddress.getProperty(USER_PRIVATE_KEY),
-                        dataAddress.getProperty(USER_NAME)))
+                        dataAddress.getStringProperty(USER_PRIVATE_KEY),
+                        dataAddress.getStringProperty(USER_NAME)))
                 .build();
     }
 

--- a/edc-extensions/transferprocess-sftp-common/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/common/SftpDataAddressTest.java
+++ b/edc-extensions/transferprocess-sftp-common/src/test/java/org/eclipse/tractusx/edc/transferprocess/sftp/common/SftpDataAddressTest.java
@@ -32,7 +32,7 @@ class SftpDataAddressTest {
 
     @Test
     void fromDataAddress_password() {
-        var properties = Map.of(
+        Map<String, Object> properties = Map.of(
                 "type", "sftp",
                 "locationHost", "localhost",
                 "locationPort", "22",
@@ -59,7 +59,7 @@ class SftpDataAddressTest {
         var keyPair = keyPairGenerator.generateKeyPair();
         var privateKeyBytes = keyPair.getPrivate().getEncoded();
 
-        var properties =
+        Map<String, Object> properties =
                 Map.of(
                         "type", "sftp",
                         "locationHost", "localhost",
@@ -84,7 +84,7 @@ class SftpDataAddressTest {
 
     @Test
     void fromDataAddress_noAuth() {
-        var properties =
+        Map<String, Object> properties =
                 Map.of(
                         "type", "sftp",
                         "locationHost", "localhost",
@@ -106,7 +106,7 @@ class SftpDataAddressTest {
 
     @Test
     void fromDataAddress_invalidKeyPairBrokenBase64() {
-        var properties =
+        Map<String, Object> properties =
                 Map.of(
                         "type", "sftp",
                         "locationHost", "localhost",
@@ -127,7 +127,7 @@ class SftpDataAddressTest {
 
     @Test
     void fromDataAddress_invalidKeyPairButCorrectBase64() {
-        var properties =
+        Map<String, Object> properties =
                 Map.of(
                         "type", "sftp",
                         "locationHost", "localhost",
@@ -148,7 +148,7 @@ class SftpDataAddressTest {
 
     @Test
     void fromDataAddress_portNaN() {
-        var properties =
+        Map<String, Object> properties =
                 Map.of(
                         "type", "sftp",
                         "locationHost", "localhost",
@@ -168,7 +168,7 @@ class SftpDataAddressTest {
 
     @Test
     void fromDataAddress_missingParameter() {
-        var properties =
+        Map<String, Object> properties =
                 Map.of(
                         "type", "sftp",
                         "locationPort", "22",
@@ -185,7 +185,7 @@ class SftpDataAddressTest {
 
     @Test
     void fromDataAddress_notSftp() {
-        var properties =
+        Map<String, Object> properties =
                 Map.of(
                         "type", "somethingOtherThanSftp",
                         "locationHost", "localhost",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 group=org.eclipse.tractusx.edc
 version=0.5.1-SNAPSHOT
 # configure the build:
-annotationProcessorVersion=0.2.0
-edcGradlePluginsVersion=0.2.0
-metaModelVersion=0.2.0
+annotationProcessorVersion=0.2.1
+edcGradlePluginsVersion=0.2.1
+metaModelVersion=0.2.1
 txScmConnection=scm:git:git@github.com:eclipse-tractusx/tractusx-edc.git
 txWebsiteUrl=https://github.com/eclipse-tractusx/tractusx-edc.git
 txScmUrl=https://github.com/eclipse-tractusx/tractusx-edc.git

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 format.version = "1.1"
 
 [versions]
-edc = "0.2.0"
+edc = "0.2.1"
 postgres = "42.6.0"
 awaitility = "4.2.0"
 nimbus = "9.31"


### PR DESCRIPTION
## WHAT

Upgrades to EDC 0.2.1 fixing some compiler errors in the process.

## WHY

Limit the technical debt

## FURTHER NOTES

- fixed som `final XYZ -> var` in the process
- Updates DEPENDENCIES
- Re-enables Postgres E2E Tests
- Removing the JWS2020 Suite will be done in another PR (it has been upstreamed)

Closes # <-- _insert Issue number if one exists_
