### PR TITLE
fix(legacyBpn): register also the namespaced version of the constraint key

### DIFF
--- a/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/LegacyBusinessPartnerValidationExtension.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/LegacyBusinessPartnerValidationExtension.java
@@ -37,6 +37,7 @@ import org.eclipse.tractusx.edc.validation.businesspartner.functions.legacy.Busi
 import static org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver.CATALOGING_SCOPE;
 import static org.eclipse.edc.connector.contract.spi.validation.ContractValidationService.NEGOTIATION_SCOPE;
 import static org.eclipse.edc.connector.contract.spi.validation.ContractValidationService.TRANSFER_SCOPE;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
 
 /**
  * Business partner number evaluation function.
@@ -61,6 +62,9 @@ public class LegacyBusinessPartnerValidationExtension implements ServiceExtensio
      * </pre>
      */
     public static final String BUSINESS_PARTNER_CONSTRAINT_KEY = "BusinessPartnerNumber";
+
+    public static final String TX_BUSINESS_PARTNER_CONSTRAINT_KEY = TX_NAMESPACE + BUSINESS_PARTNER_CONSTRAINT_KEY;
+
 
     public static final String DEFAULT_LOG_AGREEMENT_EVALUATION = "true";
 
@@ -107,10 +111,14 @@ public class LegacyBusinessPartnerValidationExtension implements ServiceExtensio
     private void bindToScope(BusinessPartnerDutyFunction dutyFunction, BusinessPartnerPermissionFunction permissionFunction, BusinessPartnerProhibitionFunction prohibitionFunction, String scope) {
         ruleBindingRegistry.bind("USE", scope);
         ruleBindingRegistry.bind(BUSINESS_PARTNER_CONSTRAINT_KEY, scope);
+        ruleBindingRegistry.bind(TX_BUSINESS_PARTNER_CONSTRAINT_KEY, scope);
+
 
         policyEngine.registerFunction(scope, Duty.class, BUSINESS_PARTNER_CONSTRAINT_KEY, dutyFunction);
         policyEngine.registerFunction(scope, Permission.class, BUSINESS_PARTNER_CONSTRAINT_KEY, permissionFunction);
         policyEngine.registerFunction(scope, Prohibition.class, BUSINESS_PARTNER_CONSTRAINT_KEY, prohibitionFunction);
+
+        policyEngine.registerFunction(scope, Permission.class, TX_BUSINESS_PARTNER_CONSTRAINT_KEY, permissionFunction);
     }
 
     private boolean logAgreementEvaluationSetting(ServiceExtensionContext context) {

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/helpers/PolicyHelperFunctions.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/helpers/PolicyHelperFunctions.java
@@ -44,6 +44,9 @@ public class PolicyHelperFunctions {
 
     public static final String TX_NAMESPACE = "https://w3id.org/tractusx/v0.0.1/ns/";
     private static final String BUSINESS_PARTNER_EVALUATION_KEY = "BusinessPartnerNumber";
+
+    public static final String BUSINESS_PARTNER_LEGACY_EVALUATION_KEY = TX_NAMESPACE + BUSINESS_PARTNER_EVALUATION_KEY;
+
     private static final String BUSINESS_PARTNER_CONSTRAINT_KEY = TX_NAMESPACE + "BusinessPartnerGroup";
 
     private static final ObjectMapper MAPPER = JacksonJsonLd.createObjectMapper();


### PR DESCRIPTION

## WHAT

Register the legacy `BusibessPartnerNumber` as constraint key with the namespaced version

## WHY

consistency

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #729
