### PR TITLE
fix:(charts): api key config missing in dataplane for proxy

### DIFF
--- a/charts/tractusx-connector-azure-vault/README.md
+++ b/charts/tractusx-connector-azure-vault/README.md
@@ -184,6 +184,7 @@ helm install my-release tractusx-edc/tractusx-connector-azure-vault --version 0.
 | dataplane.endpoints.default.port | int | `8080` |  |
 | dataplane.endpoints.metrics.path | string | `"/metrics"` |  |
 | dataplane.endpoints.metrics.port | int | `9090` |  |
+| dataplane.endpoints.proxy.authKey | string | `""` |  |
 | dataplane.endpoints.proxy.path | string | `"/proxy"` |  |
 | dataplane.endpoints.proxy.port | int | `8186` |  |
 | dataplane.endpoints.public.path | string | `"/api/public"` |  |

--- a/charts/tractusx-connector-azure-vault/templates/deployment-dataplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/deployment-dataplane.yaml
@@ -148,6 +148,8 @@ spec:
             #######
             # API #
             #######
+            - name: "EDC_API_AUTH_KEY"
+              value: {{ .Values.dataplane.endpoints.proxy.authKey | required ".Values.proxy.endpoints.proxy.authKey is required" | quote }}
             - name: "WEB_HTTP_DEFAULT_PORT"
               value: {{ .Values.dataplane.endpoints.default.port | quote }}
             - name: "WEB_HTTP_DEFAULT_PATH"

--- a/charts/tractusx-connector-azure-vault/values.yaml
+++ b/charts/tractusx-connector-azure-vault/values.yaml
@@ -354,6 +354,7 @@ dataplane:
     proxy:
       port: 8186
       path: /proxy
+      authKey: ""
     metrics:
       port: 9090
       path: /metrics

--- a/charts/tractusx-connector/README.md
+++ b/charts/tractusx-connector/README.md
@@ -178,6 +178,7 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.5.1 \
 | dataplane.endpoints.default.port | int | `8080` |  |
 | dataplane.endpoints.metrics.path | string | `"/metrics"` |  |
 | dataplane.endpoints.metrics.port | int | `9090` |  |
+| dataplane.endpoints.proxy.authKey | string | `""` |  |
 | dataplane.endpoints.proxy.path | string | `"/proxy"` |  |
 | dataplane.endpoints.proxy.port | int | `8186` |  |
 | dataplane.endpoints.public.path | string | `"/api/public"` |  |

--- a/charts/tractusx-connector/templates/deployment-dataplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-dataplane.yaml
@@ -148,6 +148,8 @@ spec:
             #######
             # API #
             #######
+            - name: "EDC_API_AUTH_KEY"
+              value: {{ .Values.dataplane.endpoints.proxy.authKey | required ".Values.proxy.endpoints.proxy.authKey is required" | quote }}
             - name: "WEB_HTTP_DEFAULT_PORT"
               value: {{ .Values.dataplane.endpoints.default.port | quote }}
             - name: "WEB_HTTP_DEFAULT_PATH"

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -352,6 +352,7 @@ dataplane:
     proxy:
       port: 8186
       path: /proxy
+      authKey: ""
     metrics:
       port: 9090
       path: /metrics

--- a/docs/samples/example-dataspace/plato-values.yaml
+++ b/docs/samples/example-dataspace/plato-values.yaml
@@ -48,6 +48,9 @@ controlplane:
           id: ""
           secretAlias: "client-secret"
 dataplane:
+  endpoints:
+    management:
+      authKey: password
   image:
     pullPolicy: Never
     tag: "latest"

--- a/docs/samples/example-dataspace/sokrates-values.yaml
+++ b/docs/samples/example-dataspace/sokrates-values.yaml
@@ -46,6 +46,9 @@ controlplane:
         id: ""
         secretAlias: "client-secret"
 dataplane:
+  endpoints:
+    proxy:
+      authKey: password
   image:
     pullPolicy: Never
     tag: "latest"

--- a/edc-tests/deployment/src/main/resources/helm/tractusx-connector-azure-vault-test.yaml
+++ b/edc-tests/deployment/src/main/resources/helm/tractusx-connector-azure-vault-test.yaml
@@ -57,6 +57,9 @@ controlplane:
     # avoids some errors in the log: cannot write temp files of large multipart requests when R/O
     readOnlyRootFilesystem: false
 dataplane:
+  endpoints:
+    proxy:
+      authKey: password
   image:
     pullPolicy: Never
     tag: "latest"

--- a/edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml
+++ b/edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml
@@ -44,6 +44,9 @@ controlplane:
       client:
         secretAlias: "client-secret"
 dataplane:
+  endpoints:
+    proxy:
+      authKey: password
   image:
     pullPolicy: Never
     tag: "latest"


### PR DESCRIPTION
## WHAT

api key config missing in dataplane for proxy

## WHY

bug, consistency


Closes #734 
