### PR TITLE
chore: upgrade docker base images

### DIFF
--- a/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:17.0.6_10-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:17.0.8_7-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin

--- a/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-memory-hashicorp-vault/src/main/docker/Dockerfile
@@ -19,7 +19,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
-FROM eclipse-temurin:17.0.6_10-jre-alpine
+FROM eclipse-temurin:17.0.8_7-jre-alpine
 ARG JAR
 ARG OTEL_JAR
 

--- a/edc-controlplane/edc-controlplane-postgresql-azure-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-postgresql-azure-vault/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:17.0.6_10-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:17.0.8_7-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin

--- a/edc-controlplane/edc-controlplane-postgresql-azure-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql-azure-vault/src/main/docker/Dockerfile
@@ -18,7 +18,7 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-FROM eclipse-temurin:17.0.6_10-jre-alpine
+FROM eclipse-temurin:17.0.8_7-jre-alpine
 ARG JAR
 ARG OTEL_JAR
 

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:17.0.6_10-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:17.0.8_7-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
@@ -19,7 +19,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
-FROM eclipse-temurin:17.0.6_10-jre-alpine
+FROM eclipse-temurin:17.0.8_7-jre-alpine
 ARG JAR
 ARG OTEL_JAR
 

--- a/edc-controlplane/edc-runtime-memory/notice.md
+++ b/edc-controlplane/edc-runtime-memory/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:17.0.6_10-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:17.0.8_7-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin

--- a/edc-controlplane/edc-runtime-memory/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-runtime-memory/src/main/docker/Dockerfile
@@ -20,7 +20,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
-FROM eclipse-temurin:17.0.6_10-jre-alpine
+FROM eclipse-temurin:17.0.8_7-jre-alpine
 ARG JAR
 
 ARG APP_USER=docker

--- a/edc-dataplane/edc-dataplane-azure-vault/notice.md
+++ b/edc-dataplane/edc-dataplane-azure-vault/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:17.0.6_10-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:17.0.8_7-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin

--- a/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
@@ -18,7 +18,7 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-FROM eclipse-temurin:17.0.6_10-jre-alpine
+FROM eclipse-temurin:17.0.8_7-jre-alpine
 ARG JAR
 ARG OTEL_JAR
 

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/notice.md
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:17.0.6_10-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:17.0.8_7-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
@@ -19,7 +19,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
-FROM eclipse-temurin:17.0.6_10-jre-alpine
+FROM eclipse-temurin:17.0.8_7-jre-alpine
 ARG JAR
 ARG OTEL_JAR
 


### PR DESCRIPTION
## WHAT

 upgrade docker base images to `eclipse-temurin:17.0.8_7-jre-alpine`

## WHY

security vulnerabilities in the current image


Closes #742 
