### PR TITLE
chore: fix create docker images jobs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -154,8 +154,7 @@ subprojects {
 
             val agentFile = project.buildDir.resolve("opentelemetry-javaagent.jar")
             // create task to download the opentelemetry agent
-            val openTelemetryAgentUrl =
-                "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.27.0/opentelemetry-javaagent.jar"
+            val openTelemetryAgentUrl = "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.27.0/opentelemetry-javaagent.jar"
             val downloadOtel = tasks.create("downloadOtel") {
                 // only execute task if the opentelemetry agent does not exist. invoke the "clean" task to force
                 onlyIf {


### PR DESCRIPTION
## WHAT

Fixes the publish artifact jobs

https://github.com/eclipse-tractusx/tractusx-edc/actions/runs/6073175379

## WHY

After this #749, the changes in the `build.gradle.kts` made the publish artifacts failing

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
