### PR TITLE
refactor: centralize edc version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,16 +33,14 @@ plugins {
 val txScmConnection: String by project
 val txWebsiteUrl: String by project
 val txScmUrl: String by project
-val annotationProcessorVersion: String by project
-val metaModelVersion: String by project
+val edcVersion = libs.versions.edc
 
 buildscript {
     repositories {
         mavenLocal()
     }
     dependencies {
-        val edcGradlePluginsVersion: String by project
-        classpath("org.eclipse.edc.edc-build:org.eclipse.edc.edc-build.gradle.plugin:${edcGradlePluginsVersion}")
+        classpath(libs.edc.build.plugin)
     }
 }
 
@@ -78,7 +76,7 @@ allprojects {
 
     // configure which version of the annotation processor to use. defaults to the same version as the plugin
     configure<org.eclipse.edc.plugins.autodoc.AutodocExtension> {
-        processorVersion.set(annotationProcessorVersion)
+        processorVersion.set(edcVersion)
         outputDirectory.set(project.buildDir)
         // uncomment the following lines to enable the Autodoc-2-Markdown converter
         // only available with EDC 0.2.1 SNAPSHOT
@@ -89,7 +87,7 @@ allprojects {
     configure<org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension> {
         versions {
             // override default dependency versions here
-            metaModel.set(metaModelVersion)
+            metaModel.set(edcVersion)
 
         }
         pom {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,6 @@
 group=org.eclipse.tractusx.edc
 version=0.5.2-SNAPSHOT
 # configure the build:
-annotationProcessorVersion=0.2.1
-edcGradlePluginsVersion=0.2.1
-metaModelVersion=0.2.1
 txScmConnection=scm:git:git@github.com:eclipse-tractusx/tractusx-edc.git
 txWebsiteUrl=https://github.com/eclipse-tractusx/tractusx-edc.git
 txScmUrl=https://github.com/eclipse-tractusx/tractusx-edc.git

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ edc-jwt-core = { module = "org.eclipse.edc:jwt-core", version.ref = "edc" }
 edc-spi-oauth2 = { module = "org.eclipse.edc:oauth2-spi", version.ref = "edc" }
 edc-util = { module = "org.eclipse.edc:util", version.ref = "edc" }
 edc-boot = { module = "org.eclipse.edc:boot", version.ref = "edc" }
+edc-build-plugin = { module = "org.eclipse.edc.edc-build:org.eclipse.edc.edc-build.gradle.plugin", version.ref = "edc" }
 edc-config-filesystem = { module = "org.eclipse.edc:configuration-filesystem", version.ref = "edc" }
 edc-jsonld = { module = "org.eclipse.edc:json-ld", version.ref = "edc" }
 edc-vault-filesystem = { module = "org.eclipse.edc:vault-filesystem", version.ref = "edc" }


### PR DESCRIPTION
## WHAT

removes 

```kotlin
val annotationProcessorVersion: String by project
val metaModelVersion: String by project
val edcGradlePluginsVersion: String by project
```

and the version from `gradle.properties` by using the centralized version in the catalog

## WHY

refactoring


Closes #753 
