### PR TITLE
docs: enriched the EDR API overview with transfer documentation

### DIFF
--- a/docs/samples/edr-api-overview/edr-api-overview.md
+++ b/docs/samples/edr-api-overview/edr-api-overview.md
@@ -23,9 +23,9 @@ This endpoint will perform the contract negotiation, transfer process and EDR st
 
 > Please note that the `data destination` will always be `HttpProxy`, requiring a request against the provider's `data-plane` to fetch the asset data.
 
-| Path                            | Method | Query Params             |
-|---------------------------------|--------|--------------------------|
-| `<MANAGEMENT_URL>/edrs`         | POST   | none                     |
+| Path                    | Method | Spec                                                                                                                                   |
+|-------------------------|--------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `<MANAGEMENT_URL>/edrs` | POST   | [OpenApi](https://app.swaggerhub.com/apis/eclipse-tractusx-bot/tractusx-edc/0.5.1#/Control%20Plane%20EDR%20Api/initiateEdrNegotiation) |
 
 #### Payload
 
@@ -77,8 +77,8 @@ This endpoint will perform the contract negotiation, transfer process and EDR st
 
 The EDR negotiation returns only the id of the negotiation process that has been started.
 
-The EDR negotiation rely on two steps, contract negotiation and transfer process, both of which are asynchronous.
-In order to plug-in and get notified in every state of the two state machines, callbacks can be configured while starting
+The EDR negotiation relies on two steps: contract negotiation and transfer process, both of which are asynchronous.
+In order to get notified in every state transition of the two state machines, callbacks can be configured when starting
 the EDR negotiation:
 
 ```json
@@ -98,21 +98,29 @@ the EDR negotiation:
 
 In this case we are interested only when the transfer process transition to the `STARTED` state.
 
+Available events type in callbacks are:
+
+- Transfer Process [`transfer.process.started`,`transfer.process.initiated`,`transfer.process.terminated`,`transfer.process.completed`]
+- Contract Negotiation [`contract.negotiation.initiated`,`contract.negotiation.agreed`,`contract.negotiation.accepted`, `contract.negotiation.terminated`,`contract.negotiation.finalized`]
+
+For getting all events in transfer process or contract negotiation we can simply use `transfer.process` or `contract.negotiation`
+in order to be notified of all state transition.
+
 Once the EDR has been negotiated with the provider, the EDR itself will be stored in the configured vault and the metadata
 associated to it in the configured datasource for future querying.
 
-Since `tractusx-edc` v0.5.1 the cached EDRs also come with a state machine that will manage the lifecycle of an EDR
-on the consumer side. That means that it will auto-renew itself when the expiration date is approaching by
-firing another transfer process request with the same parameters as the original one. Once renewed the old-one
-will transition to the state `EXPIRED` and it will be removed from the database and the vault according to the [configuration](../../../core/edr-core/README.md).
+Since `tractusx-edc` [v0.5.1](https://github.com/eclipse-tractusx/tractusx-edc/releases/tag/0.5.1) the cached EDRs also come with a state machine that will manage the lifecycle of an EDR
+on the consumer side. That means that it will auto-renew it is nearing its expiration date by
+firing another transfer process request with the same parameters as the original one. Once renewed, the old EDR
+will transition to the `EXPIRED` state, and it will be removed from the database and the vault according to the [configuration](../../../core/edr-core/README.md).
 
 ### EDR Management | Fetch cached EDRs
 
 This endpoint will retrieve all EDR entries by their `assetId` or `agreementId` references, which are passed as `query parameters`.
 
-| Path                                         | Method | Query Params         |
-|----------------------------------------------|--------|----------------------|
-| `<MANAGEMENT_URL>/edrs`                      | GET    | assetId, agreementId |
+| Path                    | Method | Spec                                                                                                                      |
+|-------------------------|--------|---------------------------------------------------------------------------------------------------------------------------|
+| `<MANAGEMENT_URL>/edrs` | GET    | [OpenApi](https://app.swaggerhub.com/apis/eclipse-tractusx-bot/tractusx-edc/0.5.1#/Control%20Plane%20EDR%20Api/queryEdrs) |
 
 #### EDR Entry Response
 
@@ -142,9 +150,9 @@ This endpoint will retrieve all EDR entries by their `assetId` or `agreementId` 
 
 This endpoint, through the `transfer-process-id` passed as `path variable`, will retrieve the actual EDR.
 
-| Path                                          | Method | Query Params             |
-|-----------------------------------------------|--------|--------------------------|
-| `<MANAGEMENT_URL>/edrs/{transfer-process-id}` | GET    | none                     |
+| Path                                          | Method | Spec                                                                                                                   |
+|-----------------------------------------------|--------|------------------------------------------------------------------------------------------------------------------------|
+| `<MANAGEMENT_URL>/edrs/{transfer-process-id}` | GET    | [OpenApi](https://app.swaggerhub.com/apis/eclipse-tractusx-bot/tractusx-edc/0.5.1#/Control%20Plane%20EDR%20Api/getEdr) |
 
 #### EDR Response
 
@@ -175,15 +183,15 @@ This endpoint, through the `transfer-process-id` passed as `path variable`, will
 This endpoint will delete the EDR entry associated with the `transfer-process-id` and it will remove the EDR itself
 from the vault.
 
-| Path                                          | Method | Query Params             |
-|-----------------------------------------------|--------|--------------------------|
-| `<MANAGEMENT_URL>/edrs/{transfer-process-id}` | DELETE | none                     |
+| Path                                          | Method | Spec                                                                                                                      |
+|-----------------------------------------------|--------|---------------------------------------------------------------------------------------------------------------------------|
+| `<MANAGEMENT_URL>/edrs/{transfer-process-id}` | DELETE | [OpenApi](https://app.swaggerhub.com/apis/eclipse-tractusx-bot/tractusx-edc/0.5.1#/Control%20Plane%20EDR%20Api/deleteEdr) |
 
 ### EDR Usage | Fetching data
 
 Once the EDR has been negotiated and stored, the data can be fetched in two ways depending on the use-case:
 
-- Provider data-plane (EDC way)
+- Provider data-plane ("EDC way")
 - Consumer proxy (Tractus-X EDC simplified)
 
 #### Provider data-plane
@@ -215,9 +223,9 @@ the data request on consumer side. The documentation is available [here](../../.
 
 The only API is:
 
-| Path                      | Method | Query Params             |
-|---------------------------|--------|--------------------------|
-| `<PROXY_URL>/aas/request` | POST   | none                     |
+| Path                      | Method | Spec                                                                                                                        |
+|---------------------------|--------|-----------------------------------------------------------------------------------------------------------------------------|
+| `<PROXY_URL>/aas/request` | POST   | [OpenApi](https://app.swaggerhub.com/apis/eclipse-tractusx-bot/tractusx-edc/0.5.1#/Data%20Plane%20Proxy%20API/requestAsset) |
 
 which fetches the data according to the input body. The body should contain the `assetId` plus `providerId` or the `transferProcessId`,
 which identifies the EDR to use for fetching data and an `endpointUrl` which is the [provider gateway](../../../edc-extensions/dataplane-proxy/edc-dataplane-proxy-provider-api/README.md)

--- a/docs/samples/edr-api-overview/edr-api-overview.md
+++ b/docs/samples/edr-api-overview/edr-api-overview.md
@@ -75,6 +75,37 @@ This endpoint will perform the contract negotiation, transfer process and EDR st
 }
 ```
 
+The EDR negotiation returns only the id of the negotiation process that has been started.
+
+The EDR negotiation rely on two steps, contract negotiation and transfer process, both of which are asynchronous.
+In order to plug-in and get notified in every state of the two state machines, callbacks can be configured while starting
+the EDR negotiation:
+
+```json
+{
+  ...
+  "callbackAddresses": [
+    {
+      "uri": "http://localhost:8080/hooks",
+      "events": [
+        "transfer.process.started"
+      ],
+      "transactional": false
+    }
+  ]
+}
+```
+
+In this case we are interested only when the transfer process transition to the `STARTED` state.
+
+Once the EDR has been negotiated with the provider, the EDR itself will be stored in the configured vault and the metadata
+associated to it in the configured datasource for future querying.
+
+Since `tractusx-edc` v0.5.1 the cached EDRs also come with a state machine that will manage the lifecycle of an EDR
+on the consumer side. That means that it will auto-renew itself when the expiration date is approaching by
+firing another transfer process request with the same parameters as the original one. Once renewed the old-one
+will transition to the state `EXPIRED` and it will be removed from the database and the vault according to the [configuration](../../../core/edr-core/README.md).
+
 ### EDR Management | Fetch cached EDRs
 
 This endpoint will retrieve all EDR entries by their `assetId` or `agreementId` references, which are passed as `query parameters`.
@@ -89,9 +120,12 @@ This endpoint will retrieve all EDR entries by their `assetId` or `agreementId` 
 [
   {
     "@type": "tx:EndpointDataReferenceEntry",
-    "edc:agreementId": "contract-agreement-id",
-    "edc:transferProcessId": "transfer-process-id",
-    "edc:assetId": "asset-id",
+    "edc:agreementId": "<agreement-id>",
+    "edc:transferProcessId": "<transfer-process-od>",
+    "edc:assetId": "<asset-id>",
+    "edc:providerId": "<provider-id>",
+    "tx:edrState": "NEGOTIATED",
+    "tx:expirationDate": 1693928132000,
     "@context": {
       "dct": "https://purl.org/dc/terms/",
       "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
@@ -103,6 +137,8 @@ This endpoint will retrieve all EDR entries by their `assetId` or `agreementId` 
   }
 ]
 ```
+
+### EDR Management | Fetch single EDR
 
 This endpoint, through the `transfer-process-id` passed as `path variable`, will retrieve the actual EDR.
 
@@ -133,3 +169,85 @@ This endpoint, through the `transfer-process-id` passed as `path variable`, will
 ```
 
 > Please note that now with the EDR you are able to request the `Asset` data from provider's `data-plane`.
+
+### EDR Management | Deleting a cached EDR
+
+This endpoint will delete the EDR entry associated with the `transfer-process-id` and it will remove the EDR itself
+from the vault.
+
+| Path                                          | Method | Query Params             |
+|-----------------------------------------------|--------|--------------------------|
+| `<MANAGEMENT_URL>/edrs/{transfer-process-id}` | DELETE | none                     |
+
+### EDR Usage | Fetching data
+
+Once the EDR has been negotiated and stored, the data can be fetched in two ways depending on the use-case:
+
+- Provider data-plane (EDC way)
+- Consumer proxy (Tractus-X EDC simplified)
+
+#### Provider data-plane
+
+Once the right EDR has been identified using the EDR management API the current asset/agreement/transfer-process that
+you want to transfer, we can use the `endpont`, `authCode` and `authKey` to make the request:
+
+```sh
+curl --request GET \
+  --url http://provider-data-plane/public-url \
+  --header 'Authorization: auth-code' \
+  --header 'Content-Type: application/json' 
+```
+
+If the HTTP asset has been configured to proxy also query parameters and path segments they will be forwarded
+to the backend from the provider data-plane:
+
+```sh
+curl --request GET \
+  --url http://provider-data-plane/public-url/subroute?foo=bar \
+  --header 'Authorization: auth-code' \
+  --header 'Content-Type: application/json' 
+```
+
+#### Consumer data-plane (proxy)
+
+The Consumer data-plane proxy is an extension available in `tractusx-edc` that will use the EDR store to simplify
+the data request on consumer side. The documentation is available [here](../../../edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/README.md).
+
+The only API is:
+
+| Path                      | Method | Query Params             |
+|---------------------------|--------|--------------------------|
+| `<PROXY_URL>/aas/request` | POST   | none                     |
+
+which fetches the data according to the input body. The body should contain the `assetId` plus `providerId` or the `transferProcessId`,
+which identifies the EDR to use for fetching data and an `endpointUrl` which is the [provider gateway](../../../edc-extensions/dataplane-proxy/edc-dataplane-proxy-provider-api/README.md)
+on which the data is available.
+
+Example:
+
+```sh
+curl --request POST \
+  --url http://localhost:8186/proxy/aas/request \
+  --header 'Content-Type: application/json' \
+  --header 'X-Api-Key: password' \
+  --data '{"assetId": "1","providerId": "BPNL000000000001","endpointUrl": "http://localhost:8080/api/gateway/aas/test"}'
+```
+
+Alternatively if the `endpointUrl` is not known or the gateway on the provider side is not configured, it can be omitted and the `Edr#endpointUrl`
+will be used as base url. In this scenario if needed, users can provide additional properties to the request for composing the final
+url:
+
+- `pathSegments` sub path to append to the base url
+- `queryParams` query parameters to add to the url
+
+Example of an asset with base url `http://localhost:8080/test`
+
+```sh
+curl --request POST \
+  --url http://localhost:8186/proxy/aas/request \
+  --header 'Content-Type: application/json' \
+  --header 'X-Api-Key: password' \
+  --data '{"assetId": "1","providerId": "BPNL000000000001","pathSegments": "/sub","queryParams": "foo=bar"}'
+```
+
+The final url will look like `http://localhost:8080/test/sub?foo=bar`.

--- a/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/README.md
+++ b/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/README.md
@@ -36,7 +36,7 @@ Example with base url `http://localhost:8080/test`
 
 The final url will look like `http://localhost:8080/test/sub?foo=bar` composed by the DataPlane manager with the Http request flow,
 
-> Note: the endpoint is not protected with configured `AuthenticationService`, which most likely will be the token based (auth key) one.
+> Note: the endpoint is protected with configured `AuthenticationService`.
 
 ## Configuration
 


### PR DESCRIPTION
## WHAT

Enriches the EDR management API with docs on how to use the `ConsumerDataPlaneProxy` for fetching data

## WHY

docs


Closes #391 
