### PR TITLE
chore: add default values to helm charts

### DIFF
--- a/charts/tractusx-connector-azure-vault/README.md
+++ b/charts/tractusx-connector-azure-vault/README.md
@@ -247,7 +247,7 @@ helm install my-release tractusx-edc/tractusx-connector-azure-vault --version 0.
 | imagePullSecrets | list | `[]` | Existing image pull secret to use to [obtain the container image from private registries](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry) |
 | install.postgresql | bool | `true` |  |
 | nameOverride | string | `""` |  |
-| participant.id | string | `"BPNL00DATAP00001"` | BPN Number |
+| participant.id | string | `"BPNLCHANGEME"` | BPN Number |
 | postgresql.auth.database | string | `"edc"` |  |
 | postgresql.auth.password | string | `"password"` |  |
 | postgresql.auth.username | string | `"user"` |  |
@@ -262,10 +262,10 @@ helm install my-release tractusx-edc/tractusx-connector-azure-vault --version 0.
 | tests | object | `{"hookDeletePolicy":"before-hook-creation,hook-succeeded"}` | Configurations for Helm tests |
 | tests.hookDeletePolicy | string | `"before-hook-creation,hook-succeeded"` | Configure the hook-delete-policy for Helm tests |
 | vault.azure.certificate | string | `nil` |  |
-| vault.azure.client | string | `"53ba6f2b-6d52-4f5c-8ae0-7adc20808854"` |  |
+| vault.azure.client | string | `"<AZURE_CLIENT_ID>"` |  |
 | vault.azure.name | string | `""` |  |
 | vault.azure.secret | string | `nil` |  |
-| vault.azure.tenant | string | `"11e55098-68xd-4992-aaf9-7adx20808854"` |  |
+| vault.azure.tenant | string | `"<AZURE_TENANT_ID>"` |  |
 | vault.secretNames.transferProxyTokenEncryptionAesKey | string | `"transfer-proxy-token-encryption-aes-key"` |  |
 | vault.secretNames.transferProxyTokenSignerPrivateKey | string | `nil` |  |
 | vault.secretNames.transferProxyTokenSignerPublicKey | string | `nil` |  |

--- a/charts/tractusx-connector-azure-vault/README.md
+++ b/charts/tractusx-connector-azure-vault/README.md
@@ -263,7 +263,7 @@ helm install my-release tractusx-edc/tractusx-connector-azure-vault --version 0.
 | tests.hookDeletePolicy | string | `"before-hook-creation,hook-succeeded"` | Configure the hook-delete-policy for Helm tests |
 | vault.azure.certificate | string | `nil` |  |
 | vault.azure.client | string | `"<AZURE_CLIENT_ID>"` |  |
-| vault.azure.name | string | `""` |  |
+| vault.azure.name | string | `"<AZURE_NAME>"` |  |
 | vault.azure.secret | string | `nil` |  |
 | vault.azure.tenant | string | `"<AZURE_TENANT_ID>"` |  |
 | vault.secretNames.transferProxyTokenEncryptionAesKey | string | `"transfer-proxy-token-encryption-aes-key"` |  |

--- a/charts/tractusx-connector-azure-vault/README.md
+++ b/charts/tractusx-connector-azure-vault/README.md
@@ -67,7 +67,7 @@ helm install my-release tractusx-edc/tractusx-connector-azure-vault --version 0.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backendService.httpProxyTokenReceiverUrl | string | `""` |  |
+| backendService.httpProxyTokenReceiverUrl | string | `"httpProxyTokenReceiverUrl"` |  |
 | controlplane.affinity | object | `{}` |  |
 | controlplane.autoscaling.enabled | bool | `false` | Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
 | controlplane.autoscaling.maxReplicas | int | `100` | Maximum replicas if resource consumption exceeds resource threshholds |
@@ -78,15 +78,15 @@ helm install my-release tractusx-edc/tractusx-connector-azure-vault --version 0.
 | controlplane.debug.enabled | bool | `false` |  |
 | controlplane.debug.port | int | `1044` |  |
 | controlplane.debug.suspendOnStart | bool | `false` |  |
-| controlplane.endpoints | object | `{"control":{"path":"/control","port":8083},"default":{"path":"/api","port":8080},"management":{"authKey":"","path":"/management","port":8081},"metrics":{"path":"/metrics","port":9090},"protocol":{"path":"/api/v1/dsp","port":8084}}` | endpoints of the control plane |
+| controlplane.endpoints | object | `{"control":{"path":"/control","port":8083},"default":{"path":"/api","port":8080},"management":{"authKey":"password","path":"/management","port":8081},"metrics":{"path":"/metrics","port":9090},"protocol":{"path":"/api/v1/dsp","port":8084}}` | endpoints of the control plane |
 | controlplane.endpoints.control | object | `{"path":"/control","port":8083}` | control api, used for internal control calls. can be added to the internal ingress, but should probably not |
 | controlplane.endpoints.control.path | string | `"/control"` | path for incoming api calls |
 | controlplane.endpoints.control.port | int | `8083` | port for incoming api calls |
 | controlplane.endpoints.default | object | `{"path":"/api","port":8080}` | default api for health checks, should not be added to any ingress |
 | controlplane.endpoints.default.path | string | `"/api"` | path for incoming api calls |
 | controlplane.endpoints.default.port | int | `8080` | port for incoming api calls |
-| controlplane.endpoints.management | object | `{"authKey":"","path":"/management","port":8081}` | data management api, used by internal users, can be added to an ingress and must not be internet facing |
-| controlplane.endpoints.management.authKey | string | `""` | authentication key, must be attached to each 'X-Api-Key' request header |
+| controlplane.endpoints.management | object | `{"authKey":"password","path":"/management","port":8081}` | data management api, used by internal users, can be added to an ingress and must not be internet facing |
+| controlplane.endpoints.management.authKey | string | `"password"` | authentication key, must be attached to each 'X-Api-Key' request header |
 | controlplane.endpoints.management.path | string | `"/management"` | path for incoming api calls |
 | controlplane.endpoints.management.port | int | `8081` | port for incoming api calls |
 | controlplane.endpoints.metrics | object | `{"path":"/metrics","port":9090}` | metrics api, used for application metrics, must not be internet facing |
@@ -184,7 +184,7 @@ helm install my-release tractusx-edc/tractusx-connector-azure-vault --version 0.
 | dataplane.endpoints.default.port | int | `8080` |  |
 | dataplane.endpoints.metrics.path | string | `"/metrics"` |  |
 | dataplane.endpoints.metrics.port | int | `9090` |  |
-| dataplane.endpoints.proxy.authKey | string | `""` |  |
+| dataplane.endpoints.proxy.authKey | string | `"password"` |  |
 | dataplane.endpoints.proxy.path | string | `"/proxy"` |  |
 | dataplane.endpoints.proxy.port | int | `8186` |  |
 | dataplane.endpoints.public.path | string | `"/api/public"` |  |
@@ -247,7 +247,7 @@ helm install my-release tractusx-edc/tractusx-connector-azure-vault --version 0.
 | imagePullSecrets | list | `[]` | Existing image pull secret to use to [obtain the container image from private registries](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry) |
 | install.postgresql | bool | `true` |  |
 | nameOverride | string | `""` |  |
-| participant.id | string | `""` | BPN Number |
+| participant.id | string | `"BPNL00DATAP00001"` | BPN Number |
 | postgresql.auth.database | string | `"edc"` |  |
 | postgresql.auth.password | string | `"password"` |  |
 | postgresql.auth.username | string | `"user"` |  |
@@ -262,10 +262,10 @@ helm install my-release tractusx-edc/tractusx-connector-azure-vault --version 0.
 | tests | object | `{"hookDeletePolicy":"before-hook-creation,hook-succeeded"}` | Configurations for Helm tests |
 | tests.hookDeletePolicy | string | `"before-hook-creation,hook-succeeded"` | Configure the hook-delete-policy for Helm tests |
 | vault.azure.certificate | string | `nil` |  |
-| vault.azure.client | string | `""` |  |
+| vault.azure.client | string | `"53ba6f2b-6d52-4f5c-8ae0-7adc20808854"` |  |
 | vault.azure.name | string | `""` |  |
 | vault.azure.secret | string | `nil` |  |
-| vault.azure.tenant | string | `""` |  |
+| vault.azure.tenant | string | `"11e55098-68xd-4992-aaf9-7adx20808854"` |  |
 | vault.secretNames.transferProxyTokenEncryptionAesKey | string | `"transfer-proxy-token-encryption-aes-key"` |  |
 | vault.secretNames.transferProxyTokenSignerPrivateKey | string | `nil` |  |
 | vault.secretNames.transferProxyTokenSignerPublicKey | string | `nil` |  |

--- a/charts/tractusx-connector-azure-vault/README.md
+++ b/charts/tractusx-connector-azure-vault/README.md
@@ -67,7 +67,7 @@ helm install my-release tractusx-edc/tractusx-connector-azure-vault --version 0.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backendService.httpProxyTokenReceiverUrl | string | `"httpProxyTokenReceiverUrl"` |  |
+| backendService.httpProxyTokenReceiverUrl | string | `"https://example.com"` | Specifies a backend service which will receive the EDR |
 | controlplane.affinity | object | `{}` |  |
 | controlplane.autoscaling.enabled | bool | `false` | Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
 | controlplane.autoscaling.maxReplicas | int | `100` | Maximum replicas if resource consumption exceeds resource threshholds |

--- a/charts/tractusx-connector-azure-vault/values.yaml
+++ b/charts/tractusx-connector-azure-vault/values.yaml
@@ -508,7 +508,7 @@ postgresql:
     password: "password"
 vault:
   azure:
-    name: ""
+    name: "<AZURE_NAME>"
     client: "<AZURE_CLIENT_ID>"
     tenant: "<AZURE_TENANT_ID>"
     secret:

--- a/charts/tractusx-connector-azure-vault/values.yaml
+++ b/charts/tractusx-connector-azure-vault/values.yaml
@@ -520,8 +520,8 @@ vault:
     transferProxyTokenEncryptionAesKey: transfer-proxy-token-encryption-aes-key
 
 backendService:
-  # Specifies a backend service which will receive the EDR
-  httpProxyTokenReceiverUrl: "httpProxyTokenReceiverUrl"
+  # -- Specifies a backend service which will receive the EDR
+  httpProxyTokenReceiverUrl: "https://example.com"
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/tractusx-connector-azure-vault/values.yaml
+++ b/charts/tractusx-connector-azure-vault/values.yaml
@@ -38,7 +38,7 @@ customLabels: {}
 
 participant:
   # -- BPN Number
-  id: "BPNL00DATAP00001"
+  id: "BPNLCHANGEME"
 
 controlplane:
   image:
@@ -509,8 +509,8 @@ postgresql:
 vault:
   azure:
     name: ""
-    client: "53ba6f2b-6d52-4f5c-8ae0-7adc20808854"
-    tenant: "11e55098-68xd-4992-aaf9-7adx20808854"
+    client: "<AZURE_CLIENT_ID>"
+    tenant: "<AZURE_TENANT_ID>"
     secret:
     certificate:
 

--- a/charts/tractusx-connector-azure-vault/values.yaml
+++ b/charts/tractusx-connector-azure-vault/values.yaml
@@ -38,7 +38,7 @@ customLabels: {}
 
 participant:
   # -- BPN Number
-  id: ""
+  id: "BPNL00DATAP00001"
 
 controlplane:
   image:
@@ -94,7 +94,7 @@ controlplane:
       # -- path for incoming api calls
       path: /management
       # -- authentication key, must be attached to each 'X-Api-Key' request header
-      authKey: ""
+      authKey: "password"
     # -- control api, used for internal control calls. can be added to the internal ingress, but should probably not
     control:
       # -- port for incoming api calls
@@ -354,7 +354,7 @@ dataplane:
     proxy:
       port: 8186
       path: /proxy
-      authKey: ""
+      authKey: "password"
     metrics:
       port: 9090
       path: /metrics
@@ -509,8 +509,8 @@ postgresql:
 vault:
   azure:
     name: ""
-    client: ""
-    tenant: ""
+    client: "53ba6f2b-6d52-4f5c-8ae0-7adc20808854"
+    tenant: "11e55098-68xd-4992-aaf9-7adx20808854"
     secret:
     certificate:
 
@@ -520,7 +520,8 @@ vault:
     transferProxyTokenEncryptionAesKey: transfer-proxy-token-encryption-aes-key
 
 backendService:
-  httpProxyTokenReceiverUrl: ""
+  # Specifies a backend service which will receive the EDR
+  httpProxyTokenReceiverUrl: "httpProxyTokenReceiverUrl"
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/tractusx-connector-memory/README.md
+++ b/charts/tractusx-connector-memory/README.md
@@ -58,7 +58,7 @@ helm install my-release tractusx-edc/tractusx-connector-memory --version 0.5.1 \
 | fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` | Existing image pull secret to use to [obtain the container image from private registries](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry) |
 | nameOverride | string | `""` |  |
-| participant.id | string | `"BPNL00DATAP00001"` | BPN Number |
+| participant.id | string | `"BPNLCHANGEME"` | BPN Number |
 | runtime.affinity | object | `{}` |  |
 | runtime.autoscaling.enabled | bool | `false` | Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
 | runtime.autoscaling.maxReplicas | int | `100` | Maximum replicas if resource consumption exceeds resource threshholds |

--- a/charts/tractusx-connector-memory/README.md
+++ b/charts/tractusx-connector-memory/README.md
@@ -52,7 +52,7 @@ helm install my-release tractusx-edc/tractusx-connector-memory --version 0.5.1 \
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backendService.httpProxyTokenReceiverUrl | string | `"http://backend:8080"` |  |
+| backendService.httpProxyTokenReceiverUrl | string | `"https://example.com"` | Specifies a backend service which will receive the EDR |
 | customCaCerts | object | `{}` | Add custom ca certificates to the truststore |
 | customLabels | object | `{}` | To add some custom labels |
 | fullnameOverride | string | `""` |  |

--- a/charts/tractusx-connector-memory/README.md
+++ b/charts/tractusx-connector-memory/README.md
@@ -52,21 +52,13 @@ helm install my-release tractusx-edc/tractusx-connector-memory --version 0.5.1 \
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backendService.httpProxyTokenReceiverUrl | string | `""` |  |
+| backendService.httpProxyTokenReceiverUrl | string | `"http://backend:8080"` |  |
 | customCaCerts | object | `{}` | Add custom ca certificates to the truststore |
 | customLabels | object | `{}` | To add some custom labels |
-| daps.clientId | string | `""` |  |
-| daps.connectors[0].attributes.referringConnector | string | `"http://sokrates-controlplane/BPNSOKRATES"` |  |
-| daps.connectors[0].certificate | string | `""` |  |
-| daps.connectors[0].id | string | `"E7:07:2D:74:56:66:31:F0:7B:10:EA:B6:03:06:4C:23:7F:ED:A6:65:keyid:E7:07:2D:74:56:66:31:F0:7B:10:EA:B6:03:06:4C:23:7F:ED:A6:65"` |  |
-| daps.connectors[0].name | string | `"sokrates"` |  |
-| daps.paths.jwks | string | `"/jwks.json"` |  |
-| daps.paths.token | string | `"/token"` |  |
-| daps.url | string | `"http://{{ .Release.Name }}-daps:4567"` |  |
 | fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` | Existing image pull secret to use to [obtain the container image from private registries](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry) |
 | nameOverride | string | `""` |  |
-| participant.id | string | `""` | BPN Number |
+| participant.id | string | `"BPNL00DATAP00001"` | BPN Number |
 | runtime.affinity | object | `{}` |  |
 | runtime.autoscaling.enabled | bool | `false` | Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
 | runtime.autoscaling.maxReplicas | int | `100` | Maximum replicas if resource consumption exceeds resource threshholds |
@@ -77,15 +69,15 @@ helm install my-release tractusx-edc/tractusx-connector-memory --version 0.5.1 \
 | runtime.debug.enabled | bool | `false` |  |
 | runtime.debug.port | int | `1044` |  |
 | runtime.debug.suspendOnStart | bool | `false` |  |
-| runtime.endpoints | object | `{"control":{"path":"/control","port":8083},"default":{"path":"/api","port":8080},"management":{"authKey":"","path":"/management","port":8081},"protocol":{"path":"/api/v1/dsp","port":8084},"proxy":{"path":"/proxy","port":8186},"public":{"path":"/api/public","port":8086},"validation":{"path":"/validation","port":8082}}` | endpoints of the control plane |
+| runtime.endpoints | object | `{"control":{"path":"/control","port":8083},"default":{"path":"/api","port":8080},"management":{"authKey":"password","path":"/management","port":8081},"protocol":{"path":"/api/v1/dsp","port":8084},"proxy":{"path":"/proxy","port":8186},"public":{"path":"/api/public","port":8086},"validation":{"path":"/validation","port":8082}}` | endpoints of the control plane |
 | runtime.endpoints.control | object | `{"path":"/control","port":8083}` | control api, used for internal control calls. can be added to the internal ingress, but should probably not |
 | runtime.endpoints.control.path | string | `"/control"` | path for incoming api calls |
 | runtime.endpoints.control.port | int | `8083` | port for incoming api calls |
 | runtime.endpoints.default | object | `{"path":"/api","port":8080}` | default api for health checks, should not be added to any ingress |
 | runtime.endpoints.default.path | string | `"/api"` | path for incoming api calls |
 | runtime.endpoints.default.port | int | `8080` | port for incoming api calls |
-| runtime.endpoints.management | object | `{"authKey":"","path":"/management","port":8081}` | data management api, used by internal users, can be added to an ingress and must not be internet facing |
-| runtime.endpoints.management.authKey | string | `""` | authentication key, must be attached to each 'X-Api-Key' request header |
+| runtime.endpoints.management | object | `{"authKey":"password","path":"/management","port":8081}` | data management api, used by internal users, can be added to an ingress and must not be internet facing |
+| runtime.endpoints.management.authKey | string | `"password"` | authentication key, must be attached to each 'X-Api-Key' request header |
 | runtime.endpoints.management.path | string | `"/management"` | path for incoming api calls |
 | runtime.endpoints.management.port | int | `8081` | port for incoming api calls |
 | runtime.endpoints.protocol | object | `{"path":"/api/v1/dsp","port":8084}` | dsp api, used for inter connector communication and must be internet facing |

--- a/charts/tractusx-connector-memory/values.yaml
+++ b/charts/tractusx-connector-memory/values.yaml
@@ -32,7 +32,7 @@ customLabels: {}
 
 participant:
   # -- BPN Number
-  id: ""
+  id: "BPNL00DATAP00001"
 
 # -- Add custom ca certificates to the truststore
 customCaCerts: {}
@@ -90,7 +90,7 @@ runtime:
       # -- path for incoming api calls
       path: /management
       # -- authentication key, must be attached to each 'X-Api-Key' request header
-      authKey: ""
+      authKey: "password"
     # -- validation api, only used by the data plane and should not be added to any ingress
     validation:
       # -- port for incoming api calls
@@ -298,21 +298,9 @@ vault:
     transferProxyTokenEncryptionAesKey: transfer-proxy-token-encryption-aes-key
   server:
     postStart: |-
-daps:
-  url: "http://{{ .Release.Name }}-daps:4567"
-  clientId: ""
-  paths:
-    jwks: /jwks.json
-    token: /token
-  connectors:
-    - id: E7:07:2D:74:56:66:31:F0:7B:10:EA:B6:03:06:4C:23:7F:ED:A6:65:keyid:E7:07:2D:74:56:66:31:F0:7B:10:EA:B6:03:06:4C:23:7F:ED:A6:65
-      name: sokrates
-      attributes:
-        referringConnector: http://sokrates-controlplane/BPNSOKRATES
-      # Must be the same certificate that is stores in section 'sokrates-vault'
-      certificate: ""     # must be set externally!
 backendService:
-  httpProxyTokenReceiverUrl: ""
+  # Specifies a backend service which will receive the EDR
+  httpProxyTokenReceiverUrl: "http://backend:8080"
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/tractusx-connector-memory/values.yaml
+++ b/charts/tractusx-connector-memory/values.yaml
@@ -32,7 +32,7 @@ customLabels: {}
 
 participant:
   # -- BPN Number
-  id: "BPNL00DATAP00001"
+  id: "BPNLCHANGEME"
 
 # -- Add custom ca certificates to the truststore
 customCaCerts: {}

--- a/charts/tractusx-connector-memory/values.yaml
+++ b/charts/tractusx-connector-memory/values.yaml
@@ -299,8 +299,8 @@ vault:
   server:
     postStart: |-
 backendService:
-  # Specifies a backend service which will receive the EDR
-  httpProxyTokenReceiverUrl: "http://backend:8080"
+  # -- Specifies a backend service which will receive the EDR
+  httpProxyTokenReceiverUrl: "https://example.com"
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/tractusx-connector/README.md
+++ b/charts/tractusx-connector/README.md
@@ -61,7 +61,7 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.5.1 \
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backendService.httpProxyTokenReceiverUrl | string | `""` |  |
+| backendService.httpProxyTokenReceiverUrl | string | `"http://backend:8080"` |  |
 | controlplane.affinity | object | `{}` |  |
 | controlplane.autoscaling.enabled | bool | `false` | Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
 | controlplane.autoscaling.maxReplicas | int | `100` | Maximum replicas if resource consumption exceeds resource threshholds |
@@ -72,15 +72,15 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.5.1 \
 | controlplane.debug.enabled | bool | `false` |  |
 | controlplane.debug.port | int | `1044` |  |
 | controlplane.debug.suspendOnStart | bool | `false` |  |
-| controlplane.endpoints | object | `{"control":{"path":"/control","port":8083},"default":{"path":"/api","port":8080},"management":{"authKey":"","path":"/management","port":8081},"metrics":{"path":"/metrics","port":9090},"protocol":{"path":"/api/v1/dsp","port":8084}}` | endpoints of the control plane |
+| controlplane.endpoints | object | `{"control":{"path":"/control","port":8083},"default":{"path":"/api","port":8080},"management":{"authKey":"password","path":"/management","port":8081},"metrics":{"path":"/metrics","port":9090},"protocol":{"path":"/api/v1/dsp","port":8084}}` | endpoints of the control plane |
 | controlplane.endpoints.control | object | `{"path":"/control","port":8083}` | control api, used for internal control calls. can be added to the internal ingress, but should probably not |
 | controlplane.endpoints.control.path | string | `"/control"` | path for incoming api calls |
 | controlplane.endpoints.control.port | int | `8083` | port for incoming api calls |
 | controlplane.endpoints.default | object | `{"path":"/api","port":8080}` | default api for health checks, should not be added to any ingress |
 | controlplane.endpoints.default.path | string | `"/api"` | path for incoming api calls |
 | controlplane.endpoints.default.port | int | `8080` | port for incoming api calls |
-| controlplane.endpoints.management | object | `{"authKey":"","path":"/management","port":8081}` | data management api, used by internal users, can be added to an ingress and must not be internet facing |
-| controlplane.endpoints.management.authKey | string | `""` | authentication key, must be attached to each 'X-Api-Key' request header |
+| controlplane.endpoints.management | object | `{"authKey":"password","path":"/management","port":8081}` | data management api, used by internal users, can be added to an ingress and must not be internet facing |
+| controlplane.endpoints.management.authKey | string | `"password"` | authentication key, must be attached to each 'X-Api-Key' request header |
 | controlplane.endpoints.management.path | string | `"/management"` | path for incoming api calls |
 | controlplane.endpoints.management.port | int | `8081` | port for incoming api calls |
 | controlplane.endpoints.metrics | object | `{"path":"/metrics","port":9090}` | metrics api, used for application metrics, must not be internet facing |
@@ -178,7 +178,7 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.5.1 \
 | dataplane.endpoints.default.port | int | `8080` |  |
 | dataplane.endpoints.metrics.path | string | `"/metrics"` |  |
 | dataplane.endpoints.metrics.port | int | `9090` |  |
-| dataplane.endpoints.proxy.authKey | string | `""` |  |
+| dataplane.endpoints.proxy.authKey | string | `"password"` |  |
 | dataplane.endpoints.proxy.path | string | `"/proxy"` |  |
 | dataplane.endpoints.proxy.port | int | `8186` |  |
 | dataplane.endpoints.public.path | string | `"/api/public"` |  |
@@ -247,7 +247,7 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.5.1 \
 | networkPolicy.dataplane | object | `{"from":[{"namespaceSelector":{}}]}` | Configuration of the dataplane component |
 | networkPolicy.dataplane.from | list | `[{"namespaceSelector":{}}]` | Specify from rule network policy for dp (defaults to all namespaces) |
 | networkPolicy.enabled | bool | `false` | If `true` network policy will be created to restrict access to control- and dataplane |
-| participant.id | string | `""` | BPN Number |
+| participant.id | string | `"BPNL00DATAP00001"` | BPN Number |
 | postgresql.auth.database | string | `"edc"` |  |
 | postgresql.auth.password | string | `"password"` |  |
 | postgresql.auth.username | string | `"user"` |  |
@@ -265,7 +265,7 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.5.1 \
 | vault.hashicorp.paths.health | string | `"/v1/sys/health"` |  |
 | vault.hashicorp.paths.secret | string | `"/v1/secret"` |  |
 | vault.hashicorp.timeout | int | `30` |  |
-| vault.hashicorp.token | string | `""` |  |
+| vault.hashicorp.token | string | `"root"` |  |
 | vault.hashicorp.url | string | `"http://{{ .Release.Name }}-vault:8200"` |  |
 | vault.injector.enabled | bool | `false` |  |
 | vault.secretNames.transferProxyTokenEncryptionAesKey | string | `"transfer-proxy-token-encryption-aes-key"` |  |

--- a/charts/tractusx-connector/README.md
+++ b/charts/tractusx-connector/README.md
@@ -247,7 +247,7 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.5.1 \
 | networkPolicy.dataplane | object | `{"from":[{"namespaceSelector":{}}]}` | Configuration of the dataplane component |
 | networkPolicy.dataplane.from | list | `[{"namespaceSelector":{}}]` | Specify from rule network policy for dp (defaults to all namespaces) |
 | networkPolicy.enabled | bool | `false` | If `true` network policy will be created to restrict access to control- and dataplane |
-| participant.id | string | `"BPNL00DATAP00001"` | BPN Number |
+| participant.id | string | `"BPNLCHANGEME"` | BPN Number |
 | postgresql.auth.database | string | `"edc"` |  |
 | postgresql.auth.password | string | `"password"` |  |
 | postgresql.auth.username | string | `"user"` |  |

--- a/charts/tractusx-connector/README.md
+++ b/charts/tractusx-connector/README.md
@@ -61,7 +61,7 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.5.1 \
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backendService.httpProxyTokenReceiverUrl | string | `"http://backend:8080"` |  |
+| backendService.httpProxyTokenReceiverUrl | string | `"https://example.com"` | Specifies a backend service which will receive the EDR |
 | controlplane.affinity | object | `{}` |  |
 | controlplane.autoscaling.enabled | bool | `false` | Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
 | controlplane.autoscaling.maxReplicas | int | `100` | Maximum replicas if resource consumption exceeds resource threshholds |

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -38,7 +38,7 @@ customLabels: {}
 
 participant:
   # -- BPN Number
-  id: "BPNL00DATAP00001"
+  id: "BPNLCHANGEME"
 
 controlplane:
   image:

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -38,7 +38,7 @@ customLabels: {}
 
 participant:
   # -- BPN Number
-  id: ""
+  id: "BPNL00DATAP00001"
 
 controlplane:
   image:
@@ -94,7 +94,7 @@ controlplane:
       # -- path for incoming api calls
       path: /management
       # -- authentication key, must be attached to each 'X-Api-Key' request header
-      authKey: ""
+      authKey: "password"
     # -- control api, used for internal control calls. can be added to the internal ingress, but should probably not
     control:
       # -- port for incoming api calls
@@ -352,7 +352,7 @@ dataplane:
     proxy:
       port: 8186
       path: /proxy
-      authKey: ""
+      authKey: "password"
     metrics:
       port: 9090
       path: /metrics
@@ -512,7 +512,7 @@ vault:
     postStart:    # must be set externally!
   hashicorp:
     url: "http://{{ .Release.Name }}-vault:8200"
-    token: ""
+    token: "root"
     timeout: 30
     healthCheck:
       enabled: true
@@ -525,7 +525,8 @@ vault:
     transferProxyTokenSignerPublicKey:
     transferProxyTokenEncryptionAesKey: transfer-proxy-token-encryption-aes-key
 backendService:
-  httpProxyTokenReceiverUrl: ""
+  # Specifies a backend service which will receive the EDR
+  httpProxyTokenReceiverUrl: "http://backend:8080"
 
 networkPolicy:
   # -- If `true` network policy will be created to restrict access to control- and dataplane

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -525,8 +525,8 @@ vault:
     transferProxyTokenSignerPublicKey:
     transferProxyTokenEncryptionAesKey: transfer-proxy-token-encryption-aes-key
 backendService:
-  # Specifies a backend service which will receive the EDR
-  httpProxyTokenReceiverUrl: "http://backend:8080"
+  # -- Specifies a backend service which will receive the EDR
+  httpProxyTokenReceiverUrl: "https://example.com"
 
 networkPolicy:
   # -- If `true` network policy will be created to restrict access to control- and dataplane


### PR DESCRIPTION
## WHAT

Add default values to helm charts


## WHY

Because of QG checks [TRG 5.01](https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-01/)

## FURTHER NOTES

- Cleanup daps values from memory chart
- Recreate README.md files

Closes #724 
