### PR TITLE
chore: bump version to 0.6.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.eclipse.tractusx.edc
-version=0.5.2-SNAPSHOT
+version=0.6.0-SNAPSHOT
 # configure the build:
 txScmConnection=scm:git:git@github.com:eclipse-tractusx/tractusx-edc.git
 txWebsiteUrl=https://github.com/eclipse-tractusx/tractusx-edc.git


### PR DESCRIPTION
## WHAT

Bumps the connector version to 0.6.0-SNAPSHOT

## WHY

Next product increment

## FURTHER NOTES

- chart versions etc. will get bumped during the release process

Closes # <-- _insert Issue number if one exists_
