### PR TITLE
fix(docs): use correct url in docu

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -8,11 +8,11 @@ maven/mavencentral/com.azure/azure-core-http-netty/1.13.6, MIT AND Apache-2.0, a
 maven/mavencentral/com.azure/azure-core-http-netty/1.13.7, MIT AND Apache-2.0, approved, #7948
 maven/mavencentral/com.azure/azure-core/1.41.0, MIT AND Apache-2.0, approved, #9648
 maven/mavencentral/com.azure/azure-core/1.42.0, MIT AND Apache-2.0, approved, #10089
-maven/mavencentral/com.azure/azure-core/1.43.0, , restricted, clearlydefined
+maven/mavencentral/com.azure/azure-core/1.43.0, MIT AND Apache-2.0, approved, #10548
 maven/mavencentral/com.azure/azure-identity/1.10.0, MIT AND Apache-2.0, approved, #10086
 maven/mavencentral/com.azure/azure-identity/1.10.1, MIT AND Apache-2.0, approved, #10086
 maven/mavencentral/com.azure/azure-json/1.0.1, MIT AND Apache-2.0, approved, #7933
-maven/mavencentral/com.azure/azure-json/1.1.0, , restricted, clearlydefined
+maven/mavencentral/com.azure/azure-json/1.1.0, MIT AND Apache-2.0, approved, #10547
 maven/mavencentral/com.azure/azure-security-keyvault-secrets/4.6.5, MIT, approved, #7940
 maven/mavencentral/com.azure/azure-storage-blob/12.23.0, MIT, approved, #9632
 maven/mavencentral/com.azure/azure-storage-common/12.22.0, MIT, approved, #9645
@@ -73,7 +73,7 @@ maven/mavencentral/com.nimbusds/content-type/2.2, Apache-2.0, approved, clearlyd
 maven/mavencentral/com.nimbusds/lang-tag/1.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.30.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.31, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.34, , restricted, clearlydefined
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.34, Apache-2.0, approved, #10549
 maven/mavencentral/com.nimbusds/oauth2-oidc-sdk/10.7.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.puppycrawl.tools/checkstyle/10.0, LGPL-2.1-or-later, approved, #7936
 maven/mavencentral/com.squareup.okhttp3/mockwebserver/5.0.0-alpha.11, Apache-2.0, approved, clearlydefined
@@ -160,7 +160,7 @@ maven/mavencentral/io.swagger.core.v3/swagger-integration/2.2.10, Apache-2.0, ap
 maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2/2.2.10, Apache-2.0, approved, #9814
 maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.2, Apache-2.0, approved, #5919
-maven/mavencentral/io.swagger.core.v3/swagger-models/2.2.10, LicenseRef-scancode-proprietary-license AND Apache-2.0, restricted, #10520
+maven/mavencentral/io.swagger.core.v3/swagger-models/2.2.10, Apache-2.0, approved, #10353
 maven/mavencentral/jakarta.activation/jakarta.activation-api/1.2.1, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
@@ -430,7 +430,7 @@ maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
 maven/mavencentral/org.testcontainers/database-commons/1.19.0, Apache-2.0, approved, #10345
 maven/mavencentral/org.testcontainers/jdbc/1.19.0, Apache-2.0, approved, #10348
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.0, MIT, approved, #10344
-maven/mavencentral/org.testcontainers/postgresql/1.19.0, None, restricted, #10350
+maven/mavencentral/org.testcontainers/postgresql/1.19.0, MIT, approved, #10350
 maven/mavencentral/org.testcontainers/testcontainers/1.19.0, Apache-2.0 AND MIT, approved, #10347
 maven/mavencentral/org.yaml/snakeyaml/1.33, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275

--- a/edc-extensions/bpn-validation/README.md
+++ b/edc-extensions/bpn-validation/README.md
@@ -70,7 +70,7 @@ which constraint functions is called to evaluate the policy. Here, it is the `Bu
 
 The `bpn-evaluation` module provides a simple CRUD REST API to manipulate BPN <> group associations. Each BPN is stored
 in an internal database together with the groups that it was assigned. The OpenAPI specification can be
-found [here](../../resources/openapi/yaml/bpn-validation-api.yaml).
+found [here](https://app.swaggerhub.com/apis/eclipse-tractusx-bot/tractusx-edc).
 
 ## Business Partner Number Policy [not recommended]
 


### PR DESCRIPTION
## WHAT

Fix an url to the OpenAPI specification.

## WHY

documentation

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
