### PR TITLE
chore: update postgresql helm chart from 12.1.6 to 12.11.2

### DIFF
--- a/charts/tractusx-connector-azure-vault/Chart.yaml
+++ b/charts/tractusx-connector-azure-vault/Chart.yaml
@@ -53,6 +53,6 @@ dependencies:
   # PostgreSQL
   - name: postgresql
     alias: postgresql
-    version: 15.4.0
+    version: 12.11.2
     repository: https://charts.bitnami.com/bitnami
     condition: install.postgresql

--- a/charts/tractusx-connector-azure-vault/Chart.yaml
+++ b/charts/tractusx-connector-azure-vault/Chart.yaml
@@ -53,6 +53,6 @@ dependencies:
   # PostgreSQL
   - name: postgresql
     alias: postgresql
-    version: 12.1.6
+    version: 15.4.0
     repository: https://charts.bitnami.com/bitnami
     condition: install.postgresql

--- a/charts/tractusx-connector-azure-vault/README.md
+++ b/charts/tractusx-connector-azure-vault/README.md
@@ -61,7 +61,7 @@ helm install my-release tractusx-edc/tractusx-connector-azure-vault --version 0.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql(postgresql) | 15.4.0 |
+| https://charts.bitnami.com/bitnami | postgresql(postgresql) | 12.11.2 |
 
 ## Values
 

--- a/charts/tractusx-connector-azure-vault/README.md
+++ b/charts/tractusx-connector-azure-vault/README.md
@@ -61,7 +61,7 @@ helm install my-release tractusx-edc/tractusx-connector-azure-vault --version 0.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql(postgresql) | 12.1.6 |
+| https://charts.bitnami.com/bitnami | postgresql(postgresql) | 15.4.0 |
 
 ## Values
 

--- a/charts/tractusx-connector/Chart.yaml
+++ b/charts/tractusx-connector/Chart.yaml
@@ -59,6 +59,6 @@ dependencies:
   # PostgreSQL
   - name: postgresql
     alias: postgresql
-    version: 15.4.0
+    version: 12.11.2
     repository: https://charts.bitnami.com/bitnami
     condition: install.postgresql

--- a/charts/tractusx-connector/Chart.yaml
+++ b/charts/tractusx-connector/Chart.yaml
@@ -59,6 +59,6 @@ dependencies:
   # PostgreSQL
   - name: postgresql
     alias: postgresql
-    version: 12.1.6
+    version: 15.4.0
     repository: https://charts.bitnami.com/bitnami
     condition: install.postgresql

--- a/charts/tractusx-connector/README.md
+++ b/charts/tractusx-connector/README.md
@@ -54,7 +54,7 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.5.1 \
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql(postgresql) | 15.4.0 |
+| https://charts.bitnami.com/bitnami | postgresql(postgresql) | 12.11.2 |
 | https://helm.releases.hashicorp.com | vault(vault) | 0.20.0 |
 
 ## Values

--- a/charts/tractusx-connector/README.md
+++ b/charts/tractusx-connector/README.md
@@ -54,7 +54,7 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.5.1 \
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql(postgresql) | 12.1.6 |
+| https://charts.bitnami.com/bitnami | postgresql(postgresql) | 15.4.0 |
 | https://helm.releases.hashicorp.com | vault(vault) | 0.20.0 |
 
 ## Values


### PR DESCRIPTION
## WHAT

Update Postgres helm chart from 12.1.6 to 12.11.2

## WHY

Because of a bug in current version 12.1.6

## FURTHER NOTES

Closes #677 
