### PR TITLE
fix: Error Message in SsiMiwOauth2ClientExtension updated

### DIFF
--- a/edc-extensions/ssi/ssi-miw-credential-client/src/main/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwOauth2ClientExtension.java
+++ b/edc-extensions/ssi/ssi-miw-credential-client/src/main/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwOauth2ClientExtension.java
@@ -67,7 +67,7 @@ public class SsiMiwOauth2ClientExtension implements ServiceExtension {
         var clientId = context.getConfig().getString(CLIENT_ID);
         var clientSecretAlias = context.getConfig().getString(CLIENT_SECRET_ALIAS);
         var clientSecret = vault.resolveSecret(clientSecretAlias);
-        Objects.requireNonNull(clientSecret, "Client secret not found in the vault");
+        Objects.requireNonNull(clientSecret, "Client secret could not be retrieved");
 
         return MiwOauth2ClientConfiguration.Builder.newInstance()
                 .tokenUrl(tokenUrl)


### PR DESCRIPTION
## WHAT

I have adjusted the error message in the `SsiMiwOauth2ClientExtension`.

## WHY

#777
Because the statement that the secret could not be found in the Vault can be confusing. For example, if the client has no permissions then the same message appears.

## FURTHER NOTES

Closes #777
