### PR TITLE
feat(ConsumerProxy): enhances error response when fetching data

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -143,8 +143,8 @@ maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR G
 maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/jakarta.json/jakarta.json-api/2.1.1, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7907
 maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.0, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7697
-maven/mavencentral/jakarta.validation/jakarta.validation-api/2.0.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/jakarta.validation/jakarta.validation-api/2.0.2, Apache-2.0, approved, ee4j.validation
+maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, ee4j.validation
 maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.rest
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/2.3.2, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/3.0.0, BSD-3-Clause, approved, ee4j.jaxb

--- a/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/asset/ClientErrorExceptionMapper.java
+++ b/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/asset/ClientErrorExceptionMapper.java
@@ -18,6 +18,7 @@ import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
+import org.eclipse.edc.web.spi.ApiErrorDetail;
 
 /**
  * Maps client errors to return the associated status.
@@ -30,7 +31,8 @@ public class ClientErrorExceptionMapper implements ExceptionMapper<ClientErrorEx
 
     @Override
     public Response toResponse(ClientErrorException exception) {
-        return Response.status(exception.getResponse().getStatus()).build();
+        var detail = ApiErrorDetail.Builder.newInstance().message(exception.getMessage()).build();
+        return Response.status(exception.getResponse().getStatus()).entity(detail).build();
     }
 }
 

--- a/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/asset/ConsumerAssetRequestController.java
+++ b/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/asset/ConsumerAssetRequestController.java
@@ -17,8 +17,10 @@ package org.eclipse.tractusx.edc.dataplane.proxy.consumer.api.asset;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.StreamingOutput;
 import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
@@ -51,6 +53,7 @@ import static org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSche
  * Implements the HTTP proxy API.
  */
 @Path("/aas")
+@Produces(MediaType.APPLICATION_JSON)
 public class ConsumerAssetRequestController implements ConsumerAssetRequestApi {
     public static final String BASE_URL = "baseUrl";
     private static final String HTTP_DATA = "HttpData";

--- a/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/test/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/asset/model/ConsumerAssetRequestControllerTest.java
+++ b/edc-extensions/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/test/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/asset/model/ConsumerAssetRequestControllerTest.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.eclipse.tractusx.edc.dataplane.proxy.consumer.api.asset.ClientErrorExceptionMapper;
 import org.eclipse.tractusx.edc.dataplane.proxy.consumer.api.asset.ConsumerAssetRequestController;
 import org.eclipse.tractusx.edc.edr.spi.store.EndpointDataReferenceCache;
 import org.junit.jupiter.api.Test;
@@ -53,6 +54,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSchema.PATH;
 import static org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSchema.QUERY_PARAMS;
 import static org.eclipse.tractusx.edc.dataplane.proxy.consumer.api.asset.ConsumerAssetRequestController.BASE_URL;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -159,7 +161,8 @@ public class ConsumerAssetRequestControllerTest extends RestControllerTestBase {
                 .body(request)
                 .post(ASSET_REQUEST_PATH)
                 .then()
-                .statusCode(400);
+                .statusCode(400)
+                .body("message", notNullValue());
 
     }
 
@@ -184,7 +187,8 @@ public class ConsumerAssetRequestControllerTest extends RestControllerTestBase {
                 .body(request)
                 .post(ASSET_REQUEST_PATH)
                 .then()
-                .statusCode(428);
+                .statusCode(428)
+                .body("message", notNullValue());
 
     }
 
@@ -245,7 +249,8 @@ public class ConsumerAssetRequestControllerTest extends RestControllerTestBase {
                 .body(request)
                 .post(ASSET_REQUEST_PATH)
                 .then()
-                .statusCode(400);
+                .statusCode(400)
+                .body("message", notNullValue());
 
     }
 
@@ -307,6 +312,11 @@ public class ConsumerAssetRequestControllerTest extends RestControllerTestBase {
     @Override
     protected Object controller() {
         return new ConsumerAssetRequestController(cache, dataPlaneManager, Executors.newSingleThreadExecutor(), mock(Monitor.class));
+    }
+
+    @Override
+    protected Object additionalResource() {
+        return new ClientErrorExceptionMapper();
     }
 
     private RequestSpecification baseRequest() {


### PR DESCRIPTION
## WHAT

Adds `JSON` response when getting errors like:

- Not authorized
- EDR by TransferProcess ID not found
- EDR by Asset ID not found
- Multiple EDRs for Asset ID found

## WHY

User experience

Closes #779 
