### PR TITLE
Feature: Add config parameter for ProviderGatewayController context registration

### DIFF
--- a/edc-extensions/dataplane-proxy/edc-dataplane-proxy-provider-api/README.md
+++ b/edc-extensions/dataplane-proxy/edc-dataplane-proxy-provider-api/README.md
@@ -19,5 +19,6 @@ When the proxy receive a request, it must contain the EDR, which will be decoded
 ## Configuration
 
 | Key                                        | Required | Default       | Description                                                 |
-|---------------------------------|----------|----------------------------------------------------------------------------------------|
+|--------------------------------------------|----------------------------------------------------------------------------------------|
 | tx.dpf.provider.proxy.thread.pool          |          | 10            | Thread pool size for the provider data plane proxy gateway  |
+| web.http.gateway.context                   |          | default       | Context to register the ProviderGatewayController into      |

--- a/edc-extensions/dataplane-proxy/edc-dataplane-proxy-provider-api/README.md
+++ b/edc-extensions/dataplane-proxy/edc-dataplane-proxy-provider-api/README.md
@@ -21,4 +21,6 @@ When the proxy receive a request, it must contain the EDR, which will be decoded
 | Key                                        | Required | Default       | Description                                                 |
 |--------------------------------------------|----------------------------------------------------------------------------------------|
 | tx.dpf.provider.proxy.thread.pool          |          | 10            | Thread pool size for the provider data plane proxy gateway  |
-| web.http.gateway.context                   |          | default       | Context to register the ProviderGatewayController into      |
+| edc.dataplane.token.validation.endpoint    | x        |               | URL of the token validation endpoint                        |
+| web.http.gateway.context.path              |          |               | Path to register the ProviderGatewayController to           |
+| web.http.gateway.context.port              |          |               | Port to register the ProviderGatewayController to           |

--- a/edc-extensions/dataplane-proxy/edc-dataplane-proxy-provider-api/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/provider/api/DataPlaneProxyProviderApiExtension.java
+++ b/edc-extensions/dataplane-proxy/edc-dataplane-proxy-provider-api/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/provider/api/DataPlaneProxyProviderApiExtension.java
@@ -42,8 +42,13 @@ public class DataPlaneProxyProviderApiExtension implements ServiceExtension {
     static final String NAME = "Data Plane Proxy Provider API";
     @Setting(value = "Thread pool size for the provider data plane proxy gateway", type = "int")
     private static final String THREAD_POOL_SIZE = "tx.dpf.provider.proxy.thread.pool";
+
+    @Setting(value = "Context to register the ProviderGatewayController into", type = "String")
+    private static final String WEB_HTTP_GATEWAY_CONTEXT = "web.http.gateway.context";
+
     @Setting
     private static final String CONTROL_PLANE_VALIDATION_ENDPOINT = "edc.dataplane.token.validation.endpoint";
+
     @Inject
     private WebService webService;
 
@@ -87,7 +92,13 @@ public class DataPlaneProxyProviderApiExtension implements ServiceExtension {
                 executorService,
                 monitor);
 
-        webService.registerResource(controller);
+        var webHttpGateWayContext = context.getConfig().getString(WEB_HTTP_GATEWAY_CONTEXT);
+
+        if (webHttpGateWayContext == null) {
+            webService.registerResource(controller);
+        } else {
+            webService.registerResource(webHttpGateWayContext, controller);
+        }
     }
 
 

--- a/edc-extensions/dataplane-proxy/edc-dataplane-proxy-provider-api/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/provider/api/DataPlaneProxyProviderApiExtension.java
+++ b/edc-extensions/dataplane-proxy/edc-dataplane-proxy-provider-api/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/provider/api/DataPlaneProxyProviderApiExtension.java
@@ -92,12 +92,10 @@ public class DataPlaneProxyProviderApiExtension implements ServiceExtension {
                 executorService,
                 monitor);
 
-        var webHttpGateWayContext = context.getConfig().getString(WEB_HTTP_GATEWAY_CONTEXT);
-
-        if (webHttpGateWayContext == null) {
-            webService.registerResource(controller);
+        if (context.getConfig().hasKey(WEB_HTTP_GATEWAY_CONTEXT)) {
+            webService.registerResource(context.getConfig().getString(WEB_HTTP_GATEWAY_CONTEXT), controller);
         } else {
-            webService.registerResource(webHttpGateWayContext, controller);
+            webService.registerResource(controller);
         }
     }
 

--- a/edc-extensions/dataplane-proxy/edc-dataplane-proxy-provider-api/src/test/java/org/eclipse/tractusx/edc/dataplane/proxy/provider/api/response/DataPlaneProxyProviderApiExtensionTest.java
+++ b/edc-extensions/dataplane-proxy/edc-dataplane-proxy-provider-api/src/test/java/org/eclipse/tractusx/edc/dataplane/proxy/provider/api/response/DataPlaneProxyProviderApiExtensionTest.java
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (c) 2023 Mercedes Benz Tech Innovation GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Mercedes Benz Tech Innovation GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.dataplane.proxy.provider.api.response;
+
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.spi.system.injection.ObjectFactory;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.tractusx.edc.dataplane.proxy.provider.api.DataPlaneProxyProviderApiExtension;
+import org.eclipse.tractusx.edc.dataplane.proxy.provider.api.gateway.ProviderGatewayController;
+import org.eclipse.tractusx.edc.dataplane.proxy.provider.api.validation.ProxyProviderDataAddressResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class DataPlaneProxyProviderApiExtensionTest {
+
+    private DataPlaneProxyProviderApiExtension extension;
+
+    private static final String CONFIG_THREAD_POOL_SIZE_KEY = "tx.dpf.provider.proxy.thread.pool";
+    private static final String CONFIG_THREAD_POOL_SIZE_VALUE = "10";
+
+    private static final String CONFIG_WEB_HTTP_GATEWAY_PATH_KEY = "web.http.gateway.path";
+    private static final String CONFIG_WEB_HTTP_GATEWAY_PATH_VALUE = "/api/v1/gateway";
+
+    private static final String CONFIG_WEB_HTTP_GATEWAY_PORT_KEY = "web.http.gateway.port";
+    private static final String CONFIG_WEB_HTTP_GATEWAY_PORT_VALUE = "11111";
+
+    private static final String CONFIG_CONTROL_PLANE_VALIDATION_ENDPOINT_KEY = "edc.dataplane.token.validation.endpoint";
+    private static final String CONFIG_CONTROL_PLANE_VALIDATION_ENDPOINT_VALUE = "http://example.com";
+
+    // mocks
+    private ServiceExtensionContext serviceExtensionContext;
+    private ProviderGatewayController providerGatewayController;
+    private Monitor monitor;
+    private WebService webService;
+    private ProxyProviderDataAddressResolver proxyProviderDataAddressResolver;
+    private TypeManager typeManager;
+
+
+    @BeforeEach
+    void setup(ObjectFactory factory, ServiceExtensionContext context) {
+        serviceExtensionContext = Mockito.mock(ServiceExtensionContext.class);
+        providerGatewayController = Mockito.mock(ProviderGatewayController.class);
+        monitor = Mockito.mock(Monitor.class);
+        webService = Mockito.mock(WebService.class);
+        proxyProviderDataAddressResolver = Mockito.mock(ProxyProviderDataAddressResolver.class);
+        typeManager = Mockito.mock(TypeManager.class);
+
+        Mockito.when(serviceExtensionContext.getService(ProviderGatewayController.class))
+                .thenReturn(providerGatewayController);
+        Mockito.when(serviceExtensionContext.getMonitor()).thenReturn(monitor);
+        context.registerService(TypeManager.class, typeManager);
+        context.registerService(WebService.class, webService);
+
+        extension = factory.constructInstance(DataPlaneProxyProviderApiExtension.class);
+    }
+
+    private Map<String, String> getConfig() {
+        return new HashMap<>() {
+            {
+                put(CONFIG_THREAD_POOL_SIZE_KEY, CONFIG_THREAD_POOL_SIZE_VALUE);
+                put(CONFIG_CONTROL_PLANE_VALIDATION_ENDPOINT_KEY, CONFIG_CONTROL_PLANE_VALIDATION_ENDPOINT_VALUE);
+            }
+        };
+    }
+
+    private Map<String, String> getConfigWithContext() {
+        var config = getConfig();
+        config.put(CONFIG_WEB_HTTP_GATEWAY_PATH_KEY, CONFIG_WEB_HTTP_GATEWAY_PATH_VALUE);
+        config.put(CONFIG_WEB_HTTP_GATEWAY_PORT_KEY, CONFIG_WEB_HTTP_GATEWAY_PORT_VALUE);
+        return config;
+    }
+
+    @Test
+    void testInitialize() {
+        var config = ConfigFactory.fromMap(getConfig());
+        Mockito.when(serviceExtensionContext.getConfig()).thenReturn(config);
+
+        extension.initialize(serviceExtensionContext);
+
+        Mockito.verify(webService, Mockito.times(1)).registerResource(Mockito.any(ProviderGatewayController.class));
+    }
+
+    @Test
+    void testInitializeWithContext() {
+        var config = ConfigFactory.fromMap(getConfigWithContext());
+        Mockito.when(serviceExtensionContext.getConfig()).thenReturn(config);
+
+        extension.initialize(serviceExtensionContext);
+
+        Mockito.verify(webService, Mockito.times(1)).registerResource(Mockito.any(String.class), Mockito.any(ProviderGatewayController.class));
+    }
+}

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/lifecycle/TestRuntimeConfiguration.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/lifecycle/TestRuntimeConfiguration.java
@@ -46,8 +46,10 @@ public class TestRuntimeConfiguration {
     public static final String PLATO_DSP_CALLBACK = "http://localhost:" + PLATO_DSP_API_PORT + DSP_PATH;
     static final int SOKRATES_CONNECTOR_PORT = getFreePort();
     static final int SOKRATES_MANAGEMENT_PORT = getFreePort();
+    static final int SOKRATES_GATEWAY_PORT = getFreePort();
     static final String SOKRATES_CONNECTOR_PATH = "/api";
     static final String SOKRATES_MANAGEMENT_PATH = "/api/v1/management";
+    static final String SOKRATES_GATEWAY_PATH = "/api/v1/gateway";
     static final int SOKRATES_DSP_API_PORT = getFreePort();
     public static final String SOKRATES_DSP_CALLBACK = "http://localhost:" + SOKRATES_DSP_API_PORT + DSP_PATH;
     static final String SOKRATES_PUBLIC_API_PORT = String.valueOf(getFreePort());
@@ -96,6 +98,8 @@ public class TestRuntimeConfiguration {
                 put("edc.api.auth.key", "testkey");
                 put("web.http.public.path", "/api/public");
                 put("web.http.public.port", SOKRATES_PUBLIC_API_PORT);
+                put("web.http.gateway.path", SOKRATES_GATEWAY_PATH);
+                put("web.http.gateway.port", String.valueOf(SOKRATES_GATEWAY_PORT));
 
                 put("edc.transfer.send.retry.limit", "1");
                 put("edc.transfer.send.retry.base-delay.ms", "100");


### PR DESCRIPTION
## WHAT

Adds an optional setting to specify a jetty context into which to register the ProviderGatewayController.

## WHY

[365](https://github.com/eclipse-tractusx/tractusx-edc/issues/365)

## FURTHER NOTES

I don't know whether this is actually the correct approach.

Closes #365 
