### PR TITLE
docs: run autodoc and upload resulting md to docusaurus

### DIFF
--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup JDK 17
-      uses: actions/setup-java@v3.11.0
+      uses: actions/setup-java@v3.13.0
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/publish-docusaurus.yaml
+++ b/.github/workflows/publish-docusaurus.yaml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/setup-java
+
       - name: "Extract version"
         id: extract_version
         run: |
@@ -54,6 +56,12 @@ jobs:
           else
             echo "DOWNSTREAM_VERSION=${{ inputs.downstream-version }}" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: "Run autodoc"
+        run: |
+          ./gradlew autodoc
+          ./gradlew mergeManifests
+          ./gradlew doc2md
 
       - name: "Gather documentation files"
         run: |

--- a/.github/workflows/publish-swaggerhub.yaml
+++ b/.github/workflows/publish-swaggerhub.yaml
@@ -51,12 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup JDK 17
-        uses: actions/setup-java@v3.13.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+      - uses: ./.github/actions/setup-java
 
       - name: Setup node
         uses: actions/setup-node@v3

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -406,7 +406,7 @@ maven/mavencentral/org.testcontainers/jdbc/1.19.0, Apache-2.0, approved, #10348
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.0, MIT, approved, #10344
 maven/mavencentral/org.testcontainers/postgresql/1.19.0, MIT, approved, #10350
 maven/mavencentral/org.testcontainers/testcontainers/1.19.0, Apache-2.0 AND MIT, approved, #10347
-maven/mavencentral/org.testcontainers/vault/1.19.0, MIT, approved, clearlydefined
+maven/mavencentral/org.testcontainers/vault/1.19.0, None, restricted, #10852
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275
 maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #10232
 maven/mavencentral/software.amazon.awssdk/annotations/2.20.146, Apache-2.0, approved, #8598

--- a/resources/create_kit_documentation.sh
+++ b/resources/create_kit_documentation.sh
@@ -8,46 +8,51 @@ echo $1 $2 $3
 
 cd ${repo_root}
 
-mkdir -p ${output_dir}/tractusx-edc/Connector\ Kit/
-rsync -a --prune-empty-dirs --exclude 'build' --include '*' ./docs/kit/* ${output_dir}/tractusx-edc/Connector\ Kit/
+connector_kit="${output_dir}/tractusx-edc/Connector Kit"
+mkdir -p "${connector_kit}"
+rsync -a --prune-empty-dirs --exclude 'build' --include '*' ./docs/kit/* "${connector_kit}/"
 
-mkdir -p ${output_dir}/tractusx-edc/Connector\ Kit/Operation\ View/03_deployment_via_helm
-cp ./docs/samples/example-dataspace/README.md ${output_dir}/tractusx-edc/Connector\ Kit/Operation\ View/03_deployment_via_helm/00_example_dataspace.md
-cp ./docs/samples/edr-api-overview/edr-api-overview.md ${output_dir}/tractusx-edc/Connector\ Kit/Operation\ View/03_deployment_via_helm/01_edr_api_overview.md
+operation_view="${connector_kit}/Operation View"
+mkdir -p "${operation_view}/03_deployment_via_helm"
+cp ./docs/samples/example-dataspace/README.md "${operation_view}/03_deployment_via_helm/00_example_dataspace.md"
+cp ./docs/samples/edr-api-overview/edr-api-overview.md "${operation_view}/03_deployment_via_helm/01_edr_api_overview.md"
 
-mkdir -p ${output_dir}/tractusx-edc/Connector\ Kit/Operation\ View/04_Test\ Your\ Setup
-cp ./docs/development/postman/README.md ${output_dir}/tractusx-edc/Connector\ Kit/Operation\ View/04_Test\ Your\ Setup/00_postman.md
-cp ./docs/samples/Transfer\ Data.md ${output_dir}/tractusx-edc/Connector\ Kit/Operation\ View/04_Test\ Your\ Setup/02_transfer_data.md
-cp -r ./docs/samples/diagrams ${output_dir}/tractusx-edc/Connector\ Kit/Operation\ View/04_Test\ Your\ Setup/
+mkdir -p "${operation_view}/04_Test Your Setup"
+cp ./docs/development/postman/README.md "${operation_view}/04_Test Your Setup/00_postman.md"
+cp ./docs/samples/Transfer\ Data.md "${operation_view}/04_Test Your Setup/02_transfer_data.md"
+cp -r ./docs/samples/diagrams "${operation_view}/04_Test Your Setup/"
 
-mkdir -p ${output_dir}/tractusx-edc/Connector\ Kit/Operation\ View/05_Migration
-cp ./docs/migration/* ${output_dir}/tractusx-edc/Connector\ Kit/Operation\ View/05_Migration/
+mkdir -p "${operation_view}/05_Migration"
+cp ./docs/migration/* "${operation_view}/05_Migration/"
 
-mkdir -p ${output_dir}/tractusx-edc/Connector\ Kit/Development\ View
-cp ./docs/README.md ${output_dir}/tractusx-edc/Connector\ Kit/Development\ View/00_tractusx_edc.md
-cp ./core/edr-core/README.md ${output_dir}/tractusx-edc/Connector\ Kit/Development\ View/06_edr_core.md
-cp ./docs/development/Release.md ${output_dir}/tractusx-edc/Connector\ Kit/Development\ View/07_release.md
+development_view="${connector_kit}/Development View"
+mkdir -p "${development_view}"
+cp ./docs/README.md "${development_view}/00_tractusx_edc.md"
+cp ./core/edr-core/README.md "${development_view}/06_edr_core.md"
+cp ./docs/development/Release.md "${development_view}/07_release.md"
 
-mkdir -p ${output_dir}/tractusx-edc/Connector\ Kit/Development\ View/03_EDC\ Controlplane
-rsync -a --prune-empty-dirs --include '*/' --exclude 'build' --include '*.md' --include '*.png' --include '*.puml' --exclude '*' ./edc-controlplane/* ${output_dir}/tractusx-edc/Connector\ Kit/Development\ View/03_EDC\ Controlplane
+mkdir -p "${development_view}/03_EDC Controlplane"
+rsync -a --prune-empty-dirs --include '*/' --exclude 'build' --include '*.md' --include '*.png' --include '*.puml' --exclude '*' ./edc-controlplane/* "${development_view}/03_EDC Controlplane"
 
-mkdir -p ${output_dir}/tractusx-edc/Connector\ Kit/Development\ View/04_EDC\ Dataplane
-rsync -a --prune-empty-dirs --include '*/' --exclude 'build' --include '*.md' --include '*.png' --include '*.puml' --exclude '*' ./edc-dataplane/* ${output_dir}/tractusx-edc/Connector\ Kit/Development\ View/04_EDC\ Dataplane
+mkdir -p "${development_view}/04_EDC Dataplane"
+rsync -a --prune-empty-dirs --include '*/' --exclude 'build' --include '*.md' --include '*.png' --include '*.puml' --exclude '*' ./edc-dataplane/* "${development_view}/04_EDC Dataplane"
 
-mkdir -p ${output_dir}/tractusx-edc/Connector\ Kit/Development\ View/05_EDC\ Extensions
-rsync -a --prune-empty-dirs --include '*/' --exclude 'build' --include '*.md' --include '*.png' --include '*.puml' --exclude '*' ./edc-extensions/* ${output_dir}/tractusx-edc/Connector\ Kit/Development\ View/05_EDC\ Extensions
+mkdir -p "${development_view}/05_EDC Extensions"
+rsync -a --prune-empty-dirs --include '*/' --exclude 'build' --include '*.md' --include '*.png' --include '*.puml' --exclude '*' ./edc-extensions/* "${development_view}/05_EDC Extensions"
+cp ./build/tractusx-edc.md "${development_view}/05_EDC Extensions/01_autodoc_manifest.md"
 
-mkdir -p ${output_dir}/tractusx-edc/Connector\ Kit/Documentation
-cp ./docs/development/coding-principles.md ${output_dir}/tractusx-edc/Connector\ Kit/Documentation/02_coding_principles.md
-cp ./pr_etiquette.md ${output_dir}/tractusx-edc/Connector\ Kit/Documentation/03_pr_etiquette.md
-cp ./styleguide.md ${output_dir}/tractusx-edc/Connector\ Kit/Documentation/04_styleguide.md
-mkdir -p ${output_dir}/tractusx-edc/Connector\ Kit/Documentation/resources
-cp ./resources/tx-checkstyle-config.xml ${output_dir}/tractusx-edc/Connector\ Kit/Documentation/resources
-cp ./SECURITY.md ${output_dir}/tractusx-edc/Connector\ Kit/Documentation/05_security.md
-mkdir -p ${output_dir}/tractusx-edc/Connector\ Kit/Documentation/resources
-cp ./resources/save_actions_scr.png ${output_dir}/tractusx-edc/Connector\ Kit/Documentation/resources/
+documentation="${output_dir}/tractusx-edc/Connector Kit/Documentation"
+mkdir -p "${documentation}"
+cp ./docs/development/coding-principles.md "${documentation}/02_coding_principles.md"
+cp ./pr_etiquette.md "${documentation}/03_pr_etiquette.md"
+cp ./styleguide.md "${documentation}/04_styleguide.md"
+mkdir -p "${documentation}/resources"
+cp ./resources/tx-checkstyle-config.xml "${documentation}/resources"
+cp ./SECURITY.md "${documentation}/05_security.md"
+mkdir -p "${documentation}/resources"
+cp ./resources/save_actions_scr.png "${documentation}/resources/"
 
-curl https://api.swaggerhub.com/apis/tractusx-edc/${release_version}/swagger.yaml > ${output_dir}/tractusx-edc/tractusx-edc-${release_version}.yaml
+curl "https://api.swaggerhub.com/apis/tractusx-edc/${release_version}/swagger.yaml" > "${output_dir}/tractusx-edc/tractusx-edc-${release_version}.yaml"
 
 cd ${output_dir}/tractusx-edc
 zip -r ../tractusx-edc-docusaurus-${release_version}.zip ./*


### PR DESCRIPTION
## WHAT

run `autodoc` on `publish-docusaurus` ci job to have the resulting `md` uploaded to docusaurus in the `Development View/05_EDC Extensions/` folder

## WHY

documentation

## FURTHER NOTES

- made `publish-swaggerhub` use the shared `setup-java` action step
- upgraded `setup-java` to `3.13.0`
- refactored `created_kit_documentation.sh`, extracting variables and wrapping paths with double quotes, to make the script less error prone

Closes #700 