### PR TITLE
build: give permissions to Publish Artefacts

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -141,7 +141,8 @@ jobs:
   publish-docusaurus:
     name: Publish docusaurus docs
     permissions:
-      contents: read
+      contents: write
+      packages: write
     needs: [ secret-presence, publish-to-swaggerhub ]
     if: needs.secret-presence.outputs.HAS_SWAGGER
     uses: ./.github/workflows/publish-docusaurus.yaml


### PR DESCRIPTION
## WHAT

Add write permissions to the `publish-docusaurus` job

## WHY

they are needed to run the job

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #809 
