### PR TITLE
docs: set openapi default version on swaggerhub

### DIFF
--- a/.github/workflows/publish-swaggerhub.yaml
+++ b/.github/workflows/publish-swaggerhub.yaml
@@ -102,6 +102,7 @@ jobs:
           if [[ ${{ env.DOWNSTREAM_VERSION }} != *-SNAPSHOT ]]; then
             echo "no snapshot, will set the API to 'published'";
             swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/tractusx-edc/${{ env.DOWNSTREAM_VERSION }} -f ./resources/openapi/yaml/tractusx-edc-api.yaml --visibility=public --published=publish
+            swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/tractusx-edc/${{ env.DOWNSTREAM_VERSION }}
           else
             echo "snapshot, will set the API to 'unpublished'";
             swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/tractusx-edc/${{ env.DOWNSTREAM_VERSION }} -f ./resources/openapi/yaml/tractusx-edc-api.yaml --visibility=public --published=unpublish


### PR DESCRIPTION
## WHAT

Sets the published version as default when it's a proper release (not snapshot)

## WHY

documentation

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #819 
