### PR TITLE
chore: removes secret-presence needs from publish release workflow

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -255,7 +255,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    needs: [ secret-presence, publish-to-swaggerhub, github-release ]
+    needs: [ publish-to-swaggerhub, github-release ]
     with:
       downstream-version: ${{ needs.release-version.outputs.RELEASE_VERSION }}
     uses: ./.github/workflows/publish-docusaurus.yaml


### PR DESCRIPTION
## WHAT

Fix release pipeline by removing `secret-presence` from the `publish-docusaurus` step

## WHY

Release it's not working

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
