### PR TITLE
fix: add removed setting from publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -56,11 +56,11 @@ jobs:
         id: secret-presence
         run: |
           [ ! -z "${{ secrets.DOCKER_HUB_TOKEN }}" ] && echo "DOCKER_HUB_TOKEN=true" >> $GITHUB_OUTPUT
-          [ ! -z "${{ secrets.ORG_GPG_PASSPHRASE }}" ] && 
-          [ ! -z "${{ secrets.ORG_GPG_PRIVATE_KEY }}" ] && 
-          [ ! -z "${{ secrets.ORG_OSSRH_USERNAME }}" ] && 
+          [ ! -z "${{ secrets.ORG_GPG_PASSPHRASE }}" ] &&
+          [ ! -z "${{ secrets.ORG_GPG_PRIVATE_KEY }}" ] &&
+          [ ! -z "${{ secrets.ORG_OSSRH_USERNAME }}" ] &&
           [ ! -z "${{ secrets.ORG_OSSRH_PASSWORD }}" ]  && echo "HAS_OSSRH=true" >> $GITHUB_OUTPUT
-          [ ! -z "${{ secrets.SWAGGERHUB_API_KEY }}" ]  && 
+          [ ! -z "${{ secrets.SWAGGERHUB_API_KEY }}" ]  &&
           [ ! -z "${{ secrets.SWAGGERHUB_USER }}" ]  && echo "HAS_SWAGGER=true" >> $GITHUB_OUTPUT
           exit 0
 
@@ -137,6 +137,7 @@ jobs:
     needs: [ secret-presence ]
     if: needs.secret-presence.outputs.HAS_SWAGGER
     uses: ./.github/workflows/publish-swaggerhub.yaml
+    secrets: inherit
 
   publish-docusaurus:
     name: Publish docusaurus docs


### PR DESCRIPTION
## WHAT

the `secrets: inherit` was removed for some reasons in https://github.com/eclipse-tractusx/tractusx-edc/commit/c8dd495469136af2c4db26856f5af2c9cf263f0c#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caL140

but as mentioned by the EF help desk, that setting is necessary:
https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3773#note_1223226 

## WHY

fix publish to swaggerhub

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
