### PR TITLE
feat: use encryption in all inmem tests

### DIFF
--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/lifecycle/TestRuntimeConfiguration.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/lifecycle/TestRuntimeConfiguration.java
@@ -111,6 +111,7 @@ public class TestRuntimeConfiguration {
                 put("edc.receiver.http.dynamic.endpoint", "http://localhost:" + SOKRATES_CONNECTOR_PORT + "/api/consumer/datareference");
                 put("tractusx.businesspartnervalidation.log.agreement.validation", "true");
                 put("edc.agent.identity.key", "BusinessPartnerNumber");
+                put("edc.data.encryption.keys.alias", "test-alias");
             }
         };
     }
@@ -145,6 +146,7 @@ public class TestRuntimeConfiguration {
                 put("edc.agent.identity.key", "BusinessPartnerNumber");
                 put("tx.dpf.proxy.gateway.aas.proxied.path", "http://localhost:" + PLATO_PROXIED_AAS_BACKEND_PORT + PROXIED_PATH);
                 put("tx.dpf.proxy.gateway.aas.authorization.type", "none");
+                put("edc.data.encryption.keys.alias", "test-alias");
             }
         };
     }

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/edr/DeleteEdrInMemoryTest.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/edr/DeleteEdrInMemoryTest.java
@@ -15,9 +15,14 @@
 package org.eclipse.tractusx.edc.tests.edr;
 
 
+import com.nimbusds.jose.util.Base64;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.tractusx.edc.lifecycle.ParticipantRuntime;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.security.SecureRandom;
 
 import static org.eclipse.tractusx.edc.lifecycle.TestRuntimeConfiguration.PLATO_BPN;
 import static org.eclipse.tractusx.edc.lifecycle.TestRuntimeConfiguration.PLATO_NAME;
@@ -45,4 +50,17 @@ public class DeleteEdrInMemoryTest extends AbstractDeleteEdrTest {
             PLATO_BPN,
             renewalConfiguration(platoConfiguration())
     );
+
+    @BeforeAll
+    static void prepare() {
+        var bytes = new byte[32];
+
+        new SecureRandom().nextBytes(bytes);
+        var value = Base64.encode(bytes).toString();
+        var vault = SOKRATES_RUNTIME.getContext().getService(Vault.class);
+        vault.storeSecret("test-alias", value);
+        vault = PLATO_RUNTIME.getContext().getService(Vault.class);
+        vault.storeSecret("test-alias", value);
+
+    }
 }

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/edr/NegotiateEdrInMemoryTest.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/edr/NegotiateEdrInMemoryTest.java
@@ -15,9 +15,14 @@
 package org.eclipse.tractusx.edc.tests.edr;
 
 
+import com.nimbusds.jose.util.Base64;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.tractusx.edc.lifecycle.ParticipantRuntime;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.security.SecureRandom;
 
 import static org.eclipse.tractusx.edc.lifecycle.TestRuntimeConfiguration.PLATO_BPN;
 import static org.eclipse.tractusx.edc.lifecycle.TestRuntimeConfiguration.PLATO_NAME;
@@ -44,4 +49,17 @@ public class NegotiateEdrInMemoryTest extends AbstractNegotiateEdrTest {
             PLATO_BPN,
             platoConfiguration()
     );
+
+    @BeforeAll
+    static void prepare() {
+        var bytes = new byte[32];
+
+        new SecureRandom().nextBytes(bytes);
+        var value = Base64.encode(bytes).toString();
+        var vault = SOKRATES_RUNTIME.getContext().getService(Vault.class);
+        vault.storeSecret("test-alias", value);
+        vault = PLATO_RUNTIME.getContext().getService(Vault.class);
+        vault.storeSecret("test-alias", value);
+
+    }
 }

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/edr/RenewalEdrInMemoryTest.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/edr/RenewalEdrInMemoryTest.java
@@ -15,9 +15,14 @@
 package org.eclipse.tractusx.edc.tests.edr;
 
 
+import com.nimbusds.jose.util.Base64;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.tractusx.edc.lifecycle.ParticipantRuntime;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.security.SecureRandom;
 
 import static org.eclipse.tractusx.edc.lifecycle.TestRuntimeConfiguration.PLATO_BPN;
 import static org.eclipse.tractusx.edc.lifecycle.TestRuntimeConfiguration.PLATO_NAME;
@@ -45,4 +50,17 @@ public class RenewalEdrInMemoryTest extends AbstractRenewalEdrTest {
             PLATO_BPN,
             renewalConfiguration(platoConfiguration())
     );
+
+    @BeforeAll
+    static void prepare() {
+        var bytes = new byte[32];
+
+        new SecureRandom().nextBytes(bytes);
+        var value = Base64.encode(bytes).toString();
+        var vault = SOKRATES_RUNTIME.getContext().getService(Vault.class);
+        vault.storeSecret("test-alias", value);
+        vault = PLATO_RUNTIME.getContext().getService(Vault.class);
+        vault.storeSecret("test-alias", value);
+
+    }
 }

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/proxy/DataPlaneProxyInMemoryTest.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/proxy/DataPlaneProxyInMemoryTest.java
@@ -14,9 +14,14 @@
 
 package org.eclipse.tractusx.edc.tests.proxy;
 
+import com.nimbusds.jose.util.Base64;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.tractusx.edc.lifecycle.ParticipantRuntime;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.security.SecureRandom;
 
 import static org.eclipse.tractusx.edc.lifecycle.TestRuntimeConfiguration.PLATO_BPN;
 import static org.eclipse.tractusx.edc.lifecycle.TestRuntimeConfiguration.PLATO_NAME;
@@ -27,7 +32,7 @@ import static org.eclipse.tractusx.edc.lifecycle.TestRuntimeConfiguration.sokrat
 
 @EndToEndTest
 public class DataPlaneProxyInMemoryTest extends AbstractDataPlaneProxyTest {
-    
+
     @RegisterExtension
     protected static final ParticipantRuntime SOKRATES_RUNTIME = new ParticipantRuntime(
             ":edc-tests:runtime:runtime-memory",
@@ -43,4 +48,17 @@ public class DataPlaneProxyInMemoryTest extends AbstractDataPlaneProxyTest {
             PLATO_BPN,
             platoConfiguration()
     );
+
+    @BeforeAll
+    static void prepare() {
+        var bytes = new byte[32];
+
+        new SecureRandom().nextBytes(bytes);
+        var value = Base64.encode(bytes).toString();
+        var vault = SOKRATES_RUNTIME.getContext().getService(Vault.class);
+        vault.storeSecret("test-alias", value);
+        vault = PLATO_RUNTIME.getContext().getService(Vault.class);
+        vault.storeSecret("test-alias", value);
+
+    }
 }

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/AbstractHttpConsumerPullWithProxyTest.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/AbstractHttpConsumerPullWithProxyTest.java
@@ -58,6 +58,7 @@ public abstract class AbstractHttpConsumerPullWithProxyTest {
     @BeforeEach
     void setup() throws IOException {
         server = new MockWebServer();
+
     }
 
     @Test

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/HttpConsumerPullWithProxyInMemoryTest.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/HttpConsumerPullWithProxyInMemoryTest.java
@@ -14,9 +14,14 @@
 
 package org.eclipse.tractusx.edc.tests.transfer;
 
+import com.nimbusds.jose.util.Base64;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.tractusx.edc.lifecycle.ParticipantRuntime;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.security.SecureRandom;
 
 import static org.eclipse.tractusx.edc.lifecycle.TestRuntimeConfiguration.PLATO_BPN;
 import static org.eclipse.tractusx.edc.lifecycle.TestRuntimeConfiguration.PLATO_NAME;
@@ -43,4 +48,17 @@ public class HttpConsumerPullWithProxyInMemoryTest extends AbstractHttpConsumerP
             PLATO_BPN,
             platoConfiguration()
     );
+
+    @BeforeAll
+    static void prepare() {
+        var bytes = new byte[32];
+
+        new SecureRandom().nextBytes(bytes);
+        var value = Base64.encode(bytes).toString();
+        var vault = SOKRATES_RUNTIME.getContext().getService(Vault.class);
+        vault.storeSecret("test-alias", value);
+        vault = PLATO_RUNTIME.getContext().getService(Vault.class);
+        vault.storeSecret("test-alias", value);
+
+    }
 }

--- a/edc-tests/runtime/runtime-memory/build.gradle.kts
+++ b/edc-tests/runtime/runtime-memory/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
         exclude("org.eclipse.edc", "oauth2-core")
         exclude("org.eclipse.edc", "oauth2-daps")
 
-        exclude(module = "data-encryption")
+//        exclude(module = "data-encryption")
         exclude(module = "json-ld-core")
         exclude(module = "ssi-identity-core")
         exclude(module = "ssi-miw-credential-client")


### PR DESCRIPTION
## WHAT

This test enables the DataEncryptor for all the in-mem tests

## WHY

No reason not to have encryption

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
