### PR TITLE
feat: adds support for multiple trusted issuers 

### DIFF
--- a/edc-extensions/ssi/ssi-miw-credential-client/src/main/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwValidationRuleExtension.java
+++ b/edc-extensions/ssi/ssi-miw-credential-client/src/main/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwValidationRuleExtension.java
@@ -45,6 +45,6 @@ public class SsiMiwValidationRuleExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         registry.addRule(new SsiCredentialSubjectIdValidationRule(monitor));
-        registry.addRule(new SsiCredentialIssuerValidationRule(miwConfiguration.getAuthorityIssuer(), monitor));
+        registry.addRule(new SsiCredentialIssuerValidationRule(miwConfiguration.getAuthorityIssuers(), monitor));
     }
 }

--- a/edc-extensions/ssi/ssi-miw-credential-client/src/main/java/org/eclipse/tractusx/edc/iam/ssi/miw/config/SsiMiwConfiguration.java
+++ b/edc-extensions/ssi/ssi-miw-credential-client/src/main/java/org/eclipse/tractusx/edc/iam/ssi/miw/config/SsiMiwConfiguration.java
@@ -14,13 +14,15 @@
 
 package org.eclipse.tractusx.edc.iam.ssi.miw.config;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 public class SsiMiwConfiguration {
 
     protected String url;
     protected String authorityId;
-    protected String authorityIssuer;
+    protected Set<String> authorityIssuers = new HashSet<>();
 
     public String getAuthorityId() {
         return authorityId;
@@ -30,8 +32,8 @@ public class SsiMiwConfiguration {
         return url;
     }
 
-    public String getAuthorityIssuer() {
-        return authorityIssuer;
+    public Set<String> getAuthorityIssuers() {
+        return authorityIssuers;
     }
 
     public static class Builder {
@@ -44,7 +46,7 @@ public class SsiMiwConfiguration {
         public static Builder newInstance() {
             return new Builder();
         }
-        
+
         public Builder url(String url) {
             config.url = url;
             return this;
@@ -55,14 +57,14 @@ public class SsiMiwConfiguration {
             return this;
         }
 
-        public Builder authorityIssuer(String authorityIssuer) {
-            config.authorityIssuer = authorityIssuer;
+        public Builder authorityIssuers(Set<String> authorityIssuers) {
+            config.authorityIssuers = authorityIssuers;
             return this;
         }
-
+        
         public SsiMiwConfiguration build() {
             Objects.requireNonNull(config.url);
-            Objects.requireNonNull(config.authorityIssuer);
+            Objects.requireNonNull(config.authorityIssuers);
             Objects.requireNonNull(config.authorityId);
             return config;
         }

--- a/edc-extensions/ssi/ssi-miw-credential-client/src/main/java/org/eclipse/tractusx/edc/iam/ssi/miw/rule/SsiCredentialIssuerValidationRule.java
+++ b/edc-extensions/ssi/ssi-miw-credential-client/src/main/java/org/eclipse/tractusx/edc/iam/ssi/miw/rule/SsiCredentialIssuerValidationRule.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
@@ -44,7 +45,7 @@ public class SsiCredentialIssuerValidationRule implements TokenValidationRule {
 
     private static final String SUBJECT_ISSUER_FIELD_ALIAS = "issuer";
 
-    private final String credentialIssuer;
+    private final Set<String> credentialIssuers;
 
     private final Monitor monitor;
 
@@ -54,8 +55,8 @@ public class SsiCredentialIssuerValidationRule implements TokenValidationRule {
             .errorPrefix(SUBJECT_ISSUER_EXTRACTOR_PREFIX)
             .build();
 
-    public SsiCredentialIssuerValidationRule(String credentialIssuer, Monitor monitor) {
-        this.credentialIssuer = credentialIssuer;
+    public SsiCredentialIssuerValidationRule(Set<String> credentialIssuers, Monitor monitor) {
+        this.credentialIssuers = credentialIssuers;
         this.monitor = monitor;
     }
 
@@ -76,10 +77,10 @@ public class SsiCredentialIssuerValidationRule implements TokenValidationRule {
     }
 
     private Result<Void> validateCredentialIssuer(String extractedCredentialIssuer) {
-        if (credentialIssuer.equals(extractedCredentialIssuer)) {
+        if (credentialIssuers.contains(extractedCredentialIssuer)) {
             return Result.success();
         } else {
-            return Result.failure(format("Invalid credential issuer: expected %s, found %s", credentialIssuer, extractedCredentialIssuer));
+            return Result.failure(format("Invalid credential issuer: expected %s, found %s", credentialIssuers, extractedCredentialIssuer));
         }
     }
 

--- a/edc-extensions/ssi/ssi-miw-credential-client/src/test/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwConfigurationExtensionTest.java
+++ b/edc-extensions/ssi/ssi-miw-credential-client/src/test/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwConfigurationExtensionTest.java
@@ -22,14 +22,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.Set;
+
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.tractusx.edc.iam.ssi.miw.SsiMiwConfigurationExtension.AUTHORITY_ID_TEMPLATE;
 import static org.eclipse.tractusx.edc.iam.ssi.miw.SsiMiwConfigurationExtension.MIW_AUTHORITY_ID;
-import static org.eclipse.tractusx.edc.iam.ssi.miw.SsiMiwConfigurationExtension.MIW_AUTHORITY_ISSUER;
+import static org.eclipse.tractusx.edc.iam.ssi.miw.SsiMiwConfigurationExtension.MIW_AUTHORITY_ISSUERS;
 import static org.eclipse.tractusx.edc.iam.ssi.miw.SsiMiwConfigurationExtension.MIW_BASE_URL;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -59,17 +61,43 @@ public class SsiMiwConfigurationExtensionTest {
 
         when(cfg.getString(MIW_BASE_URL)).thenReturn(url);
         when(cfg.getString(MIW_AUTHORITY_ID)).thenReturn(authorityId);
-        when(cfg.getString(eq(MIW_AUTHORITY_ISSUER), anyString())).thenReturn(authorityIssuer);
+        when(cfg.getString(eq(MIW_AUTHORITY_ISSUERS), isNull())).thenReturn(authorityIssuer);
 
         var miwConfig = extension.miwConfiguration(context);
 
         verify(cfg).getString(MIW_BASE_URL);
         verify(cfg).getString(MIW_AUTHORITY_ID);
-        verify(cfg).getString(eq(MIW_AUTHORITY_ISSUER), anyString());
+        verify(cfg).getString(eq(MIW_AUTHORITY_ISSUERS), isNull());
 
         assertThat(miwConfig.getUrl()).isEqualTo(url);
         assertThat(miwConfig.getAuthorityId()).isEqualTo(authorityId);
-        assertThat(miwConfig.getAuthorityIssuer()).isEqualTo(authorityIssuer);
+        assertThat(miwConfig.getAuthorityIssuers()).contains(authorityIssuer);
+
+    }
+
+    @Test
+    void initialize_withMultipleIssuers() {
+        var url = "http://localhost:8080";
+        var authorityId = "id";
+
+        var issuers = Set.of("issuer1", "issuer2");
+
+        var cfg = mock(Config.class);
+        when(context.getConfig()).thenReturn(cfg);
+
+        when(cfg.getString(MIW_BASE_URL)).thenReturn(url);
+        when(cfg.getString(MIW_AUTHORITY_ID)).thenReturn(authorityId);
+        when(cfg.getString(eq(MIW_AUTHORITY_ISSUERS), isNull())).thenReturn(String.join(",", issuers));
+
+        var miwConfig = extension.miwConfiguration(context);
+
+        verify(cfg).getString(MIW_BASE_URL);
+        verify(cfg).getString(MIW_AUTHORITY_ID);
+        verify(cfg).getString(eq(MIW_AUTHORITY_ISSUERS), isNull());
+
+        assertThat(miwConfig.getUrl()).isEqualTo(url);
+        assertThat(miwConfig.getAuthorityId()).isEqualTo(authorityId);
+        assertThat(miwConfig.getAuthorityIssuers()).containsAll(issuers);
 
     }
 
@@ -83,17 +111,17 @@ public class SsiMiwConfigurationExtensionTest {
 
         when(cfg.getString(MIW_BASE_URL)).thenReturn(url);
         when(cfg.getString(MIW_AUTHORITY_ID)).thenReturn(authorityId);
-        when(cfg.getString(eq(MIW_AUTHORITY_ISSUER), anyString())).thenAnswer(answer -> answer.getArgument(1));
+        when(cfg.getString(eq(MIW_AUTHORITY_ISSUERS), isNull())).thenAnswer(answer -> answer.getArgument(1));
 
         var miwConfig = extension.miwConfiguration(context);
 
         verify(cfg).getString(MIW_BASE_URL);
         verify(cfg).getString(MIW_AUTHORITY_ID);
-        verify(cfg).getString(eq(MIW_AUTHORITY_ISSUER), anyString());
+        verify(cfg).getString(eq(MIW_AUTHORITY_ISSUERS), isNull());
 
         assertThat(miwConfig.getUrl()).isEqualTo(url);
         assertThat(miwConfig.getAuthorityId()).isEqualTo(authorityId);
-        assertThat(miwConfig.getAuthorityIssuer()).isEqualTo(format(AUTHORITY_ID_TEMPLATE, "localhost%3A8080", authorityId));
+        assertThat(miwConfig.getAuthorityIssuers()).contains(format(AUTHORITY_ID_TEMPLATE, "localhost%3A8080", authorityId));
 
     }
 
@@ -107,17 +135,17 @@ public class SsiMiwConfigurationExtensionTest {
 
         when(cfg.getString(MIW_BASE_URL)).thenReturn(url);
         when(cfg.getString(MIW_AUTHORITY_ID)).thenReturn(authorityId);
-        when(cfg.getString(eq(MIW_AUTHORITY_ISSUER), anyString())).thenAnswer(answer -> answer.getArgument(1));
+        when(cfg.getString(eq(MIW_AUTHORITY_ISSUERS), isNull())).thenAnswer(answer -> answer.getArgument(1));
 
         var miwConfig = extension.miwConfiguration(context);
 
         verify(cfg).getString(MIW_BASE_URL);
         verify(cfg).getString(MIW_AUTHORITY_ID);
-        verify(cfg).getString(eq(MIW_AUTHORITY_ISSUER), anyString());
+        verify(cfg).getString(eq(MIW_AUTHORITY_ISSUERS), isNull());
 
         assertThat(miwConfig.getUrl()).isEqualTo("http://localhost:8080");
         assertThat(miwConfig.getAuthorityId()).isEqualTo(authorityId);
-        assertThat(miwConfig.getAuthorityIssuer()).isEqualTo(format(AUTHORITY_ID_TEMPLATE, "localhost%3A8080", authorityId));
+        assertThat(miwConfig.getAuthorityIssuers()).contains(format(AUTHORITY_ID_TEMPLATE, "localhost%3A8080", authorityId));
 
     }
 

--- a/edc-extensions/ssi/ssi-miw-credential-client/src/test/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwValidationRuleExtensionTest.java
+++ b/edc-extensions/ssi/ssi-miw-credential-client/src/test/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwValidationRuleExtensionTest.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.Set;
+
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -46,13 +48,13 @@ public class SsiMiwValidationRuleExtensionTest {
 
     @Test
     void initialize(ServiceExtensionContext context) {
-        when(cfg.getAuthorityIssuer()).thenReturn("issuer");
+        when(cfg.getAuthorityIssuers()).thenReturn(Set.of("issuer"));
 
         extension.initialize(context);
         verify(registry).addRule(isA(SsiCredentialSubjectIdValidationRule.class));
         verify(registry).addRule(isA(SsiCredentialIssuerValidationRule.class));
 
-        verify(cfg).getAuthorityIssuer();
+        verify(cfg).getAuthorityIssuers();
     }
 
 }

--- a/edc-extensions/ssi/ssi-miw-credential-client/src/test/java/org/eclipse/tractusx/edc/iam/ssi/miw/rule/SsiCredentialIssuerValidationRuleTest.java
+++ b/edc-extensions/ssi/ssi-miw-credential-client/src/test/java/org/eclipse/tractusx/edc/iam/ssi/miw/rule/SsiCredentialIssuerValidationRuleTest.java
@@ -22,6 +22,7 @@ import org.eclipse.tractusx.edc.iam.ssi.spi.jsonld.SummaryContext;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.tractusx.edc.iam.ssi.spi.jsonld.CredentialsNamespaces.CX_SUMMARY_NS_V1;
@@ -39,7 +40,7 @@ public class SsiCredentialIssuerValidationRuleTest {
 
     @Test
     void checkRule() throws JsonProcessingException {
-        validationRule = new SsiCredentialIssuerValidationRule("did:web:issuer-a016-203-129-213-99.ngrok-free.app:BPNL000000000000", mock(Monitor.class));
+        validationRule = new SsiCredentialIssuerValidationRule(Set.of("did:web:issuer-a016-203-129-213-99.ngrok-free.app:BPNL000000000000"), mock(Monitor.class));
         var vp = expand(createObjectMapper().readValue(SUMMARY_VP, JsonObject.class), CONTEXT_CACHE);
         var claimToken = ClaimToken.Builder.newInstance().claim(VP_PROPERTY, vp).build();
         var result = validationRule.checkRule(claimToken, Map.of());
@@ -50,7 +51,7 @@ public class SsiCredentialIssuerValidationRuleTest {
 
     @Test
     void checkRule_shouldFail_whenIssuerIsWrong() throws JsonProcessingException {
-        validationRule = new SsiCredentialIssuerValidationRule("issuer", mock(Monitor.class));
+        validationRule = new SsiCredentialIssuerValidationRule(Set.of("issuer"), mock(Monitor.class));
         var vp = expand(createObjectMapper().readValue(SUMMARY_VP, JsonObject.class), CONTEXT_CACHE);
         var claimToken = ClaimToken.Builder.newInstance().claim(VP_PROPERTY, vp).build();
         var result = validationRule.checkRule(claimToken, Map.of());


### PR DESCRIPTION
## WHAT

adds supports for multiple trusted issuers  in `SsiCredentialIssuerValidationRule`

## WHY

allow multiple trusted issuers

Closes #814 
