### PR TITLE
chore: add 0.5.2 and 0.5.3 changes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.3] - 2023-11-10
+
+What's Canged
+
+- chore: backport autovacuum fix https://github.com/eclipse-edc/Connector/pull/3479 by @wolf4ood  in https://github.com/eclipse-tractusx/tractusx-edc/pull/871
+
+## [0.5.2] - 2023-11-08
+
+What's Canged
+
+- chore: backport autovacuum fix https://github.com/eclipse-edc/Connector/pull/3479 by @wolf4ood  in https://github.com/eclipse-tractusx/tractusx-edc/pull/866
+
 ## [0.5.1] - 2023-08-22
 
-0.5.1 Latest
 What's Changed
 
 - chore: Improve Helm Chart documentation by @tuncaytunc-zf in [#607](https://github.com/eclipse-tractusx/tractusx-edc/pull/607)


### PR DESCRIPTION
## WHAT

Add the `0.5.2` and `0.5.3` changes to our static `CHANGELOG.md`

## WHY

Keeping a complete history of our releases and changes on a single file

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #886 
