### PR TITLE
chore: deactivate azure tests temporarily

### DIFF
--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -103,8 +103,12 @@ jobs:
   test-azure-vault-postgres:
     runs-on: ubuntu-latest
     needs: [ test-prepare, secret-presence ]
-    if: |
-      needs.secret-presence.outputs.AZURE_KV_CREDS
+#    if: |
+#      needs.secret-presence.outputs.AZURE_KV_CREDS
+
+    # DEACTIVATE this job for now because our Azure Credentials are expired
+    # TODO: reactivate once we have refreshed Azure Credentials
+    if: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## WHAT

Deactivates the deployment test for the Azure-Keyvault variant temporarily.

## WHY

AZ Credentials are expired

## FURTHER NOTES

.


Closes # <-- _insert Issue number if one exists_
