### PR TITLE
chore: add legal info to Docker images

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -35,7 +35,9 @@ in the GitHub organization <https://github.com/eclipse-tractusx>:
 
 This project leverages the following third party content.
 
-See DEPENDENCIES file.
+- OpenTelemetry Agent v1.32.0: <https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.32.0>
+
+For additional dependencies, see [DEPENDENCIES](./DEPENDENCIES) file.
 
 ## Cryptography
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,8 +102,8 @@ allprojects {
         swagger {
             title.set((project.findProperty("apiTitle") ?: "Tractus-X REST API") as String)
             description =
-                (project.findProperty("apiDescription")
-                    ?: "Tractus-X REST APIs - merged by OpenApiMerger") as String
+                    (project.findProperty("apiDescription")
+                            ?: "Tractus-X REST APIs - merged by OpenApiMerger") as String
             outputFilename.set(project.name)
             outputDirectory.set(file("${rootProject.projectDir.path}/resources/openapi/yaml"))
             resourcePackages = setOf("org.eclipse.tractusx.edc")
@@ -147,12 +147,12 @@ allprojects {
 subprojects {
     afterEvaluate {
         if (project.plugins.hasPlugin("com.github.johnrengelman.shadow") &&
-            file("${project.projectDir}/src/main/docker/Dockerfile").exists()
+                file("${project.projectDir}/src/main/docker/Dockerfile").exists()
         ) {
 
             val agentFile = project.buildDir.resolve("opentelemetry-javaagent.jar")
             // create task to download the opentelemetry agent
-            val openTelemetryAgentUrl = "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.27.0/opentelemetry-javaagent.jar"
+            val openTelemetryAgentUrl = "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.32.0/opentelemetry-javaagent.jar"
             val downloadOtel = tasks.create("downloadOtel") {
                 // only execute task if the opentelemetry agent does not exist. invoke the "clean" task to force
                 onlyIf {
@@ -166,8 +166,8 @@ subprojects {
                 doLast {
                     val download = { url: String, destFile: File ->
                         ant.invokeMethod(
-                            "get",
-                            mapOf("src" to url, "dest" to destFile)
+                                "get",
+                                mapOf("src" to url, "dest" to destFile)
                         )
                     }
                     logger.lifecycle("Downloading OpenTelemetry Agent")
@@ -192,7 +192,7 @@ subprojects {
             }
             // make sure  always runs after "dockerize" and after "copyOtel"
             dockerTask.dependsOn(tasks.named(ShadowJavaPlugin.SHADOW_JAR_TASK_NAME))
-                .dependsOn(downloadOtel)
+                    .dependsOn(downloadOtel)
         }
     }
 }

--- a/edc-controlplane/edc-controlplane-postgresql-azure-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-postgresql-azure-vault/notice.md
@@ -21,6 +21,10 @@ Eclipse Tractus-X product(s) installed within the image:
 - Additional information about the Eclipse Temurin
   images: <https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin>
 
+## Third-Party Software
+
+- OpenTelemetry Agent v1.32.0: <https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.32.0>
+
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
 from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/edc-controlplane/edc-controlplane-postgresql-azure-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql-azure-vault/src/main/docker/Dockerfile
@@ -21,6 +21,7 @@
 FROM eclipse-temurin:17.0.8.1_1-jre-alpine
 ARG JAR
 ARG OTEL_JAR
+ARG ADDITIONAL_FILES
 
 ARG APP_USER=docker
 ARG APP_UID=10100
@@ -41,6 +42,7 @@ WORKDIR /app
 
 COPY ${JAR} edc-controlplane.jar
 COPY ${OTEL_JAR} opentelemetry-javaagent.jar
+COPY ${ADDITIONAL_FILES} ./
 
 HEALTHCHECK NONE
 

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/notice.md
@@ -21,6 +21,10 @@ Eclipse Tractus-X product(s) installed within the image:
 - Additional information about the Eclipse Temurin
   images: <https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin>
 
+## Third-Party Software
+
+- OpenTelemetry Agent v1.32.0: <https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.32.0>
+
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
 from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
@@ -22,6 +22,7 @@
 FROM eclipse-temurin:17.0.8.1_1-jre-alpine
 ARG JAR
 ARG OTEL_JAR
+ARG ADDITIONAL_FILES
 
 ARG APP_USER=docker
 ARG APP_UID=10100
@@ -42,6 +43,7 @@ WORKDIR /app
 
 COPY ${JAR} edc-controlplane.jar
 COPY ${OTEL_JAR} opentelemetry-javaagent.jar
+COPY ${ADDITIONAL_FILES} ./
 
 HEALTHCHECK NONE
 

--- a/edc-controlplane/edc-runtime-memory/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-runtime-memory/src/main/docker/Dockerfile
@@ -25,6 +25,7 @@ ARG JAR
 
 ARG APP_USER=docker
 ARG APP_UID=10100
+ARG ADDITIONAL_FILES
 
 RUN addgroup --system "$APP_USER"
 
@@ -41,6 +42,7 @@ USER "$APP_USER"
 WORKDIR /app
 
 COPY ${JAR} edc-controlplane.jar
+COPY ${ADDITIONAL_FILES} ./
 
 HEALTHCHECK NONE
 

--- a/edc-dataplane/edc-dataplane-azure-vault/notice.md
+++ b/edc-dataplane/edc-dataplane-azure-vault/notice.md
@@ -21,6 +21,10 @@ Eclipse Tractus-X product(s) installed within the image:
 - Additional information about the Eclipse Temurin
   images: <https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin>
 
+## Third-Party Software
+
+- OpenTelemetry Agent v1.32.0: <https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.32.0>
+
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
 from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
@@ -21,6 +21,7 @@
 FROM eclipse-temurin:17.0.8.1_1-jre-alpine
 ARG JAR
 ARG OTEL_JAR
+ARG ADDITIONAL_FILES
 
 ARG APP_USER=docker
 ARG APP_UID=10100
@@ -41,6 +42,7 @@ WORKDIR /app
 
 COPY ${JAR} edc-dataplane.jar
 COPY ${OTEL_JAR} opentelemetry-javaagent.jar
+COPY ${ADDITIONAL_FILES} ./
 
 HEALTHCHECK NONE
 

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/notice.md
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/notice.md
@@ -21,6 +21,10 @@ Eclipse Tractus-X product(s) installed within the image:
 - Additional information about the Eclipse Temurin
   images: <https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin>
 
+## Third-Party Software
+
+- OpenTelemetry Agent v1.32.0: <https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.32.0>
+
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
 from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
@@ -22,6 +22,7 @@
 FROM eclipse-temurin:17.0.8.1_1-jre-alpine
 ARG JAR
 ARG OTEL_JAR
+ARG ADDITIONAL_FILES
 
 ARG APP_USER=docker
 ARG APP_UID=10100
@@ -42,6 +43,7 @@ WORKDIR /app
 
 COPY ${JAR} edc-dataplane.jar
 COPY ${OTEL_JAR} opentelemetry-javaagent.jar
+COPY ${ADDITIONAL_FILES} ./
 
 
 HEALTHCHECK NONE


### PR DESCRIPTION
## WHAT

This PR adds legal information about the OpenTelemetry Agent to the `notice.md` that we include with each Docker image.

In addition, the following legal documents are copied to the application root of the docker image: NOTICE.md, SECURITY.md, LICENSE, DEPENDENCIES

## WHY

TRG 7.07

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #889
