### PR TITLE
feat(test): add upgradeability test for Helm charts

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -51,6 +51,10 @@ jobs:
     uses: ./.github/workflows/deployment-test.yaml
     secrets: inherit
 
+  upgradeability-test:
+    uses: ./.github/workflows/upgradeability-test.yaml
+    secrets: inherit
+
   # this job really serves no other purpose than waiting for the other two test workflows
   # in future iterations, this could be used as a choke point to collect test data, etc.
   summary:

--- a/.github/workflows/upgradeability-test.yaml
+++ b/.github/workflows/upgradeability-test.yaml
@@ -44,6 +44,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: "Setup Helm"
+        uses: azure/setup-helm@v3.5
+        with:
+          version: v3.8.1
+
+      - name: "Setup Kubectl"
+        uses: azure/setup-kubectl@v3.2
+        with:
+          version: 'v1.28.2'
+
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1.5.0
+
       - name: "Update helm repo"
         run: |
           helm repo add tractusx https://eclipse-tractusx.github.io/charts/dev
@@ -77,7 +90,20 @@ jobs:
           # wait for the pod to become ready
           kubectl rollout status deployment tx-prod-controlplane
           kubectl rollout status deployment tx-prod-dataplane
-          
+
+      - uses: ./.github/actions/setup-java
+
+      - name: "Build docker images"
+        shell: bash
+        run: |-
+          ./gradlew :edc-controlplane:edc-controlplane-postgresql-hashicorp-vault:dockerize
+          ./gradlew :edc-dataplane:edc-dataplane-hashicorp-vault:dockerize
+
+      - name: "Load images into KinD"
+        shell: bash
+        run: |
+          kind get clusters | xargs -n1 kind load docker-image edc-controlplane-postgresql-hashicorp-vault edc-dataplane-hashicorp-vault --name
+
       - name: "Install new chart"
         run: |
           helm upgrade --install tx-prod charts/tractusx-connector \
@@ -91,3 +117,9 @@ jobs:
           
           # execute the helm test
           helm test tx-prod
+
+      - name: Destroy the kind cluster
+        if: always()
+        shell: bash
+        run: >-
+          kind get clusters | xargs -n1 kind delete cluster --name

--- a/.github/workflows/upgradeability-test.yaml
+++ b/.github/workflows/upgradeability-test.yaml
@@ -1,0 +1,93 @@
+#
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
+---
+name: "Upgradeability Tests"
+
+on:
+  workflow_call:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+
+  test-prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache ContainerD Image Layers
+        uses: actions/cache@v3
+        with:
+          path: /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs
+          key: ${{ runner.os }}-io.containerd.snapshotter.v1.overlayfs
+
+  test-upgradeability:
+    runs-on: ubuntu-latest
+    needs: [ test-prepare ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: "Update helm repo"
+        run: |
+          helm repo add tractusx https://eclipse-tractusx.github.io/charts/dev
+          helm repo update tractusx
+
+      - name: "Get latest released version"
+        id: get-version
+        run: |
+          RELEASED_VERSION=$(helm search repo tractusx/tractusx-connector -o json | jq -r '.[0].version')
+          echo "Last official release is $RELEASED_VERSION"
+          echo "RELEASE=$RELEASED_VERSION" >> $GITHUB_ENV
+          exit 0
+
+      - name: "Install latest release"
+        run: |
+          sh -c "edc-tests/deployment/src/main/resources/prepare-test.sh \
+                         edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml"
+          
+          helm upgrade --install tx-prod tractusx/tractusx-connector \
+            -f edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml \
+            --set "controlplane.image.tag=$RELEASE" \
+            --set "controlplane.image.pullPolicy=Always" \
+            --set "controlplane.image.repository=tractusx/edc-controlplane-postgresql-hashicorp-vault" \
+            --set "dataplane.image.tag=$RELEASE" \
+            --set "dataplane.image.pullPolicy=Always" \
+            --set "dataplane.image.repository=tractusx/edc-dataplane-hashicorp-vault" \
+            --dependency-update \
+            --wait-for-jobs --timeout=120s \
+            --version $RELEASE
+          
+          # wait for the pod to become ready
+          kubectl rollout status deployment tx-prod-controlplane
+          kubectl rollout status deployment tx-prod-dataplane
+          
+      - name: "Install new chart"
+        run: |
+          helm upgrade --install tx-prod charts/tractusx-connector \
+            -f edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml \
+            --dependency-update \
+            --wait-for-jobs --timeout=120s
+          
+           # wait for the pod to become ready
+          kubectl rollout status deployment tx-prod-controlplane
+          kubectl rollout status deployment tx-prod-dataplane
+          
+          # execute the helm test
+          helm test tx-prod


### PR DESCRIPTION
## WHAT

This PR adds an upgradeability test for our helm charts. to that end it:
- installs the last official release
- waits until both pods come up (DP and CP)
- installs the current (unreleased) version 
- waits until _that_ comes up
- executes `helm test`

## WHY

TRG 5.09

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #887
