### PR TITLE
chore: Change the state of the transfer process when EDR expires to Teminated

### DIFF
--- a/core/edr-core/src/main/java/org/eclipse/tractusx/edc/edr/core/manager/EdrManagerImpl.java
+++ b/core/edr-core/src/main/java/org/eclipse/tractusx/edc/edr/core/manager/EdrManagerImpl.java
@@ -151,7 +151,7 @@ public class EdrManagerImpl implements EdrManager {
 
 
     private ProcessorImpl<EndpointDataReferenceEntry> processEdrInState(EndpointDataReferenceEntryStates state, Function<EndpointDataReferenceEntry, Boolean> function) {
-        var filter = new Criterion[] {hasState(state.code())};
+        var filter = new Criterion[]{ hasState(state.code()) };
         return processor(() -> edrCache.nextNotLeased(batchSize, filter), telemetry.contextPropagationMiddleware(function));
     }
 
@@ -222,7 +222,7 @@ public class EdrManagerImpl implements EdrManager {
             return StatusResult.success();
         } else {
             breakLease(entry);
-            return StatusResult.failure(ResponseStatus.ERROR_RETRY, "Not yet expired.");
+            return StatusResult.success();
         }
     }
 
@@ -302,6 +302,10 @@ public class EdrManagerImpl implements EdrManager {
             edrManager = new EdrManagerImpl();
         }
 
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
         public Builder contractNegotiationService(ContractNegotiationService negotiationService) {
             edrManager.contractNegotiationService = negotiationService;
             return this;
@@ -372,10 +376,6 @@ public class EdrManagerImpl implements EdrManager {
             edrManager.entityRetryProcessFactory = new EntityRetryProcessFactory(edrManager.monitor, edrManager.clock, edrManager.entityRetryProcessConfiguration);
 
             return edrManager;
-        }
-
-        public static Builder newInstance() {
-            return new Builder();
         }
     }
 }

--- a/edc-extensions/edr/edr-callback/src/main/java/org/eclipse/tractusx/edc/callback/TransferProcessLocalCallback.java
+++ b/edc-extensions/edr/edr-callback/src/main/java/org/eclipse/tractusx/edc/callback/TransferProcessLocalCallback.java
@@ -151,8 +151,8 @@ public class TransferProcessLocalCallback implements InProcessCallback {
 
             var transferProcess = transferProcessStore.findById(entry.getTransferProcessId());
 
-            if (transferProcess != null && transferProcess.canBeCompleted()) {
-                transferProcess.transitionCompleting();
+            if (transferProcess != null && transferProcess.canBeTerminated()) {
+                transferProcess.transitionTerminating();
                 transferProcessStore.save(transferProcess);
             } else {
                 monitor.info(format("Cannot terminate transfer process with id: %s", entry.getTransferProcessId()));

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/lifecycle/Participant.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/lifecycle/Participant.java
@@ -290,6 +290,17 @@ public class Participant {
 
     }
 
+    public JsonArray getAllTransferProcess() {
+        return baseRequest()
+                .when()
+                .post("/v2/transferprocesses/request")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(JsonArray.class);
+    }
+
     public String getTransferProcessState(String id) {
         return baseRequest()
                 .when()

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/edr/AbstractRenewalEdrTest.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/edr/AbstractRenewalEdrTest.java
@@ -130,11 +130,28 @@ public abstract class AbstractRenewalEdrTest {
                 .findFirst()
                 .orElseThrow();
 
+        // Check Termination on Sokrates
         await().pollInterval(fibonacci())
                 .atMost(ASYNC_TIMEOUT)
                 .untilAsserted(() -> {
                     var tpState = SOKRATES.getTransferProcessState(transferProcessId);
-                    assertThat(tpState).isNotNull().isEqualTo(TransferProcessStates.COMPLETED.toString());
+                    assertThat(tpState).isNotNull().isEqualTo(TransferProcessStates.TERMINATED.toString());
+                });
+
+
+        // Check Termination on Plato
+        await().pollInterval(fibonacci())
+                .atMost(ASYNC_TIMEOUT)
+                .untilAsserted(() -> {
+                    var tpState = PLATO.getAllTransferProcess()
+                            .stream()
+                            .filter(json -> json.asJsonObject().getJsonString("correlationId").getString().equals(transferProcessId))
+                            .map(json -> json.asJsonObject().getJsonString("state").getString())
+                            .findFirst();
+
+                    assertThat(tpState)
+                            .isPresent()
+                            .hasValue(TransferProcessStates.TERMINATED.toString());
                 });
     }
 


### PR DESCRIPTION


## WHAT

As discussed in this PR #934 the correct state to transition when an EDR expire is `Terminated` and not `Completed` which aligns this with the `PolicyMonitor` behavior 

## WHY

Consistency

