### PR TITLE
feat: switch assets_selector type from text to json

### DIFF
--- a/edc-extensions/postgresql-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/contractdefinition/V0_0_8__Alter_ContractDefinition_Switch_Assets_Selector_Json.sql
+++ b/edc-extensions/postgresql-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/contractdefinition/V0_0_8__Alter_ContractDefinition_Switch_Assets_Selector_Json.sql
@@ -1,0 +1,16 @@
+--
+--  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+--
+--  This program and the accompanying materials are made available under the
+--  terms of the Apache License, Version 2.0 which is available at
+--  https://www.apache.org/licenses/LICENSE-2.0
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+--  Contributors:
+--       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+--
+
+-- switch assets_selector type to json
+ALTER TABLE edc_contract_definitions
+    ALTER COLUMN assets_selector TYPE JSON USING assets_selector::JSON;


### PR DESCRIPTION
## WHAT

Switch `assets_selector` type from `text` to `json`

## WHY

permit queries over the assets selector properties

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #933 
