### PR TITLE
build(deps): bump eclipse-temurin base image to java 21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,7 @@ allprojects {
     // configure which version of the annotation processor to use. defaults to the same version as the plugin
     configure<org.eclipse.edc.plugins.autodoc.AutodocExtension> {
         processorVersion.set(edcVersion)
-        outputDirectory.set(project.buildDir)
+        outputDirectory.set(project.layout.buildDirectory.asFile.get())
         // uncomment the following lines to enable the Autodoc-2-Markdown converter
         // only available with EDC 0.2.1 SNAPSHOT
         // additionalInputDirectory.set(downloadDir.asFile)
@@ -85,11 +85,6 @@ allprojects {
     }
 
     configure<org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension> {
-        versions {
-            // override default dependency versions here
-            metaModel.set(edcVersion)
-
-        }
         pom {
             // this is actually important, so we can publish under the correct GID
             groupId = project.group.toString()

--- a/edc-controlplane/edc-controlplane-postgresql-azure-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-postgresql-azure-vault/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:17.0.9_9-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:21.0.2_13-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: <https://hub.docker.com/_/eclipse-temurin>
 - Eclipse Temurin Project: <https://projects.eclipse.org/projects/adoptium.temurin>
 - Additional information about the Eclipse Temurin

--- a/edc-controlplane/edc-controlplane-postgresql-azure-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql-azure-vault/src/main/docker/Dockerfile
@@ -18,7 +18,7 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-FROM eclipse-temurin:17.0.9_9-jre-alpine
+FROM eclipse-temurin:21.0.2_13-jre-alpine
 ARG JAR
 ARG OTEL_JAR
 ARG ADDITIONAL_FILES

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/notice.md
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:17.0.9_9-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:21.0.2_13-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: <https://hub.docker.com/_/eclipse-temurin>
 - Eclipse Temurin Project: <https://projects.eclipse.org/projects/adoptium.temurin>
 - Additional information about the Eclipse Temurin

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/src/main/docker/Dockerfile
@@ -19,7 +19,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
-FROM eclipse-temurin:17.0.9_9-jre-alpine
+FROM eclipse-temurin:21.0.2_13-jre-alpine
 ARG JAR
 ARG OTEL_JAR
 ARG ADDITIONAL_FILES

--- a/edc-controlplane/edc-runtime-memory/notice.md
+++ b/edc-controlplane/edc-runtime-memory/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:17.0.9_9-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:21.0.2_13-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: <https://hub.docker.com/_/eclipse-temurin>
 - Eclipse Temurin Project: <https://projects.eclipse.org/projects/adoptium.temurin>
 - Additional information about the Eclipse Temurin

--- a/edc-controlplane/edc-runtime-memory/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-runtime-memory/src/main/docker/Dockerfile
@@ -20,7 +20,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
-FROM eclipse-temurin:17.0.9_9-jre-alpine
+FROM eclipse-temurin:21.0.2_13-jre-alpine
 ARG JAR
 
 ARG APP_USER=docker

--- a/edc-dataplane/edc-dataplane-azure-vault/notice.md
+++ b/edc-dataplane/edc-dataplane-azure-vault/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:17.0.9_9-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:21.0.2_13-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: <https://hub.docker.com/_/eclipse-temurin>
 - Eclipse Temurin Project: <https://projects.eclipse.org/projects/adoptium.temurin>
 - Additional information about the Eclipse Temurin

--- a/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-azure-vault/src/main/docker/Dockerfile
@@ -18,7 +18,7 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-FROM eclipse-temurin:17.0.9_9-jre-alpine
+FROM eclipse-temurin:21.0.2_13-jre-alpine
 ARG JAR
 ARG OTEL_JAR
 ARG ADDITIONAL_FILES

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/notice.md
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/notice.md
@@ -15,7 +15,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 ## Used base image
 
-- [eclipse-temurin:17.0.9_9-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:21.0.2_13-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: <https://hub.docker.com/_/eclipse-temurin>
 - Eclipse Temurin Project: <https://projects.eclipse.org/projects/adoptium.temurin>
 - Additional information about the Eclipse Temurin

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/Dockerfile
@@ -19,7 +19,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
-FROM eclipse-temurin:17.0.9_9-jre-alpine
+FROM eclipse-temurin:21.0.2_13-jre-alpine
 ARG JAR
 ARG OTEL_JAR
 ARG ADDITIONAL_FILES


### PR DESCRIPTION
## WHAT

Upgrade to java 21

## WHY

is the latest LTS version

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
