### PR TITLE
feat: set default EDR data source name as default

### DIFF
--- a/core/edr-cache-core/src/main/java/org/eclipse/tractusx/edc/edr/core/EdrCacheCoreExtension.java
+++ b/core/edr-cache-core/src/main/java/org/eclipse/tractusx/edc/edr/core/EdrCacheCoreExtension.java
@@ -15,11 +15,8 @@
 package org.eclipse.tractusx.edc.edr.core;
 
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
-import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
-import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
-import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.tractusx.edc.edr.core.defaults.InMemoryEndpointDataReferenceCache;
 import org.eclipse.tractusx.edc.edr.spi.store.EndpointDataReferenceCache;
 
@@ -28,10 +25,8 @@ import org.eclipse.tractusx.edc.edr.spi.store.EndpointDataReferenceCache;
  */
 @Extension(value = EdrCacheCoreExtension.NAME)
 public class EdrCacheCoreExtension implements ServiceExtension {
-    static final String NAME = "EDR Cache Core";
 
-    @Inject
-    private Monitor monitor;
+    static final String NAME = "EDR Cache Core";
 
     @Override
     public String name() {
@@ -39,7 +34,7 @@ public class EdrCacheCoreExtension implements ServiceExtension {
     }
 
     @Provider(isDefault = true)
-    public EndpointDataReferenceCache edrCache(ServiceExtensionContext context) {
+    public EndpointDataReferenceCache edrCache() {
         return new InMemoryEndpointDataReferenceCache();
     }
 

--- a/edc-extensions/edr/edr-cache-sql/src/main/java/org/eclipse/tractusx/edc/edr/store/sql/SqlEndpointDataReferenceCacheExtension.java
+++ b/edc-extensions/edr/edr-cache-sql/src/main/java/org/eclipse/tractusx/edc/edr/store/sql/SqlEndpointDataReferenceCacheExtension.java
@@ -36,12 +36,13 @@ public class SqlEndpointDataReferenceCacheExtension implements ServiceExtension 
 
     public static final String NAME = "SQL EDR cache store";
 
-    @Setting(required = true, defaultValue = SqlEndpointDataReferenceCacheExtension.DEFAULT_DATASOURCE_NAME)
+    @Setting(required = true, value = "Datasource name for EDR Cache SQL store", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
     public static final String DATASOURCE_SETTING_NAME = "edc.datasource.edr.name";
 
-    @Setting(value = "Directory/Path where to store EDRs in the vault for vaults that supports hierarchical structuring.", required = false, defaultValue = "")
+    private static final String DEFAULT_EDR_VAULT_PATH = "";
+    @Setting(value = "Directory/Path where to store EDRs in the vault for vaults that supports hierarchical structuring.", defaultValue = DEFAULT_EDR_VAULT_PATH)
     public static final String EDC_EDR_VAULT_PATH = "edc.edr.vault.path";
-    public static final String DEFAULT_DATASOURCE_NAME = "edr";
+
     @Inject
     private DataSourceRegistry dataSourceRegistry;
     @Inject
@@ -65,9 +66,10 @@ public class SqlEndpointDataReferenceCacheExtension implements ServiceExtension 
 
     @Provider
     public EndpointDataReferenceCache edrCache(ServiceExtensionContext context) {
-        var dataSourceName = context.getConfig().getString(DATASOURCE_SETTING_NAME, DEFAULT_DATASOURCE_NAME);
-        var vaultDirectory = context.getConfig().getString(EDC_EDR_VAULT_PATH, "");
-        return new SqlEndpointDataReferenceCache(dataSourceRegistry, dataSourceName, transactionContext, getStatementImpl(), typeManager.getMapper(), vault, vaultDirectory, clock, queryExecutor, context.getConnectorId());
+        var dataSourceName = context.getConfig().getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
+        var vaultDirectory = context.getConfig().getString(EDC_EDR_VAULT_PATH, DEFAULT_EDR_VAULT_PATH);
+        return new SqlEndpointDataReferenceCache(dataSourceRegistry, dataSourceName, transactionContext, getStatementImpl(),
+                typeManager.getMapper(), vault, vaultDirectory, clock, queryExecutor, context.getConnectorId());
     }
 
     private EdrStatements getStatementImpl() {

--- a/edc-extensions/edr/edr-cache-sql/src/test/java/org/eclipse/tractusx/edc/edr/store/sql/SqlEndpointDataReferenceCacheExtensionTest.java
+++ b/edc-extensions/edr/edr-cache-sql/src/test/java/org/eclipse/tractusx/edc/edr/store/sql/SqlEndpointDataReferenceCacheExtensionTest.java
@@ -17,7 +17,6 @@ package org.eclipse.tractusx.edc.edr.store.sql;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
-import org.eclipse.edc.spi.system.injection.ObjectFactory;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,8 +24,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry.DEFAULT_DATASOURCE;
 import static org.eclipse.tractusx.edc.edr.store.sql.SqlEndpointDataReferenceCacheExtension.DATASOURCE_SETTING_NAME;
-import static org.eclipse.tractusx.edc.edr.store.sql.SqlEndpointDataReferenceCacheExtension.DEFAULT_DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -35,26 +34,21 @@ import static org.mockito.Mockito.when;
 @ExtendWith(DependencyInjectionExtension.class)
 public class SqlEndpointDataReferenceCacheExtensionTest {
 
-    SqlEndpointDataReferenceCacheExtension extension;
-    ServiceExtensionContext context;
-
-
     @BeforeEach
-    void setUp(ObjectFactory factory, ServiceExtensionContext context) {
-        this.context = context;
+    void setUp(ServiceExtensionContext context) {
         context.registerService(TypeManager.class, new TypeManager());
-        context.registerService(DataSourceRegistry.class, mock(DataSourceRegistry.class));
-        extension = factory.constructInstance(SqlEndpointDataReferenceCacheExtension.class);
+        context.registerService(DataSourceRegistry.class, mock());
     }
 
     @Test
-    void shouldInitializeTheStore() {
+    void shouldInitializeTheStore(ServiceExtensionContext context, SqlEndpointDataReferenceCacheExtension extension) {
         var config = mock(Config.class);
         when(context.getConfig()).thenReturn(config);
-        when(config.getString(any(), any())).thenReturn(DEFAULT_DATASOURCE_NAME);
+        when(config.getString(any(), any())).thenReturn(DEFAULT_DATASOURCE);
 
-        assertThat(extension.edrCache(context)).isInstanceOf(SqlEndpointDataReferenceCache.class);
+        var cache = extension.edrCache(context);
 
-        verify(config).getString(DATASOURCE_SETTING_NAME, DEFAULT_DATASOURCE_NAME);
+        assertThat(cache).isInstanceOf(SqlEndpointDataReferenceCache.class);
+        verify(config).getString(DATASOURCE_SETTING_NAME, DEFAULT_DATASOURCE);
     }
 }


### PR DESCRIPTION
## WHAT

Set EDR default data source name as `default`

## WHY

permit to use the `default` fallback data source configuration

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #1009
