### PR TITLE
docs: fix action use in ODRL payloads

### DIFF
--- a/docs/usage/management-api-walkthrough/02_policies.md
+++ b/docs/usage/management-api-walkthrough/02_policies.md
@@ -21,7 +21,7 @@ Content-Type: application/json
     "@type": "Policy",
     "odrl:permission": [
       {
-        "odrl:action": "USE",
+        "odrl:action": "use",
         "odrl:constraint": {
           "@type": "Constraint",
           "odrl:leftOperand": "BusinessPartnerNumber",
@@ -62,7 +62,7 @@ the EDC interprets policies it can't evaluate as true by default. A couple of ex
     "@type": "Policy",
     "odrl:permission": [
       {
-        "odrl:action": "USE"
+        "odrl:action": "use"
       }
     ]
   }

--- a/docs/usage/management-api-walkthrough/07_edrs.md
+++ b/docs/usage/management-api-walkthrough/07_edrs.md
@@ -38,7 +38,7 @@ Content-Type: application/json
       "odrl:permission": {
         "odrl:target": "<ASSET_ID>",
         "odrl:action": {
-          "odrl:type": "USE"
+          "odrl:type": "use"
         },
         "odrl:constraint": {
           "odrl:and": {

--- a/docs/usage/management-api-walkthrough/08_contractagreements.md
+++ b/docs/usage/management-api-walkthrough/08_contractagreements.md
@@ -24,7 +24,7 @@ A Contract Agreement looks like this:
     "odrl:permission": {
       "odrl:target": "<ASSET_ID>",
       "odrl:action": {
-        "odrl:type": "USE"
+        "odrl:type": "use"
       },
       "odrl:constraint": {
         "odrl:and": {


### PR DESCRIPTION
## WHAT

Changes the ODRL payloads from uppercase `USE` to lowercase `use`.

## WHY

As discussed [in another PR](https://github.com/eclipse-tractusx/tractusx-edc/pull/856#discussion_r1470715576), ODRL is case-sensitive. To [follow the standard](https://w3c.github.io/odrl/bp/#x1-how-to-represent-a-general-permission), use the lowercase `use`.

## FURTHER NOTES

./.
