### PR TITLE
refactor: remove unused mockito-inline dependency

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -450,7 +450,6 @@ maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only 
 maven/mavencentral/org.latencyutils/LatencyUtils/2.0.3, BSD-2-Clause, approved, CQ17408
 maven/mavencentral/org.mockito/mockito-core/5.2.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #7401
 maven/mavencentral/org.mockito/mockito-core/5.9.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #12774
-maven/mavencentral/org.mockito/mockito-inline/5.2.0, MIT, approved, clearlydefined
 maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.opentest4j/opentest4j/1.3.0, Apache-2.0, approved, #9713
 maven/mavencentral/org.ow2.asm/asm-commons/9.5, BSD-3-Clause, approved, #7553

--- a/edc-extensions/transferprocess-sftp-client/build.gradle.kts
+++ b/edc-extensions/transferprocess-sftp-client/build.gradle.kts
@@ -39,6 +39,5 @@ dependencies {
     testImplementation(libs.awaitility)
     testImplementation(libs.edc.junit)
 
-    testImplementation(libs.mockito.inline)
     testImplementation(libs.testcontainers.junit)
 }

--- a/edc-extensions/transferprocess-sftp-common/build.gradle.kts
+++ b/edc-extensions/transferprocess-sftp-common/build.gradle.kts
@@ -26,6 +26,5 @@ dependencies {
     implementation(libs.edc.spi.core)
     testImplementation(libs.edc.junit)
 
-    testImplementation(libs.mockito.inline)
     testImplementation(libs.testcontainers.junit)
 }

--- a/edc-extensions/transferprocess-sftp-provisioner/build.gradle.kts
+++ b/edc-extensions/transferprocess-sftp-provisioner/build.gradle.kts
@@ -30,6 +30,5 @@ dependencies {
     implementation(libs.edc.spi.transfer)
 
     testImplementation(libs.edc.junit)
-    testImplementation(libs.mockito.inline)
     testImplementation(libs.testcontainers.junit)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ slf4j = "2.0.11"
 okhttp = "4.12.0"
 mockwebserver = "5.0.0-alpha.12"
 bouncyCastle-jdk18on = "1.77"
-mockito = "5.2.0"
 restAssured = "5.4.0"
 apache-sshd = "2.12.0"
 testcontainers = "1.19.4"
@@ -170,7 +169,6 @@ nimbus-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbus" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
 bouncyCastle-bcpkixJdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncyCastle-jdk18on" }
-mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito" }
 restAssured = { module = "io.rest-assured:rest-assured", version.ref = "restAssured" }
 apache-sshd-core = { module = "org.apache.sshd:sshd-core", version.ref = "apache-sshd" }
 apache-sshd-sftp = { module = "org.apache.sshd:sshd-sftp", version.ref = "apache-sshd" }


### PR DESCRIPTION
## WHAT

Removes unused mockito-inline dependency

## WHY

cleanup

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #1025 
