### PR TITLE
feat: Implement EDC Extension (for submodel request)

### DIFF
--- a/edc-dataplane/edc-dataplane-base/build.gradle.kts
+++ b/edc-dataplane/edc-dataplane-base/build.gradle.kts
@@ -1,5 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2022,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -27,6 +28,7 @@ dependencies {
     runtimeOnly(project(":edc-extensions:dataplane-proxy:edc-dataplane-proxy-consumer-api"))
     runtimeOnly(project(":edc-extensions:dataplane-proxy:edc-dataplane-proxy-provider-api"))
     runtimeOnly(project(":edc-extensions:dataplane-proxy:edc-dataplane-proxy-provider-core"))
+    runtimeOnly(project(":edc-extensions:dataplane-dtr-http-access-control"))
 
     runtimeOnly(libs.edc.config.filesystem)
     runtimeOnly(libs.edc.auth.tokenbased)

--- a/edc-extensions/dataplane-dtr-http-access-control/README.md
+++ b/edc-extensions/dataplane-dtr-http-access-control/README.md
@@ -1,0 +1,185 @@
+# Data Plane: Digital Twin Registry Http Access Control
+
+The goal of this extension is to perform granular access control checks using the Digital Twin Registry (or 
+Digital Twin Registries) configured.
+
+When an HTTP request is targeting a configured Digital Twin Registry, the extension allows the request through.
+
+Otherwise, the extension calls the configured access verification endpoints of the configured Digital Twin 
+Registries and tries to verify that the client has access to the backend asset based on the registries' response.
+
+
+## Configuration
+
+```properties
+# Configure the automatically added error endpoint that is used as an alternative target when the client 
+# request cannot be allowed to reach the original backend target
+edc.granular.access.verification.error.endpoint.port=9054
+
+# Configure the URL which is used when the clients are reaching the EDC Data Plane's /public/ endpoint 
+edc.granular.access.verification.edc.data.plane.baseUrl=http://edc-data-plane:9051/public/
+
+# List the names of each DTR instance we intend to configure (comma separated list)
+edc.granular.access.verification.dtr.names=default
+
+# Configure each DTR instance using the following properties.
+# "use the edc.granular.access.verification.dtr.config.<dtr_name>." prefix with each name listed above
+
+# How long should we cache the response we have received from DTR?
+edc.granular.access.verification.dtr.config.default.dtr.decision.cache.duration.minutes=1
+# A RegExp pattern that can match the submodel endpoints in scope for DTR access control
+edc.granular.access.verification.dtr.config.default.aspect.model.url.pattern=http:\/\/aspect-model:8080\/path\/.*
+# The full URL of the access control verification endpoint of the DTR instance
+edc.granular.access.verification.dtr.config.default.dtr.access.verification.endpoint.url=http://dtr:8080/aas-registry-api/v3.0/submodel-descriptor/authorized
+# The OAuth2 configuration for accessing the DTR
+# Token endpoint URL
+edc.granular.access.verification.dtr.config.default.oauth2.token.endpoint.url=http://oauth2-iam:8080/iam/access-management/v1/tenants/00000000-0000-0000-0000-000000000000/openid-connect/token
+# Scope (audience) of the token we want to obtain
+edc.granular.access.verification.dtr.config.default.oauth2.token.scope=aud:dtr
+# OAuth2 client Id
+edc.granular.access.verification.dtr.config.default.oauth2.token.clientId=dtr_client
+# The name (path) of the secret where the OAuth2 client secret is stored in the Vault
+edc.granular.access.verification.dtr.config.default.oauth2.token.clientSecret.path=dtrsecret
+```
+> [!NOTE]
+> If none of these properties are configured, the extension is turned off.
+
+## Dependencies
+
+The following header is used from the `HttpDataAddress` when the access control is evaluated before data transfer:
+
+- `Edc-Bpn`: the BPN of the consumer
+
+## How it works?
+
+### System context (Logical view)
+
+```mermaid
+C4Context
+    System_Ext(client, "Client", "Client application")
+    System_Ext(edcCP, "Consumer EDC", "EDC Control Plane")
+    System(edcDP, "Provider EDC", "Provider EDC Data Plane with the extension ")
+    System_Ext(idp, "OAuth2 IDP", "Provides tokens for DTR access")
+    System_Ext(dtr, "Digital Twin Registry", "DTR instance registered with EDC")
+    System_Ext(backend, "Submodel backend", "System of record for submodel data")
+   
+    Rel(client, edcCP, "Get EDR")
+    Rel(client, edcDP, "Call with EDR")
+    Rel(edcDP, idp, "Get token")
+    Rel(edcDP, dtr, "Call for access verification")
+    Rel(edcDP, backend, "Proxy HTTP call if access granted")
+   
+    UpdateLayoutConfig($c4ShapeInRow="2", $c4BoundaryInRow="1")
+```
+
+### Call sequences (Runtime view)
+
+#### Prerequisites
+
+In order to perform any of the following actions, we must assume that:
+
+1. The Digital Twin Registry and the Submodel Backend are both registered in EDC as assets
+2. The Submodel Backend asset configured to proxy the request path and query parameters
+3. The client knows how to access the Digital Twin Registry through EDC
+4. The client received the Submodel Backend endpoint address from the Digital Twin Registry containing:
+   1. The full EDC Data Plane URL including the proxied path and query parameters (if any) in ```href```
+   2. The Id of the EDC asset referencing the Submodel Backend
+   3. The provider EDC control Plane's URL
+5. The DTR HTTP Access Control extension is properly configured to call the Digital Twin Registry when the 
+   ```HttpDataAddress``` URL points to an endpoint of the Submodel Backend
+6. The Provider Control Plane EDC includes the ```Edc-Bpn``` header in the ```HttpDataAddress```
+
+
+#### Happy case - The client has access to the protected submodel resource
+
+When the client has access to the protected submodel details (based on the BPN and the EDC Data Plane request URL), then
+the extension obtains an OAuth2 access token for accessing the Digital Twin Registry to perform the additional access
+verification step. The request is allowed through to the Submodel Backend when the confirmation arrives from the Digital
+Twin Registry. This flow can be seen below.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    
+    participant CLI as Client app
+    participant CCP as Consumer EDC<br/>(Control Plane)
+    participant PCP as Provider EDC<br/>(Control Plane)
+    participant PDP as Provider EDC<br/>(Data Plane)
+    participant IDP as OAuth2 IDP
+    participant DTR as Digital Twin Registry
+    participant SMB as Submodel Backend
+    
+    CLI ->>  CCP : Get EDR for submodel backend
+    CCP -->> PCP : Negotiate for EDR
+    PCP -->> CCP : Return EDR
+    CCP -->> CLI : Return EDR
+    CLI ->>  PDP : Request submodel backend data
+    PDP ->>  PDP : Evaluate whether DTR check<br/>is needed based on config
+    PDP ->>  IDP : Get OAuth2 token for DTR
+    IDP -->> PDP : Return token
+    PDP ->>  DTR : Verify submodel endpoint access using Edc-Bpn and<br/>the EDC Provider Data Plane URL of the client request
+    DTR -->> PDP : Grant access
+    PDP ->>  SMB : Proxy submodel call
+    SMB -->> PDP : Return submodel data
+    PDP -->> CLI : Return submodel data
+```
+
+#### Exceptional case - The client has no access to the protected submodel resource
+
+When the client has NO access to the protected submodel details (based on the BPN and the EDC Data Plane request URL), 
+then using the same flow, the extension will receive an error response form the Digital Twin Registry and as a result it
+will not allow the submodel request through by changing the target ```HttpDataAddress``` to point to an error endpoint
+instead. This way, the error endpoint will return a HTTP 403 response for the EDC and the client will receive an error
+response as well.
+
+```mermaid
+sequenceDiagram
+    autonumber
+
+    participant CLI as Client app
+    participant CCP as Consumer EDC<br/>(Control Plane)
+    participant PCP as Provider EDC<br/>(Control Plane)
+    participant PDP as Provider EDC<br/>(Data Plane)
+    participant IDP as OAuth2 IDP
+    participant DTR as Digital Twin Registry
+    
+    CLI ->>  CCP : Get EDR for submodel backend
+    CCP -->> PCP : Negotiate for EDR
+    PCP -->> CCP : Return EDR
+    CCP -->> CLI : Return EDR
+    CLI ->>  PDP : Request submodel backend data
+    PDP ->>  PDP : Evaluate whether DTR check<br/>is needed based on config
+    PDP ->>  IDP : Get OAuth2 token for DTR
+    IDP -->> PDP : Return token
+    PDP ->>  DTR : Verify submodel endpoint access using Edc-Bpn and<br/>the EDC Provider Data Plane URL of the client request
+    DTR -->> PDP : Deny access
+    PDP ->>  PDP : Proxy HTTP 403 error response instead of submodel data 
+    PDP -->> CLI : Return error response
+```
+
+#### Happy case - The requested resource does not require DTR verification
+
+Thanks to the configurable RegExp pattern controlling the access control mechanism, we can continue to use backends
+which do not require additional granular access control measures. In this case, the request URL won't match the pattern
+and the extension will neither obtain an OAuth2 token nor call the Digital Twin Registry as seen below. 
+
+```mermaid
+sequenceDiagram
+    autonumber
+
+    participant CLI as Client app
+    participant CCP as Consumer EDC<br/>(Control Plane)
+    participant PCP as Provider EDC<br/>(Control Plane)
+    participant PDP as Provider EDC<br/>(Data Plane)
+    participant SMB as Submodel Backend
+
+    CLI ->>  CCP : Get EDR for submodel backend
+    CCP -->> PCP : Negotiate for EDR
+    PCP -->> CCP : Return EDR
+    CCP -->> CLI : Return EDR
+    CLI ->>  PDP : Request submodel backend data
+    PDP ->>  PDP : Evaluate whether DTR check<br/>is needed based on config
+    PDP ->>  SMB : Proxy submodel call
+    SMB -->> PDP : Return submodel data
+    PDP -->> CLI : Return submodel data
+```

--- a/edc-extensions/dataplane-dtr-http-access-control/build.gradle.kts
+++ b/edc-extensions/dataplane-dtr-http-access-control/build.gradle.kts
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+plugins {
+    `maven-publish`
+    `java-library`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
+}
+
+dependencies {
+    implementation(libs.edc.spi.dataplane.http)
+    implementation(libs.edc.core.connector)
+    implementation(libs.edc.spi.core)
+    implementation(libs.edc.spi.web)
+    implementation(libs.jakarta.rsApi)
+    implementation(libs.caffeine)
+
+    testImplementation(testFixtures(libs.edc.core.jersey))
+    testImplementation(libs.edc.junit)
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/AccessControlServerException.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/AccessControlServerException.java
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol;
+
+public class AccessControlServerException extends RuntimeException {
+
+    public AccessControlServerException(final String message) {
+        super(message);
+    }
+
+    public AccessControlServerException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/DataPlaneHttpAccessControlExtension.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/DataPlaneHttpAccessControlExtension.java
@@ -1,0 +1,145 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol;
+
+import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParamsProvider;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.http.EdcHttpClient;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.web.spi.WebServer;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
+import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client.DtrAccessVerificationClient;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client.DtrOauth2TokenClient;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client.HttpAccessVerificationClient;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client.Oauth2TokenClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Extension(value = "Data Plane HTTP Access Control")
+public class DataPlaneHttpAccessControlExtension implements ServiceExtension {
+
+    @Setting(value = "Custom setting to allow configuration of error handler controller ports.")
+    public static final String ERROR_ENDPOINT_PORT = "edc.granular.access.verification.error.endpoint.port";
+    @Setting(value = "Contains the base URL of the EDC data plane endpoint where the data plane requests are sent by the end users.")
+    public static final String EDC_DATA_PLANE_BASE_URL = "edc.granular.access.verification.edc.data.plane.baseUrl";
+    @Setting(value = "Comma separated list of DTR configuration names used as keys for DTR clients.")
+    public static final String EDC_DTR_CONFIG_NAMES = "edc.granular.access.verification.dtr.names";
+    /**
+     * Prefix for individual DTR configurations.
+     */
+    public static final String EDC_DTR_CONFIG_PREFIX = "edc.granular.access.verification.dtr.config.";
+    /**
+     * Configuration property suffix for the configuration of DTR decision cache. The cache is turned off if set to 0.
+     */
+    public static final String DTR_DECISION_CACHE_MINUTES = "dtr.decision.cache.duration.minutes";
+    /**
+     * Configuration property suffix for the pattern to allow for the recognition of aspect model requests which need
+     * to be handled by DTR access control.
+     */
+    public static final String ASPECT_MODEL_URL_PATTERN = "aspect.model.url.pattern";
+    /**
+     * Configuration property suffix for the URL where DTR can be reached.
+     */
+    public static final String DTR_ACCESS_VERIFICATION_URL = "dtr.access.verification.endpoint.url";
+    /**
+     * Configuration property suffix for the URL where OAUTH2 tokens can be obtained for the DTR requests.
+     */
+    public static final String OAUTH2_TOKEN_ENDPOINT_URL = "oauth2.token.endpoint.url";
+    /**
+     * Configuration property suffix for the scope we need to use for OAUTH2 token requests when we need to access DTR.
+     */
+    public static final String OAUTH2_TOKEN_SCOPE = "oauth2.token.scope";
+    /**
+     * Configuration property suffix for the client id we need to use for OAUTH2 token requests when we need to access DTR.
+     */
+    public static final String OAUTH2_TOKEN_CLIENT_ID = "oauth2.token.clientId";
+
+    /**
+     * Configuration property suffix for the path where we can find the client secret in vault for the OAUTH2 token requests when we need to access DTR.
+     */
+    public static final String OAUTH2_TOKEN_CLIENT_SECRET_PATH = "oauth2.token.clientSecret.path";
+    public static final int DEFAULT_PORT = 9054;
+
+    public static final String ERROR = "error";
+
+    @Inject
+    private WebService webService;
+    @Inject
+    private WebServer webServer;
+    @Inject
+    private WebServiceConfigurer configurer;
+    @Inject
+    private HttpRequestParamsProvider paramsProvider;
+    @Inject
+    private Monitor monitor;
+    @Inject
+    private EdcHttpClient httpClient;
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private Vault vault;
+
+    @Override
+    public String name() {
+        return "Data Plane HTTP Access Control";
+    }
+
+    @Override
+    public void initialize(final ServiceExtensionContext context) {
+        final var config = new HttpAccessControlCheckClientConfig(context);
+        if (config.getDtrClientConfigMap().isEmpty()) {
+            //turn off the extension if no DTR is configured
+            monitor.warning(EDC_DTR_CONFIG_NAMES + " is not configured, DTR access control is turned OFF.");
+            return;
+        }
+        final Map<String, HttpAccessVerificationClient> dtrClients = new HashMap<>();
+        config.getDtrClientConfigMap().forEach((k, v) -> {
+            final Oauth2TokenClient tokenClient = new DtrOauth2TokenClient(monitor, httpClient, typeManager, vault, v);
+            final HttpAccessVerificationClient client = new DtrAccessVerificationClient(monitor, httpClient, tokenClient, typeManager, config, v);
+            dtrClients.put(k, client);
+        });
+        final var httpAclParamsDecorator = new HttpAccessControlRequestParamsDecorator(monitor, dtrClients, config);
+        paramsProvider.registerSinkDecorator(httpAclParamsDecorator);
+        paramsProvider.registerSourceDecorator(httpAclParamsDecorator);
+
+        configurer.configure(context, webServer, createApiContext(config.getErrorEndpointPort()));
+        webService.registerResource(ERROR, new HttpAccessControlErrorApiController());
+    }
+
+    private WebServiceSettings createApiContext(final int port) {
+        return WebServiceSettings.Builder.newInstance()
+                .apiConfigKey("web.http." + ERROR)
+                .contextAlias(ERROR)
+                .defaultPath("/error")
+                .defaultPort(port)
+                .name(ERROR)
+                .build();
+    }
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlCheckClientConfig.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlCheckClientConfig.java
@@ -1,0 +1,76 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.DEFAULT_PORT;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.EDC_DATA_PLANE_BASE_URL;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.EDC_DTR_CONFIG_NAMES;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.EDC_DTR_CONFIG_PREFIX;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.ERROR_ENDPOINT_PORT;
+
+public class HttpAccessControlCheckClientConfig {
+
+    private final Map<String, HttpAccessControlCheckDtrClientConfig> dtrClientConfigMap;
+    private final String edcDataPlaneBaseUrl;
+    private final int errorEndpointPort;
+
+    public HttpAccessControlCheckClientConfig(final ServiceExtensionContext context) {
+        dtrClientConfigMap = Arrays.stream(context.getSetting(EDC_DTR_CONFIG_NAMES, "").split(","))
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.toUnmodifiableMap(Function.identity(),
+                        name -> new HttpAccessControlCheckDtrClientConfig(
+                                context.getConfig(EDC_DTR_CONFIG_PREFIX + name))));
+        edcDataPlaneBaseUrl = context.getSetting(EDC_DATA_PLANE_BASE_URL, null);
+        errorEndpointPort = context.getSetting(ERROR_ENDPOINT_PORT, DEFAULT_PORT);
+    }
+
+    public Map<String, HttpAccessControlCheckDtrClientConfig> getDtrClientConfigMap() {
+        return dtrClientConfigMap;
+    }
+
+    public int getErrorEndpointPort() {
+        return errorEndpointPort;
+    }
+
+    public String getErrorEndpointBaseUrl() {
+        return "http://localhost:" + errorEndpointPort + "/error";
+    }
+
+    public String getErrorEndpointPathForStatus(final int status) {
+        return "/http/access/error/" + status;
+    }
+
+    public String getReasonPhraseParameterName() {
+        return "reasonPhrase";
+    }
+
+    public String getEdcDataPlaneBaseUrl() {
+        return edcDataPlaneBaseUrl;
+    }
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlCheckDtrClientConfig.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlCheckDtrClientConfig.java
@@ -1,0 +1,81 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol;
+
+import org.eclipse.edc.spi.system.configuration.Config;
+
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.ASPECT_MODEL_URL_PATTERN;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.DTR_ACCESS_VERIFICATION_URL;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.DTR_DECISION_CACHE_MINUTES;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.OAUTH2_TOKEN_CLIENT_ID;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.OAUTH2_TOKEN_CLIENT_SECRET_PATH;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.OAUTH2_TOKEN_ENDPOINT_URL;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.OAUTH2_TOKEN_SCOPE;
+
+
+public class HttpAccessControlCheckDtrClientConfig {
+
+    private final String aspectModelUrlPattern;
+    private final String dtrAccessVerificationUrl;
+    private final String oauth2TokenEndpointUrl;
+    private final String oauth2TokenScope;
+    private final String oauth2ClientId;
+    private final String oauth2ClientSecretPath;
+    private final int decisionCacheDurationMinutes;
+
+    public HttpAccessControlCheckDtrClientConfig(final Config context) {
+        aspectModelUrlPattern = context.getString(ASPECT_MODEL_URL_PATTERN, null);
+        dtrAccessVerificationUrl = context.getString(DTR_ACCESS_VERIFICATION_URL, null);
+        oauth2TokenEndpointUrl = context.getString(OAUTH2_TOKEN_ENDPOINT_URL, null);
+        oauth2TokenScope = context.getString(OAUTH2_TOKEN_SCOPE, null);
+        oauth2ClientId = context.getString(OAUTH2_TOKEN_CLIENT_ID, null);
+        oauth2ClientSecretPath = context.getString(OAUTH2_TOKEN_CLIENT_SECRET_PATH, null);
+        decisionCacheDurationMinutes = context.getInteger(DTR_DECISION_CACHE_MINUTES, 0);
+    }
+
+    public String getAspectModelUrlPattern() {
+        return aspectModelUrlPattern;
+    }
+
+    public String getDtrAccessVerificationUrl() {
+        return dtrAccessVerificationUrl;
+    }
+
+    public String getOauth2TokenEndpointUrl() {
+        return oauth2TokenEndpointUrl;
+    }
+
+    public String getOauth2TokenScope() {
+        return oauth2TokenScope;
+    }
+
+    public String getOauth2ClientId() {
+        return oauth2ClientId;
+    }
+
+    public String getOauth2ClientSecretPath() {
+        return oauth2ClientSecretPath;
+    }
+
+    public int getDecisionCacheDurationMinutes() {
+        return decisionCacheDurationMinutes;
+    }
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlErrorApi.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlErrorApi.java
@@ -1,0 +1,65 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+
+@OpenAPIDefinition(info = @Info(description = "With this API we can return custom error responses in case of authentication errors.", title = "HTTP Access Control Error API"))
+@Tag(name = "DTR HTTP Access Control")
+public interface HttpAccessControlErrorApi {
+
+    @Operation(description = "Return 401 error",
+            parameters = @Parameter(name = "reasonPhrase", required = true, schema = @Schema(implementation = String.class)),
+            responses = {
+                    @ApiResponse(responseCode = "401", description = "The request cannot be allowed as the user is unauthorized.")
+            })
+    Response unauthorized(String reasonPhrase);
+
+    @Operation(description = "Return 403 error",
+            parameters = @Parameter(name = "reasonPhrase", required = true, schema = @Schema(implementation = String.class)),
+            responses = {
+                    @ApiResponse(responseCode = "403", description = "The request cannot be allowed as the user is not allowed to see the target.")
+            })
+    @GET
+    @Path("/403")
+    Response forbidden(@QueryParam("reasonPhrase") String reasonPhrase);
+
+    @Operation(description = "Return 200 status",
+            requestBody = @RequestBody(required = true, description = "The desired response body."),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The provided response body is used.")
+            })
+    @POST
+    @Path("/200")
+    Response ok(@QueryParam("body") String body);
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlErrorApiController.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlErrorApiController.java
@@ -1,0 +1,59 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol;
+
+import com.fasterxml.jackson.databind.util.RawValue;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Consumes({MediaType.APPLICATION_JSON})
+@Produces({MediaType.APPLICATION_JSON})
+@Path("/http/access/error")
+public class HttpAccessControlErrorApiController implements HttpAccessControlErrorApi {
+
+    @GET
+    @Path("/401")
+    @Override
+    public Response unauthorized(@QueryParam("reasonPhrase") final String reasonPhrase) {
+        return Response.status(Response.Status.UNAUTHORIZED.getStatusCode(), reasonPhrase).build();
+    }
+
+    @GET
+    @Path("/403")
+    @Override
+    public Response forbidden(@QueryParam("reasonPhrase") final String reasonPhrase) {
+        return Response.status(Response.Status.FORBIDDEN.getStatusCode(), reasonPhrase).build();
+    }
+
+    @POST
+    @Path("/200")
+    @Override
+    public Response ok(@RequestBody final String body) {
+        return Response.ok(new RawValue(body)).build();
+    }
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlRequestParamsDecorator.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlRequestParamsDecorator.java
@@ -1,0 +1,69 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol;
+
+import org.eclipse.edc.connector.dataplane.http.spi.HttpDataAddress;
+import org.eclipse.edc.connector.dataplane.http.spi.HttpParamsDecorator;
+import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParams;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client.HttpAccessVerificationClient;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class HttpAccessControlRequestParamsDecorator implements HttpParamsDecorator {
+    public static final String HEADER_EDC_BPN = "Edc-Bpn";
+
+    private final Monitor monitor;
+
+    private final HttpAccessControlCheckClientConfig config;
+
+    private final Map<String, HttpAccessVerificationClient> clients;
+
+    public HttpAccessControlRequestParamsDecorator(
+            final Monitor monitor,
+            final Map<String, HttpAccessVerificationClient> clients,
+            final HttpAccessControlCheckClientConfig config) {
+        this.monitor = monitor;
+        this.clients = clients;
+        this.config = config;
+    }
+
+    @Override
+    public HttpRequestParams.Builder decorate(final DataFlowRequest request, final HttpDataAddress address, final HttpRequestParams.Builder params) {
+        final var targetUrl = address.getBaseUrl() + Optional.ofNullable(request.getProperties().get("pathSegments")).orElse("");
+        final Map<String, String> additionalHeaders = address.getAdditionalHeaders();
+        params.header(HEADER_EDC_BPN, additionalHeaders.getOrDefault(HEADER_EDC_BPN, ""));
+        final var relevantClients = clients.values().stream()
+                .filter(client -> client.isAspectModelCall(targetUrl))
+                .collect(Collectors.toSet());
+        if (!relevantClients.isEmpty() && relevantClients.stream().noneMatch(client -> client.shouldAllowAccess(additionalHeaders, request, address))) {
+            params.baseUrl(config.getErrorEndpointBaseUrl())
+                    .queryParams(config.getReasonPhraseParameterName() + "=Access denied.")
+                    .method("GET")
+                    .path(config.getErrorEndpointPathForStatus(403));
+        }
+
+        return params;
+    }
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/DtrAccessVerificationClient.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/DtrAccessVerificationClient.java
@@ -1,0 +1,162 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.eclipse.edc.connector.dataplane.http.spi.HttpDataAddress;
+import org.eclipse.edc.spi.http.EdcHttpClient;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.AccessControlServerException;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.HttpAccessControlCheckClientConfig;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.HttpAccessControlCheckDtrClientConfig;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client.model.DtrAccessVerificationRequest;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.HttpAccessControlRequestParamsDecorator.HEADER_EDC_BPN;
+
+public class DtrAccessVerificationClient implements HttpAccessVerificationClient {
+
+    private static final String APPLICATION_JSON = "application/json";
+    private final Monitor monitor;
+    private final EdcHttpClient httpClient;
+    private final TypeManager typeManager;
+    private final HttpAccessControlCheckClientConfig config;
+    private final HttpAccessControlCheckDtrClientConfig dtrConfig;
+    private final LoadingCache<String, String> tokenCache;
+    private final Cache<RequestKey, Boolean> accessControlDecisionCache;
+
+    public DtrAccessVerificationClient(
+            final Monitor monitor,
+            final EdcHttpClient httpClient,
+            final Oauth2TokenClient tokenClient,
+            final TypeManager typeManager,
+            final HttpAccessControlCheckClientConfig config,
+            final HttpAccessControlCheckDtrClientConfig dtrConfig) {
+        this.monitor = monitor;
+        this.httpClient = httpClient;
+        this.typeManager = typeManager;
+        this.config = config;
+        this.dtrConfig = dtrConfig;
+        this.tokenCache = Caffeine.newBuilder()
+                .maximumSize(1)
+                .expireAfterWrite(Duration.ofMinutes(5))
+                .refreshAfterWrite(Duration.ofMinutes(4))
+                .build(tokenClient::getBearerToken);
+        final long cacheDurationMinutes = dtrConfig.getDecisionCacheDurationMinutes();
+        if (cacheDurationMinutes <= 0) {
+            this.accessControlDecisionCache = null;
+        } else {
+            this.accessControlDecisionCache = Caffeine.newBuilder()
+                    .maximumSize(10000)
+                    .expireAfterWrite(Duration.ofMinutes(cacheDurationMinutes))
+                    .build();
+        }
+    }
+
+    @Override
+    public boolean isAspectModelCall(final String url) {
+        return urlMatchesPattern(url, dtrConfig.getAspectModelUrlPattern());
+    }
+
+    @Override
+    public boolean shouldAllowAccess(
+            final Map<String, String> additionalHeaders,
+            final DataFlowRequest request,
+            final HttpDataAddress address) throws AccessControlServerException {
+        final String requestedUrl = getTargetUrl(request);
+        final String bpn = Optional.ofNullable(additionalHeaders.get(HEADER_EDC_BPN))
+                .orElseThrow(() -> new AccessControlServerException("Null BPN found."));
+        final RequestKey key = new RequestKey(bpn, requestedUrl);
+        if (accessControlDecisionCache == null) {
+            return this.callDtr(key);
+        } else {
+            return accessControlDecisionCache.get(
+                    key, this::callDtr);
+        }
+    }
+
+    private boolean callDtr(final RequestKey requestKey) {
+        final Request dtrRequest = getDtrRequest(requestKey);
+        try (Response response = httpClient.execute(dtrRequest)) {
+            return response.isSuccessful();
+        } catch (final IOException exception) {
+            monitor.severe("Failed to execute DTR access verification request.", exception);
+            throw new AccessControlServerException(exception);
+        }
+    }
+
+    private boolean urlMatchesPattern(final String url, final String urlPattern) {
+        final Pattern pattern = Pattern.compile(urlPattern, Pattern.CASE_INSENSITIVE);
+        final Matcher matcher = pattern.matcher(url);
+        return matcher.find();
+    }
+
+    @NotNull
+    private String getTargetUrl(final DataFlowRequest request) {
+        final var edcBaseUrl = config.getEdcDataPlaneBaseUrl();
+        final var path = request.getProperties().getOrDefault("pathSegments", "");
+        final var query = Optional.of(request.getProperties().getOrDefault("queryParams", ""))
+                .filter(s -> !s.isBlank())
+                .map(s -> "?" + s)
+                .orElse("");
+        return edcBaseUrl + path + query;
+    }
+
+    @NotNull
+    private Request getDtrRequest(final RequestKey requestKey) {
+        final String token = tokenCache.get(dtrConfig.getOauth2TokenScope());
+        if (token == null) {
+            throw new AccessControlServerException("Token is null.");
+        }
+        final RequestBody body = RequestBody.create(
+                createRequest(requestKey),
+                MediaType.get(APPLICATION_JSON));
+        return new Request.Builder()
+                .url(dtrConfig.getDtrAccessVerificationUrl())
+                .addHeader(HEADER_EDC_BPN, requestKey.bpn())
+                .addHeader("Authorization", "Bearer " + token)
+                .addHeader("Accept", APPLICATION_JSON)
+                .addHeader("Content-Type", APPLICATION_JSON)
+                .post(body)
+                .build();
+    }
+
+    @NotNull
+    private String createRequest(RequestKey requestKey) {
+        return typeManager.writeValueAsString(new DtrAccessVerificationRequest(requestKey.requestedUrl()));
+    }
+
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/DtrOauth2TokenClient.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/DtrOauth2TokenClient.java
@@ -1,0 +1,119 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import okhttp3.FormBody;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.eclipse.edc.spi.http.EdcHttpClient;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.AccessControlServerException;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.HttpAccessControlCheckDtrClientConfig;
+import org.jetbrains.annotations.NotNull;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+
+public class DtrOauth2TokenClient implements Oauth2TokenClient {
+
+    static final TypeReference<HashMap<String, String>> MAP_TYPE_REFERENCE = new TypeReference<>() {
+    };
+    static final String ACCESS_TOKEN = "access_token";
+    private final Monitor monitor;
+    private final EdcHttpClient httpClient;
+    private final HttpAccessControlCheckDtrClientConfig dtrConfig;
+    private final TypeManager typeManager;
+    private final LoadingCache<String, String> secretCache;
+
+    public DtrOauth2TokenClient(
+            final Monitor monitor,
+            final EdcHttpClient httpClient,
+            final TypeManager typeManager,
+            final Vault vault,
+            final HttpAccessControlCheckDtrClientConfig dtrConfig) {
+        this.monitor = monitor;
+        this.httpClient = httpClient;
+        this.typeManager = typeManager;
+        this.dtrConfig = dtrConfig;
+        this.secretCache = Caffeine.newBuilder()
+                .maximumSize(1)
+                .expireAfterWrite(Duration.ofMinutes(30))
+                .refreshAfterWrite(Duration.ofMinutes(15))
+                .build(vault::resolveSecret);
+    }
+
+    @Override
+    public String getBearerToken(final String scope) {
+        final Request request = createTokenRequest(scope);
+        try (Response response = httpClient.execute(request)) {
+            if (!response.isSuccessful()) {
+                throw new IllegalStateException("OAuth2 authentication error. Response code=" + response.code());
+            }
+            final ResponseBody body = response.body();
+            if (body == null) {
+                throw new IllegalStateException("OAuth2 response body is empty.");
+            }
+            final var map = typeManager.readValue(body.string(), MAP_TYPE_REFERENCE);
+            if (!map.containsKey(ACCESS_TOKEN)) {
+                throw new IllegalStateException("OAuth2 response body had no token.");
+            }
+            return map.get(ACCESS_TOKEN);
+        } catch (final Exception e) {
+            monitor.severe("Failed to obtain Bearer token: " + e.getMessage());
+            return null;
+        }
+    }
+
+    @NotNull
+    private String fetchClientSecret() {
+        final String secret = secretCache.get(dtrConfig.getOauth2ClientSecretPath());
+        if (secret == null) {
+            throw new AccessControlServerException("Cannot resolve authentication credentials.");
+        }
+        return secret;
+    }
+
+    @NotNull
+    private Request createTokenRequest(final String scope) {
+        final String secret = fetchClientSecret();
+        final FormBody formBody = new FormBody(
+                List.of("grant_type", "client_id", "client_secret", "scope"),
+                List.of("client_credentials",
+                        URLEncoder.encode(dtrConfig.getOauth2ClientId(), StandardCharsets.UTF_8),
+                        URLEncoder.encode(secret, StandardCharsets.UTF_8),
+                        URLEncoder.encode(scope, StandardCharsets.UTF_8)));
+        return new Request.Builder()
+                .url(dtrConfig.getOauth2TokenEndpointUrl())
+                .addHeader("Accept", "application/json")
+                .addHeader("Content-Type", formBody.contentType().toString())
+                .post(formBody)
+                .build();
+    }
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/HttpAccessVerificationClient.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/HttpAccessVerificationClient.java
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client;
+
+import org.eclipse.edc.connector.dataplane.http.spi.HttpDataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.AccessControlServerException;
+
+import java.util.Map;
+
+public interface HttpAccessVerificationClient {
+
+    boolean isAspectModelCall(String url);
+
+    boolean shouldAllowAccess(Map<String, String> additionalHeaders, DataFlowRequest request, HttpDataAddress address) throws AccessControlServerException;
+
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/Oauth2TokenClient.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/Oauth2TokenClient.java
@@ -1,0 +1,26 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client;
+
+public interface Oauth2TokenClient {
+
+    String getBearerToken(String scope);
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/RequestKey.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/RequestKey.java
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client;
+
+public record RequestKey(String bpn, String requestedUrl) {
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/model/DtrAccessVerificationRequest.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/main/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/model/DtrAccessVerificationRequest.java
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client.model;
+
+public record DtrAccessVerificationRequest(String submodelEndpointUrl) {
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,21 @@
+#################################################################################
+#  Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension

--- a/edc-extensions/dataplane-dtr-http-access-control/src/test/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/DataPlaneHttpAccessControlExtensionTest.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/test/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/DataPlaneHttpAccessControlExtensionTest.java
@@ -1,0 +1,121 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParamsProvider;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.http.EdcHttpClient;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.web.spi.WebServer;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
+import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.ASPECT_MODEL_URL_PATTERN;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.DEFAULT_PORT;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.EDC_DTR_CONFIG_NAMES;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.EDC_DTR_CONFIG_PREFIX;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.ERROR_ENDPOINT_PORT;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class DataPlaneHttpAccessControlExtensionTest {
+
+    @Mock
+    private WebService webService;
+    @Mock
+    private WebServer webServer;
+    @Mock
+    private WebServiceConfigurer configurer;
+    @Mock
+    private HttpRequestParamsProvider paramsProvider;
+    @Mock
+    private Monitor monitor;
+    @Mock
+    private Vault vault;
+    @Mock
+    private EdcHttpClient httpClient;
+
+    private AutoCloseable openMocks;
+
+    @BeforeEach
+    void setUp(final ServiceExtensionContext context) {
+        openMocks = MockitoAnnotations.openMocks(this);
+        context.registerService(WebServer.class, webServer);
+        context.registerService(WebService.class, webService);
+        context.registerService(WebServiceConfigurer.class, configurer);
+        context.registerService(HttpRequestParamsProvider.class, paramsProvider);
+        context.registerService(Monitor.class, monitor);
+        context.registerService(EdcHttpClient.class, httpClient);
+        context.registerService(Vault.class, vault);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Assertions.assertThatNoException().isThrownBy(() -> openMocks.close());
+    }
+
+    @Test
+    void test_Initialize_ShouldRegisterComponents_WhenCalled(final DataPlaneHttpAccessControlExtension extension, final ServiceExtensionContext context) {
+        //given
+        doReturn("default").when(context)
+                .getSetting(eq(EDC_DTR_CONFIG_NAMES), eq(""));
+        doReturn("http://local-edc-wiremock:18080/aspect-model-api/").when(context)
+                .getSetting(eq(EDC_DTR_CONFIG_PREFIX + "default" + ASPECT_MODEL_URL_PATTERN), anyString());
+        doReturn(mock(Config.class)).when(context)
+                .getConfig(EDC_DTR_CONFIG_PREFIX + "default");
+        doReturn(DEFAULT_PORT).when(context).getSetting(eq(ERROR_ENDPOINT_PORT), anyInt());
+        doAnswer(invocation -> {
+            final WebServiceSettings settings = invocation.getArgument(2);
+            ((WebServer) invocation.getArgument(1)).addPortMapping(settings.getName(), settings.getDefaultPort(), settings.getDefaultPath());
+            return null;
+        }).when(configurer).configure(same(context), any(), isA(WebServiceSettings.class));
+
+        //when
+        extension.initialize(context);
+
+        //then
+        verify(paramsProvider).registerSinkDecorator(isA(HttpAccessControlRequestParamsDecorator.class));
+        verify(paramsProvider).registerSourceDecorator(isA(HttpAccessControlRequestParamsDecorator.class));
+        verify(configurer).configure(same(context), same(webServer), isA(WebServiceSettings.class));
+        verify(webServer).addPortMapping("error", DEFAULT_PORT, "/error");
+        verify(webService).registerResource(eq("error"), isA(HttpAccessControlErrorApiController.class));
+    }
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/test/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlCheckClientConfigTest.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/test/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlCheckClientConfigTest.java
@@ -1,0 +1,147 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol;
+
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.DEFAULT_PORT;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.EDC_DATA_PLANE_BASE_URL;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.EDC_DTR_CONFIG_NAMES;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.EDC_DTR_CONFIG_PREFIX;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.ERROR_ENDPOINT_PORT;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class HttpAccessControlCheckClientConfigTest {
+
+    private ServiceExtensionContext serviceExtensionContext;
+    private HttpAccessControlCheckClientConfig underTest;
+
+    @BeforeEach
+    void setUp() {
+        serviceExtensionContext = mock();
+    }
+
+    @Test
+    void test_GetErrorEndpointPort_ShouldReturnExpectedValue_WhenConfigurationWasSet() {
+        //given
+        final int expected = 1;
+        when(serviceExtensionContext.getSetting(EDC_DTR_CONFIG_NAMES, "")).thenReturn("name");
+        when(serviceExtensionContext.getSetting(ERROR_ENDPOINT_PORT, DEFAULT_PORT)).thenReturn(expected);
+        when(serviceExtensionContext.getConfig(EDC_DTR_CONFIG_PREFIX + "name")).thenReturn(mock());
+        underTest = new HttpAccessControlCheckClientConfig(serviceExtensionContext);
+
+        //when
+        final int actual = underTest.getErrorEndpointPort();
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void test_GetDtrClientConfigMap_ShouldReturnEmptyMap_WhenConfigurationIsNotSet() {
+        //given
+        final int expected = 1;
+        when(serviceExtensionContext.getSetting(EDC_DTR_CONFIG_NAMES, "")).thenReturn("");
+        when(serviceExtensionContext.getSetting(ERROR_ENDPOINT_PORT, DEFAULT_PORT)).thenReturn(expected);
+        underTest = new HttpAccessControlCheckClientConfig(serviceExtensionContext);
+
+        //when
+        final var actual = underTest.getDtrClientConfigMap();
+
+        //then
+        assertThat(actual).isEqualTo(Map.of());
+        verify(serviceExtensionContext, never()).getConfig(anyString());
+    }
+
+    @Test
+    void test_GetErrorEndpointBaseUrl_ShouldReturnExpectedValue_WhenConfigurationWasSet() {
+        //given
+        final String expected = "http://localhost:" + DEFAULT_PORT + "/error";
+        when(serviceExtensionContext.getSetting(EDC_DTR_CONFIG_NAMES, "")).thenReturn("name");
+        when(serviceExtensionContext.getSetting(ERROR_ENDPOINT_PORT, DEFAULT_PORT)).thenReturn(DEFAULT_PORT);
+        when(serviceExtensionContext.getConfig(EDC_DTR_CONFIG_PREFIX + "name")).thenReturn(mock());
+        underTest = new HttpAccessControlCheckClientConfig(serviceExtensionContext);
+
+        //when
+        final String actual = underTest.getErrorEndpointBaseUrl();
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void test_GetErrorEndpointPathForStatus_ShouldReturnExpectedValue_WhenCalledWithValidValue() {
+        //given
+        final int status = 401;
+        final String expected = "/http/access/error/401";
+        when(serviceExtensionContext.getSetting(EDC_DTR_CONFIG_NAMES, "")).thenReturn("name");
+        when(serviceExtensionContext.getConfig(EDC_DTR_CONFIG_PREFIX + "name")).thenReturn(mock());
+        underTest = new HttpAccessControlCheckClientConfig(serviceExtensionContext);
+
+        //when
+        final String actual = underTest.getErrorEndpointPathForStatus(status);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void test_GetReasonPhraseParameterName_ShouldReturnExpectedValue_WhenCalled() {
+        //given
+        final String expected = "reasonPhrase";
+        when(serviceExtensionContext.getSetting(EDC_DTR_CONFIG_NAMES, "")).thenReturn("name");
+        when(serviceExtensionContext.getConfig(EDC_DTR_CONFIG_PREFIX + "name")).thenReturn(mock());
+        underTest = new HttpAccessControlCheckClientConfig(serviceExtensionContext);
+
+        //when
+        final String actual = underTest.getReasonPhraseParameterName();
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void test_GetEdcDataPlaneBaseUrl_ShouldReturnExpectedValue_WhenConfigurationWasSet() {
+        //given
+        final String expected = "http://edc-data-plane/proxy";
+        when(serviceExtensionContext.getSetting(EDC_DTR_CONFIG_NAMES, "")).thenReturn("name");
+        when(serviceExtensionContext.getSetting(eq(EDC_DATA_PLANE_BASE_URL), isNull())).thenReturn(expected);
+        when(serviceExtensionContext.getConfig(EDC_DTR_CONFIG_PREFIX + "name")).thenReturn(mock());
+        underTest = new HttpAccessControlCheckClientConfig(serviceExtensionContext);
+
+        //when
+        final String actual = underTest.getEdcDataPlaneBaseUrl();
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/test/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlCheckDtrClientConfigTest.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/test/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlCheckDtrClientConfigTest.java
@@ -1,0 +1,132 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol;
+
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.ASPECT_MODEL_URL_PATTERN;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.DTR_ACCESS_VERIFICATION_URL;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.OAUTH2_TOKEN_CLIENT_ID;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.OAUTH2_TOKEN_CLIENT_SECRET_PATH;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.OAUTH2_TOKEN_ENDPOINT_URL;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.DataPlaneHttpAccessControlExtension.OAUTH2_TOKEN_SCOPE;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HttpAccessControlCheckDtrClientConfigTest {
+
+    private Config config;
+    private HttpAccessControlCheckDtrClientConfig underTest;
+
+    @BeforeEach
+    void setUp() {
+        config = mock();
+    }
+
+    @Test
+    void test_GetAspectModelUrlPattern_ShouldReturnExpectedValue_WhenConfigurationWasSet() {
+        //given
+        final String expected = "http://aspec-model/api";
+        when(config.getString(eq(ASPECT_MODEL_URL_PATTERN), isNull())).thenReturn(expected);
+        underTest = new HttpAccessControlCheckDtrClientConfig(config);
+
+        //when
+        final String actual = underTest.getAspectModelUrlPattern();
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void test_GetDtrAccessVerificationUrl_ShouldReturnExpectedValue_WhenConfigurationWasSet() {
+        //given
+        final String expected = "http://dtr/submodel-descriptor/authorized";
+        when(config.getString(eq(DTR_ACCESS_VERIFICATION_URL), isNull())).thenReturn(expected);
+        underTest = new HttpAccessControlCheckDtrClientConfig(config);
+
+        //when
+        final String actual = underTest.getDtrAccessVerificationUrl();
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void test_GetOauth2TokenEndpointUrl_ShouldReturnExpectedValue_WhenConfigurationWasSet() {
+        //given
+        final String expected = "http://oauth2/token";
+        when(config.getString(eq(OAUTH2_TOKEN_ENDPOINT_URL), isNull())).thenReturn(expected);
+        underTest = new HttpAccessControlCheckDtrClientConfig(config);
+
+        //when
+        final String actual = underTest.getOauth2TokenEndpointUrl();
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void test_GetOauth2TokenScope_ShouldReturnExpectedValue_WhenConfigurationWasSet() {
+        //given
+        final String expected = "aud:dtr-id";
+        when(config.getString(eq(OAUTH2_TOKEN_SCOPE), isNull())).thenReturn(expected);
+        underTest = new HttpAccessControlCheckDtrClientConfig(config);
+
+        //when
+        final String actual = underTest.getOauth2TokenScope();
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void test_GetOauth2ClientId_ShouldReturnExpectedValue_WhenConfigurationWasSet() {
+        //given
+        final String expected = "edc-client-id";
+        when(config.getString(eq(OAUTH2_TOKEN_CLIENT_ID), isNull())).thenReturn(expected);
+        underTest = new HttpAccessControlCheckDtrClientConfig(config);
+
+        //when
+        final String actual = underTest.getOauth2ClientId();
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void test_GetOauth2ClientSecretPath_ShouldReturnExpectedValue_WhenConfigurationWasSet() {
+        //given
+        final String expected = "edc-client-secret-path";
+        when(config.getString(eq(OAUTH2_TOKEN_CLIENT_SECRET_PATH), isNull())).thenReturn(expected);
+        underTest = new HttpAccessControlCheckDtrClientConfig(config);
+
+        //when
+        final String actual = underTest.getOauth2ClientSecretPath();
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/test/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlErrorApiControllerTest.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/test/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlErrorApiControllerTest.java
@@ -1,0 +1,71 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpAccessControlErrorApiControllerTest {
+
+    @Test
+    void test_Unauthorized_ShouldReturnHttp401_WhenCalledWithReasonCode() {
+        //given
+        final String aReason = "a reason";
+        final var underTest = new HttpAccessControlErrorApiController();
+
+        //when
+        final Response actual = underTest.unauthorized(aReason);
+
+        //then
+        assertThat(actual).isNotNull();
+        assertThat(actual.getStatus()).isEqualTo(401);
+    }
+
+    @Test
+    void test_Forbidden_ShouldReturnHttp403_WhenCalledWithReasonCode() {
+        //given
+        final String aReason = "a reason";
+        final var underTest = new HttpAccessControlErrorApiController();
+
+        //when
+        final Response actual = underTest.forbidden(aReason);
+
+        //then
+        assertThat(actual).isNotNull();
+        assertThat(actual.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void test_Ok_ShouldReturnHttp200_WhenCalledWithBody() {
+        //given
+        final String aBody = "{\"a\":\"b\"}";
+        final var underTest = new HttpAccessControlErrorApiController();
+
+        //when
+        final Response actual = underTest.ok(aBody);
+
+        //then
+        assertThat(actual).isNotNull();
+        assertThat(actual.getStatus()).isEqualTo(200);
+    }
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/test/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlRequestParamsDecoratorTest.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/test/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/HttpAccessControlRequestParamsDecoratorTest.java
@@ -1,0 +1,210 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol;
+
+import org.eclipse.edc.connector.dataplane.http.spi.HttpDataAddress;
+import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParams;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client.HttpAccessVerificationClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.HttpAccessControlRequestParamsDecorator.HEADER_EDC_BPN;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class HttpAccessControlRequestParamsDecoratorTest {
+
+    private static final int HTTP_403 = 403;
+
+    final Monitor monitor = mock();
+    final DataFlowRequest request = mock();
+    final HttpDataAddress address = mock();
+    final HttpRequestParams.Builder params = mock();
+    final HttpAccessControlCheckClientConfig config = mock();
+    final HttpAccessControlCheckDtrClientConfig dtrConfig = mock();
+    final HttpAccessVerificationClient client = mock();
+    HttpAccessControlRequestParamsDecorator underTest;
+
+    @BeforeEach
+    void initMocks() {
+        when(request.getId()).thenReturn("ID");
+
+        when(address.getMethod()).thenReturn("GET");
+        when(address.getBaseUrl()).thenReturn("http://example.com");
+        when(address.getPath()).thenReturn("");
+        when(address.getQueryParams()).thenReturn("?param1=value1");
+
+        when(params.header(anyString(), anyString())).thenReturn(params);
+
+        when(dtrConfig.getAspectModelUrlPattern()).thenReturn("http:\\/\\/example\\.com\\/path\\/to.*");
+        when(config.getDtrClientConfigMap()).thenReturn(Map.of("0", dtrConfig));
+        underTest = new HttpAccessControlRequestParamsDecorator(monitor, Map.of("0", client), config);
+    }
+
+    @Test
+    void test_DtrLookupCall_ShouldSucceed_WhenBpnHeaderIsPresent() {
+        //given
+        final Map<String, String> map = Map.of("pathSegments", "/path/dtr/resource");
+        when(request.getProperties()).thenReturn(map);
+        final Map<String, String> additionalHeaders = Map.of(
+                HEADER_EDC_BPN, "BPN0001"
+        );
+        when(address.getAdditionalHeaders()).thenReturn(additionalHeaders);
+        when(client.isAspectModelCall(anyString())).thenReturn(false);
+
+        //when
+        final HttpRequestParams.Builder actual = underTest.decorate(request, address, params);
+
+        //then
+        verify(params).header(HEADER_EDC_BPN, "BPN0001");
+        assertThat(actual).isSameAs(params);
+    }
+
+    @Test
+    void test_DtrLookupCall_ShouldSucceed_WhenBpnHeaderIsMissing() {
+        //given
+        final Map<String, String> map = Map.of("pathSegments", "/path/dtr/resource");
+        when(request.getProperties()).thenReturn(map);
+        final Map<String, String> additionalHeaders = Map.of();
+        when(address.getAdditionalHeaders()).thenReturn(additionalHeaders);
+        when(client.isAspectModelCall(anyString())).thenReturn(false);
+
+        //when
+        final HttpRequestParams.Builder actual = underTest.decorate(request, address, params);
+
+        //then
+        verify(params).header(HEADER_EDC_BPN, "");
+        assertThat(actual).isSameAs(params);
+    }
+
+    @Test
+    void test_AspectModelBackendRequest_ShouldSucceed_WhenBpnHeaderIsPresentAndDtrRespondsWithOk() {
+        //given
+        final Map<String, String> map = Map.of("pathSegments", "/path/that/does/not/match");
+        when(request.getProperties()).thenReturn(map);
+        final Map<String, String> additionalHeaders = Map.of(
+                HEADER_EDC_BPN, "BPN0001"
+        );
+        when(address.getAdditionalHeaders()).thenReturn(additionalHeaders);
+        when(client.isAspectModelCall(anyString())).thenReturn(true);
+        when(client.shouldAllowAccess(additionalHeaders, request, address)).thenReturn(true);
+
+        //when
+        final HttpRequestParams.Builder actual = underTest.decorate(request, address, params);
+
+        //then
+        verify(monitor, never()).info(anyString());
+        verify(params).header(HEADER_EDC_BPN, "BPN0001");
+        verify(client).shouldAllowAccess(anyMap(), any(), any());
+        assertThat(actual).isSameAs(params);
+    }
+
+    @Test
+    void test_AspectModelBackendRequest_ShouldThrowException_WhenBpnHeaderIsPresentAndDtrRespondsWithError() {
+        //given
+        final Map<String, String> map = Map.of("pathSegments", "/path/that/does/not/match");
+        when(request.getProperties()).thenReturn(map);
+        final Map<String, String> additionalHeaders = Map.of(
+                HEADER_EDC_BPN, "BPN0001"
+        );
+        when(address.getAdditionalHeaders()).thenReturn(additionalHeaders);
+        when(client.isAspectModelCall(anyString())).thenReturn(true);
+        when(client.shouldAllowAccess(anyMap(), any(DataFlowRequest.class), any(HttpDataAddress.class)))
+                .thenReturn(false);
+
+        //when
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> underTest.decorate(request, address, params));
+
+        //then
+        verify(monitor, never()).info(anyString());
+        verify(params).header(HEADER_EDC_BPN, "BPN0001");
+        verify(client).shouldAllowAccess(anyMap(), any(), any());
+    }
+
+    @Test
+    void test_AspectModelBackendRequest_ShouldThrowException_WhenBpnHeaderIsMissing() {
+        //given
+        final Map<String, String> map = Map.of("pathSegments", "/path/that/does/not/match");
+        when(request.getProperties()).thenReturn(map);
+        final Map<String, String> additionalHeaders = Map.of();
+        when(address.getAdditionalHeaders()).thenReturn(additionalHeaders);
+        when(client.isAspectModelCall(anyString())).thenReturn(true);
+        when(client.shouldAllowAccess(anyMap(), any(DataFlowRequest.class), any(HttpDataAddress.class)))
+                .thenReturn(false);
+
+        //when
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> underTest.decorate(request, address, params));
+
+        //then
+        verify(monitor, never()).info(anyString());
+        verify(params).header(HEADER_EDC_BPN, "");
+        verify(client).shouldAllowAccess(anyMap(), any(), any());
+    }
+
+    @Test
+    void test_AspectModelBackendRequest_ShouldRedirectToErrorPage_WhenAccessIsDenied() {
+        //given
+        final Map<String, String> map = Map.of("pathSegments", "/path/that/does/not/match", "queryParams", "id=1");
+        when(request.getProperties()).thenReturn(map);
+        final Map<String, String> additionalHeaders = Map.of(
+                HEADER_EDC_BPN, "BPN0001"
+        );
+        final String errorPageBaseUrl = "http://localhost:9090/error";
+        final String reasonPhraseParam = "reasonPhrase";
+        final String errorPagePath = "/http/access/error/403";
+        final HttpRequestParams.Builder builder = HttpRequestParams.Builder.newInstance();
+        when(config.getErrorEndpointBaseUrl()).thenReturn(errorPageBaseUrl);
+        when(config.getReasonPhraseParameterName()).thenReturn(reasonPhraseParam);
+        when(config.getErrorEndpointPathForStatus(HTTP_403)).thenReturn(errorPagePath);
+
+        when(client.isAspectModelCall(anyString())).thenReturn(true);
+        when(address.getAdditionalHeaders()).thenReturn(additionalHeaders);
+        when(client.shouldAllowAccess(anyMap(), any(DataFlowRequest.class), any(HttpDataAddress.class)))
+                .thenReturn(false);
+
+        //when
+        final HttpRequestParams actual = underTest.decorate(request, address, builder).build();
+
+        //then
+        assertThat(actual).isNotNull();
+        assertThat(actual.getBaseUrl()).isEqualTo(errorPageBaseUrl);
+        assertThat(actual.getPath()).isEqualTo(errorPagePath);
+        assertThat(actual.getQueryParams()).startsWith(reasonPhraseParam);
+        assertThat(actual.getHeaders()).containsEntry(HEADER_EDC_BPN, "BPN0001");
+        verify(monitor, never()).info(anyString());
+        verify(client).shouldAllowAccess(anyMap(), any(), any());
+    }
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/test/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/DtrAccessVerificationClientTest.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/test/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/DtrAccessVerificationClientTest.java
@@ -1,0 +1,276 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okio.Buffer;
+import org.eclipse.edc.connector.dataplane.http.spi.HttpDataAddress;
+import org.eclipse.edc.spi.http.EdcHttpClient;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.AccessControlServerException;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.HttpAccessControlCheckClientConfig;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.HttpAccessControlCheckDtrClientConfig;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client.model.DtrAccessVerificationRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.HttpAccessControlRequestParamsDecorator.HEADER_EDC_BPN;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DtrAccessVerificationClientTest {
+    static final String BPN = "BPNL000000000001";
+    static final String POST = "POST";
+    static final String SCOPE = "aud:dtr";
+    static final String DUMMY_TOKEN = "dummy_token_value";
+    static final String BEARER_PREFIX = "Bearer ";
+    static final String LOCALHOST_ACCESS_VERIFICATION = "https://localhost/access-verification";
+    static final String LOCALHOST_EDC_DATA_PROXY = "http://localhost/edc-data/proxy";
+    static final String REQUEST_LOCALHOST_EDC_DATA_PROXY = "{\"submodelEndpointUrl\":\"" + LOCALHOST_EDC_DATA_PROXY + "\"}";
+    @Mock
+    private Response httpResponse;
+    @Mock
+    private DataFlowRequest request;
+    @Mock
+    private HttpDataAddress dataAddress;
+    @Mock
+    private Monitor monitor;
+    @Mock
+    private EdcHttpClient httpClient;
+    @Mock
+    private Oauth2TokenClient tokenClient;
+    @Mock
+    private TypeManager typeManager;
+    @Mock
+    private HttpAccessControlCheckClientConfig config;
+    @Mock
+    private HttpAccessControlCheckDtrClientConfig dtrConfig;
+    private AutoCloseable mocks;
+
+    @BeforeEach
+    void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mocks.close();
+    }
+
+    public static Stream<Arguments> urlMatcherSourceProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of("^abcd$", "abcd", true))
+                .add(Arguments.of("^abcd$", "ABCDabcd0123", false))
+                .add(Arguments.of("abcd", "ABCDabcd0123", true))
+                .add(Arguments.of("^[a-dA-D]+$", "Abcd", true))
+                .build();
+    }
+
+    @ParameterizedTest
+    @MethodSource("urlMatcherSourceProvider")
+    void test_IsAspectModelCall_ShouldReturnTrue_WhenUrlIsMatchingPattern(
+            final String pattern, final String url, final boolean expected) {
+        //given
+        when(dtrConfig.getAspectModelUrlPattern()).thenReturn(pattern);
+        final var underTest = new DtrAccessVerificationClient(monitor, httpClient, tokenClient, typeManager, config, dtrConfig);
+
+        //when
+        final boolean actual = underTest.isAspectModelCall(url);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @SuppressWarnings("resource")
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    void test_ShouldAllowAccess_ShouldReturnTrue_WhenDtrResponseIsSuccessful(
+            final int cacheForMinutes) throws IOException {
+        //given
+        final Map<String, String> additionalHeaders = Map.of(HEADER_EDC_BPN, BPN);
+        final Map<String, String> properties = Map.of();
+        when(request.getProperties()).thenReturn(properties);
+        when(dtrConfig.getDtrAccessVerificationUrl()).thenReturn(LOCALHOST_ACCESS_VERIFICATION);
+        when(dtrConfig.getDecisionCacheDurationMinutes()).thenReturn(cacheForMinutes);
+        when(config.getEdcDataPlaneBaseUrl()).thenReturn(LOCALHOST_EDC_DATA_PROXY);
+        when(dtrConfig.getOauth2TokenScope()).thenReturn(SCOPE);
+
+        when(tokenClient.getBearerToken(SCOPE)).thenReturn(DUMMY_TOKEN);
+        final var requestMatcher = new RequestMatcher(
+                LOCALHOST_ACCESS_VERIFICATION, BPN, BEARER_PREFIX + DUMMY_TOKEN, LOCALHOST_EDC_DATA_PROXY);
+        when(typeManager.writeValueAsString(any(DtrAccessVerificationRequest.class))).thenReturn(REQUEST_LOCALHOST_EDC_DATA_PROXY);
+        when(httpClient.execute(argThat(requestMatcher))).thenReturn(httpResponse);
+        when(httpResponse.isSuccessful()).thenReturn(true);
+        final var underTest = new DtrAccessVerificationClient(monitor, httpClient, tokenClient, typeManager, config, dtrConfig);
+
+        //when
+        final boolean actual = underTest.shouldAllowAccess(additionalHeaders, request, dataAddress);
+
+        //then
+        assertThat(actual).isTrue();
+        verify(request, atLeastOnce()).getProperties();
+        verify(tokenClient).getBearerToken(SCOPE);
+        verify(httpClient).execute(argThat(requestMatcher));
+    }
+
+    @SuppressWarnings("resource")
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    void test_ShouldAllowAccess_ShouldReturnFalse_WhenDtrResponseIsNotSuccessful(
+            final int cacheForMinutes) throws IOException {
+        //given
+        final Map<String, String> additionalHeaders = Map.of(HEADER_EDC_BPN, BPN);
+        final Map<String, String> properties = Map.of();
+        when(request.getProperties()).thenReturn(properties);
+        when(dtrConfig.getDtrAccessVerificationUrl()).thenReturn(LOCALHOST_ACCESS_VERIFICATION);
+        when(dtrConfig.getDecisionCacheDurationMinutes()).thenReturn(cacheForMinutes);
+        when(config.getEdcDataPlaneBaseUrl()).thenReturn(LOCALHOST_EDC_DATA_PROXY);
+        when(dtrConfig.getOauth2TokenScope()).thenReturn(SCOPE);
+
+        when(tokenClient.getBearerToken(SCOPE)).thenReturn(DUMMY_TOKEN);
+        final var requestMatcher = new RequestMatcher(
+                LOCALHOST_ACCESS_VERIFICATION, BPN, BEARER_PREFIX + DUMMY_TOKEN, LOCALHOST_EDC_DATA_PROXY);
+        when(typeManager.writeValueAsString(any(DtrAccessVerificationRequest.class))).thenReturn(REQUEST_LOCALHOST_EDC_DATA_PROXY);
+        when(httpClient.execute(argThat(requestMatcher))).thenReturn(httpResponse);
+        when(httpResponse.isSuccessful()).thenReturn(false);
+        final var underTest = new DtrAccessVerificationClient(monitor, httpClient, tokenClient, typeManager, config, dtrConfig);
+
+        //when
+        final boolean actual = underTest.shouldAllowAccess(additionalHeaders, request, dataAddress);
+
+        //then
+        assertThat(actual).isFalse();
+        verify(request, atLeastOnce()).getProperties();
+        verify(tokenClient).getBearerToken(SCOPE);
+        verify(httpClient).execute(argThat(requestMatcher));
+    }
+
+    @SuppressWarnings("resource")
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    void test_ShouldDenyAccess_ShouldThrowException_WhenTokenCannotBeObtained(
+            final int cacheForMinutes) throws IOException {
+        //given
+        final Map<String, String> additionalHeaders = Map.of(HEADER_EDC_BPN, BPN);
+        final Map<String, String> properties = Map.of();
+        when(request.getProperties()).thenReturn(properties);
+        when(dtrConfig.getDtrAccessVerificationUrl()).thenReturn(LOCALHOST_ACCESS_VERIFICATION);
+        when(dtrConfig.getDecisionCacheDurationMinutes()).thenReturn(cacheForMinutes);
+        when(config.getEdcDataPlaneBaseUrl()).thenReturn(LOCALHOST_EDC_DATA_PROXY);
+        when(dtrConfig.getOauth2TokenScope()).thenReturn(SCOPE);
+
+        when(tokenClient.getBearerToken(SCOPE)).thenReturn(null);
+        final var underTest = new DtrAccessVerificationClient(monitor, httpClient, tokenClient, typeManager, config, dtrConfig);
+
+        //when
+        assertThatExceptionOfType(AccessControlServerException.class)
+                .isThrownBy(() -> underTest.shouldAllowAccess(additionalHeaders, request, dataAddress));
+
+        //then
+        verify(request, atLeastOnce()).getProperties();
+        verify(tokenClient).getBearerToken(SCOPE);
+        verify(httpClient, never()).execute(any());
+    }
+
+    @SuppressWarnings("resource")
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    void test_ShouldDenyAccess_ShouldThrowException_WhenDtrRequestResultsInException(
+            final int cacheForMinutes) throws IOException {
+        //given
+        final Map<String, String> additionalHeaders = Map.of(HEADER_EDC_BPN, BPN);
+        final Map<String, String> properties = Map.of();
+        when(request.getProperties()).thenReturn(properties);
+        when(dtrConfig.getDtrAccessVerificationUrl()).thenReturn(LOCALHOST_ACCESS_VERIFICATION);
+        when(dtrConfig.getDecisionCacheDurationMinutes()).thenReturn(cacheForMinutes);
+        when(config.getEdcDataPlaneBaseUrl()).thenReturn(LOCALHOST_EDC_DATA_PROXY);
+        when(dtrConfig.getOauth2TokenScope()).thenReturn(SCOPE);
+
+        when(tokenClient.getBearerToken(SCOPE)).thenReturn(DUMMY_TOKEN);
+        final var requestMatcher = new RequestMatcher(
+                LOCALHOST_ACCESS_VERIFICATION, BPN, BEARER_PREFIX + DUMMY_TOKEN, LOCALHOST_EDC_DATA_PROXY);
+        when(typeManager.writeValueAsString(any(DtrAccessVerificationRequest.class))).thenReturn(REQUEST_LOCALHOST_EDC_DATA_PROXY);
+        when(httpClient.execute(argThat(requestMatcher))).thenThrow(IOException.class);
+        final var underTest = new DtrAccessVerificationClient(monitor, httpClient, tokenClient, typeManager, config, dtrConfig);
+
+        //when
+        assertThatExceptionOfType(AccessControlServerException.class)
+                .isThrownBy(() -> underTest.shouldAllowAccess(additionalHeaders, request, dataAddress));
+
+        //then
+        verify(request, atLeastOnce()).getProperties();
+        verify(tokenClient).getBearerToken(SCOPE);
+        verify(httpClient).execute(any());
+        verify(httpResponse, never()).isSuccessful();
+    }
+
+    private record RequestMatcher(String url, String bpn, String authorization,
+                                  String targetUrl) implements ArgumentMatcher<Request> {
+        @SuppressWarnings("DataFlowIssue")
+        @Override
+        public boolean matches(final Request request) {
+            final boolean methodMatched = POST.equals(request.method());
+            final boolean urlMatched = url.equals(request.url().url().toString());
+            final boolean bpnHeaderFound = bpn.equals(request.header(HEADER_EDC_BPN));
+            final boolean authHeaderFound = authorization.equals(request.header(AUTHORIZATION));
+            final RequestBody body = request.body();
+            final boolean contentTypeHeaderFound = (body.contentType().type() + "/" + body.contentType().subtype()).equals(request.header(CONTENT_TYPE));
+            final String submodelEndpointUrl = bodyAsObject(body).submodelEndpointUrl();
+            final boolean bodyMatched = targetUrl.equals(submodelEndpointUrl);
+            return methodMatched && urlMatched && bpnHeaderFound && authHeaderFound && contentTypeHeaderFound && bodyMatched;
+        }
+
+        private DtrAccessVerificationRequest bodyAsObject(RequestBody body) {
+            try {
+                final Buffer buffer = new Buffer();
+                body.writeTo(buffer);
+                final String string = buffer.readUtf8();
+                return new ObjectMapper().readValue(string, DtrAccessVerificationRequest.class);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/test/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/DtrOauth2TokenClientTest.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/test/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/DtrOauth2TokenClientTest.java
@@ -1,0 +1,274 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client;
+
+import okhttp3.FormBody;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.eclipse.edc.spi.http.EdcHttpClient;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.AccessControlServerException;
+import org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.HttpAccessControlCheckDtrClientConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client.DtrOauth2TokenClient.ACCESS_TOKEN;
+import static org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client.DtrOauth2TokenClient.MAP_TYPE_REFERENCE;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+class DtrOauth2TokenClientTest {
+    static final String POST = "POST";
+    static final String SCOPE = "aud:dtr";
+    static final String ENCODED_SCOPE = URLEncoder.encode(SCOPE, StandardCharsets.UTF_8);
+    static final String CLIENT_ID = "client:id";
+    static final String ENCODED_CLIENT_ID = URLEncoder.encode(CLIENT_ID, StandardCharsets.UTF_8);
+    static final String CLIENT_SECRET_VAULT_PATH = "client_secret";
+    static final String CLIENT_SECRET = "client:secret";
+    static final String ENCODED_CLIENT_SECRET = URLEncoder.encode(CLIENT_SECRET, StandardCharsets.UTF_8);
+    static final String DUMMY_TOKEN = "dummy_token_value";
+    static final String RESPONSE_BODY = "{\"" + ACCESS_TOKEN + "\": \"" + DUMMY_TOKEN + "\"}";
+    static final String LOCALHOST_TOKEN_ENDPOINT = "https://localhost/token";
+    @Mock
+    private Response httpResponse;
+    @Mock
+    private ResponseBody responseBody;
+    @Mock
+    private Monitor monitor;
+    @Mock
+    private EdcHttpClient httpClient;
+    @Mock
+    private Vault vault;
+    @Mock
+    private TypeManager typeManager;
+    @Mock
+    private HttpAccessControlCheckDtrClientConfig dtrConfig;
+    @InjectMocks
+    private DtrOauth2TokenClient underTest;
+    private AutoCloseable mocks;
+
+    @BeforeEach
+    void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mocks.close();
+    }
+
+    @SuppressWarnings({"resource", "ResultOfMethodCallIgnored"})
+    @Test
+    void test_GetBearerToken_ShouldReturnToken_WhenOauth2ResponseContainsOne() throws IOException {
+        //given
+        when(dtrConfig.getOauth2ClientId()).thenReturn(CLIENT_ID);
+        when(dtrConfig.getOauth2TokenScope()).thenReturn(SCOPE);
+        when(dtrConfig.getOauth2ClientSecretPath()).thenReturn(CLIENT_SECRET_VAULT_PATH);
+        when(dtrConfig.getOauth2TokenEndpointUrl()).thenReturn(LOCALHOST_TOKEN_ENDPOINT);
+        when(vault.resolveSecret(CLIENT_SECRET_VAULT_PATH)).thenReturn(CLIENT_SECRET);
+
+        final var requestMatcher = new RequestMatcher(
+                LOCALHOST_TOKEN_ENDPOINT, ENCODED_CLIENT_ID, ENCODED_CLIENT_SECRET, ENCODED_SCOPE);
+        when(httpClient.execute(argThat(requestMatcher))).thenReturn(httpResponse);
+        when(httpResponse.isSuccessful()).thenReturn(true);
+        when(httpResponse.body()).thenReturn(responseBody);
+        when(responseBody.string()).thenReturn(RESPONSE_BODY);
+        when(typeManager.readValue(RESPONSE_BODY, MAP_TYPE_REFERENCE))
+                .thenReturn(new HashMap<>(Map.of(ACCESS_TOKEN, DUMMY_TOKEN)));
+
+        //when
+        final String actual = underTest.getBearerToken(SCOPE);
+
+        //then
+        assertThat(actual).isEqualTo(DUMMY_TOKEN);
+        final var inOrder = inOrder(vault, httpClient, httpResponse, responseBody, typeManager, monitor);
+        inOrder.verify(vault).resolveSecret(CLIENT_SECRET_VAULT_PATH);
+        inOrder.verify(httpClient).execute(argThat(requestMatcher));
+        inOrder.verify(httpResponse).isSuccessful();
+        inOrder.verify(httpResponse, atLeastOnce()).body();
+        inOrder.verify(responseBody).string();
+        inOrder.verify(typeManager).readValue(anyString(), eq(MAP_TYPE_REFERENCE));
+    }
+
+    @SuppressWarnings({"resource", "ResultOfMethodCallIgnored"})
+    @Test
+    void test_GetBearerToken_ShouldReturnNull_WhenOauth2ResponseIsNotSuccessful() throws IOException {
+        //given
+        when(dtrConfig.getOauth2ClientId()).thenReturn(CLIENT_ID);
+        when(dtrConfig.getOauth2TokenScope()).thenReturn(SCOPE);
+        when(dtrConfig.getOauth2ClientSecretPath()).thenReturn(CLIENT_SECRET_VAULT_PATH);
+        when(dtrConfig.getOauth2TokenEndpointUrl()).thenReturn(LOCALHOST_TOKEN_ENDPOINT);
+        when(vault.resolveSecret(CLIENT_SECRET_VAULT_PATH)).thenReturn(CLIENT_SECRET);
+
+        final var requestMatcher = new RequestMatcher(
+                LOCALHOST_TOKEN_ENDPOINT, ENCODED_CLIENT_ID, ENCODED_CLIENT_SECRET, ENCODED_SCOPE);
+        when(httpClient.execute(argThat(requestMatcher))).thenReturn(httpResponse);
+        when(httpResponse.isSuccessful()).thenReturn(false);
+
+        //when
+        final String actual = underTest.getBearerToken(SCOPE);
+
+        //then
+        assertThat(actual).isNull();
+        final var inOrder = inOrder(vault, httpClient, httpResponse, responseBody, typeManager, monitor);
+        inOrder.verify(vault).resolveSecret(CLIENT_SECRET_VAULT_PATH);
+        inOrder.verify(httpClient).execute(argThat(requestMatcher));
+        inOrder.verify(httpResponse).isSuccessful();
+        inOrder.verify(monitor).severe(anyString());
+        inOrder.verify(httpResponse, never()).body();
+        inOrder.verify(responseBody, never()).string();
+        inOrder.verify(typeManager, never()).readValue(anyString(), eq(MAP_TYPE_REFERENCE));
+    }
+
+    @SuppressWarnings({"resource", "ResultOfMethodCallIgnored"})
+    @Test
+    void test_GetBearerToken_ShouldReturnNull_WhenOauth2ResponseHasNoBody() throws IOException {
+        //given
+        when(dtrConfig.getOauth2ClientId()).thenReturn(CLIENT_ID);
+        when(dtrConfig.getOauth2TokenScope()).thenReturn(SCOPE);
+        when(dtrConfig.getOauth2ClientSecretPath()).thenReturn(CLIENT_SECRET_VAULT_PATH);
+        when(dtrConfig.getOauth2TokenEndpointUrl()).thenReturn(LOCALHOST_TOKEN_ENDPOINT);
+        when(vault.resolveSecret(CLIENT_SECRET_VAULT_PATH)).thenReturn(CLIENT_SECRET);
+
+        final var requestMatcher = new RequestMatcher(
+                LOCALHOST_TOKEN_ENDPOINT, ENCODED_CLIENT_ID, ENCODED_CLIENT_SECRET, ENCODED_SCOPE);
+        when(httpClient.execute(argThat(requestMatcher))).thenReturn(httpResponse);
+        when(httpResponse.isSuccessful()).thenReturn(true);
+        when(httpResponse.body()).thenReturn(null);
+
+        //when
+        final String actual = underTest.getBearerToken(SCOPE);
+
+        //then
+        assertThat(actual).isNull();
+        final var inOrder = inOrder(vault, httpClient, httpResponse, responseBody, typeManager, monitor);
+        inOrder.verify(vault).resolveSecret(CLIENT_SECRET_VAULT_PATH);
+        inOrder.verify(httpClient).execute(argThat(requestMatcher));
+        inOrder.verify(httpResponse).isSuccessful();
+        inOrder.verify(httpResponse).body();
+        inOrder.verify(monitor).severe(anyString());
+        inOrder.verify(responseBody, never()).string();
+        inOrder.verify(typeManager, never()).readValue(anyString(), eq(MAP_TYPE_REFERENCE));
+    }
+
+    @SuppressWarnings({"resource", "ResultOfMethodCallIgnored"})
+    @Test
+    void test_GetBearerToken_ShouldReturnNull_WhenOauth2ResponseHasNoTokenBody() throws IOException {
+        //given
+        when(dtrConfig.getOauth2ClientId()).thenReturn(CLIENT_ID);
+        when(dtrConfig.getOauth2TokenScope()).thenReturn(SCOPE);
+        when(dtrConfig.getOauth2ClientSecretPath()).thenReturn(CLIENT_SECRET_VAULT_PATH);
+        when(dtrConfig.getOauth2TokenEndpointUrl()).thenReturn(LOCALHOST_TOKEN_ENDPOINT);
+        when(vault.resolveSecret(CLIENT_SECRET_VAULT_PATH)).thenReturn(CLIENT_SECRET);
+
+        final var requestMatcher = new RequestMatcher(
+                LOCALHOST_TOKEN_ENDPOINT, ENCODED_CLIENT_ID, ENCODED_CLIENT_SECRET, ENCODED_SCOPE);
+        when(httpClient.execute(argThat(requestMatcher))).thenReturn(httpResponse);
+        when(httpResponse.isSuccessful()).thenReturn(true);
+        when(httpResponse.body()).thenReturn(responseBody);
+        when(responseBody.string()).thenReturn("{}");
+        when(typeManager.readValue("{}", MAP_TYPE_REFERENCE))
+                .thenReturn(new HashMap<>());
+
+        //when
+        final String actual = underTest.getBearerToken(SCOPE);
+
+        //then
+        assertThat(actual).isNull();
+        final var inOrder = inOrder(vault, httpClient, httpResponse, responseBody, typeManager, monitor);
+        inOrder.verify(vault).resolveSecret(CLIENT_SECRET_VAULT_PATH);
+        inOrder.verify(httpClient).execute(argThat(requestMatcher));
+        inOrder.verify(httpResponse).isSuccessful();
+        inOrder.verify(httpResponse).body();
+        inOrder.verify(responseBody).string();
+        inOrder.verify(typeManager).readValue(anyString(), eq(MAP_TYPE_REFERENCE));
+        inOrder.verify(monitor).severe(anyString());
+    }
+
+    @SuppressWarnings({"resource", "ResultOfMethodCallIgnored"})
+    @Test
+    void test_GetBearerToken_ShouldThrowException_WhenSecretCannotBeFetchedFromVault() throws IOException {
+        //given
+        when(dtrConfig.getOauth2ClientId()).thenReturn(CLIENT_ID);
+        when(dtrConfig.getOauth2TokenScope()).thenReturn(SCOPE);
+        when(dtrConfig.getOauth2ClientSecretPath()).thenReturn(CLIENT_SECRET_VAULT_PATH);
+        when(dtrConfig.getOauth2TokenEndpointUrl()).thenReturn(LOCALHOST_TOKEN_ENDPOINT);
+        when(vault.resolveSecret(CLIENT_SECRET_VAULT_PATH)).thenReturn(null);
+
+        //when
+        assertThatExceptionOfType(AccessControlServerException.class).isThrownBy(() -> underTest.getBearerToken(SCOPE));
+
+        //then
+        final var inOrder = inOrder(vault, httpClient, httpResponse, responseBody, typeManager, monitor);
+        inOrder.verify(vault).resolveSecret(CLIENT_SECRET_VAULT_PATH);
+        inOrder.verify(httpClient, never()).execute(any());
+        inOrder.verify(httpResponse, never()).isSuccessful();
+        inOrder.verify(httpResponse, never()).body();
+        inOrder.verify(responseBody, never()).string();
+        inOrder.verify(typeManager, never()).readValue(anyString(), eq(MAP_TYPE_REFERENCE));
+    }
+
+    private record RequestMatcher(String url, String clientId, String clientSecret,
+                                  String scope) implements ArgumentMatcher<Request> {
+        @SuppressWarnings("DataFlowIssue")
+        @Override
+        public boolean matches(final Request request) {
+            final boolean methodMatched = POST.equals(request.method());
+            final boolean urlMatched = url.equals(request.url().url().toString());
+            final FormBody body = (FormBody) request.body();
+            final boolean contentTypeHeaderFound = body.contentType().toString().equals(request.header(CONTENT_TYPE));
+            final Map<String, String> expectedParameterMap = Map.of(
+                    "client_id", clientId,
+                    "client_secret", clientSecret,
+                    "scope", scope,
+                    "grant_type", "client_credentials");
+            boolean bodyMatched = body.size() == expectedParameterMap.size();
+            for (int i = 0; i < body.size(); i++) {
+                bodyMatched &= expectedParameterMap.get(body.name(i)).equals(body.encodedValue(i));
+            }
+            return methodMatched && urlMatched && contentTypeHeaderFound && bodyMatched;
+        }
+    }
+
+}

--- a/edc-extensions/dataplane-dtr-http-access-control/src/test/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/model/DtrAccessVerificationRequestTest.java
+++ b/edc-extensions/dataplane-dtr-http-access-control/src/test/java/org/eclipse/tractusx/edc/dataplane/dtr/http/accesscontrol/client/model/DtrAccessVerificationRequestTest.java
@@ -1,0 +1,56 @@
+/********************************************************************************
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.dataplane.dtr.http.accesscontrol.client.model;
+
+import org.eclipse.edc.spi.types.TypeManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DtrAccessVerificationRequestTest {
+
+    private final TypeManager typeManager = new TypeManager();
+
+    @Test
+    void test_JsonDeserialization_ShouldGetBackOriginalRequest_WhenCalledWithSerializedValidData() {
+        //given
+        final var request = new DtrAccessVerificationRequest("http://edc-data-plane/url");
+        final var asString = typeManager.writeValueAsString(request);
+
+        //when
+        final var actual = typeManager.readValue(asString, DtrAccessVerificationRequest.class);
+
+        //then
+        assertThat(actual).isEqualTo(request);
+    }
+
+    @Test
+    void test_JsonSerialization_ShouldProduceExpectedJsonFormat_WhenCalledWithValidData() {
+        //given
+        final var request = new DtrAccessVerificationRequest("http://edc-data-plane/url");
+
+        //when
+        final var actual = typeManager.writeValueAsString(request);
+
+        //then
+        assertThat(actual).isEqualTo("{\"submodelEndpointUrl\":\"http://edc-data-plane/url\"}");
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ awaitility = "4.2.0"
 aws = "2.24.5"
 azure-identity = "1.11.2"
 bouncyCastle-jdk18on = "1.77"
+caffeine = "3.1.8"
 flyway = "10.8.1"
 iron-vc = "0.11.0"
 jackson = "2.16.1"
@@ -176,6 +177,7 @@ awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" 
 aws-s3 = { module = "software.amazon.awssdk:s3", version.ref = "aws" }
 aws-s3transfer = { module = "software.amazon.awssdk:s3-transfer-manager", version.ref = "aws" }
 bouncyCastle-bcpkixJdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncyCastle-jdk18on" }
+caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
 flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 flyway-database-postgres = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
 jackson-datatypeJsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -87,7 +88,7 @@ include(":edc-extensions:dataplane-proxy:edc-dataplane-proxy-consumer-api")
 include(":edc-extensions:dataplane-proxy:edc-dataplane-proxy-provider-spi")
 include(":edc-extensions:dataplane-proxy:edc-dataplane-proxy-provider-core")
 include(":edc-extensions:dataplane-proxy:edc-dataplane-proxy-provider-api")
-
+include(":edc-extensions:dataplane-dtr-http-access-control")
 include(":samples:multi-tenancy")
 
 


### PR DESCRIPTION
## WHAT

- Adds new extension: dataplane-http-access-control
- Extension implementation is filtering dataplane HTTP requests based on URL
  - Not matching requests are allowed by default
  - DTR Access verification endpoint is called for matching requests
- Error response is provided in case of error response form DTR access verification endpoint
- Adds caching for DTR tokens used by access verification logic
- Adds caching for DTR responses received by access verification logic
- Documents DTR access verification parameters in Readme.md
- Includes new extension in edc-dataplane-base
- Covers the new functionality with tests

## WHY

The Digital Twin Registry based granular access control needs additional validation to happen before we would forward/proxy the HTTP request to the aspect model backend services.

## FURTHER NOTES

Adds new dependency: Caffeine

Closes https://github.com/eclipse-tractusx/sldt-digital-twin-registry/issues/288
