### PR TITLE
refactor(tests): Tests use ServiceExtensionContext injection

### DIFF
--- a/core/json-ld-core/src/test/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtensionTest.java
+++ b/core/json-ld-core/src/test/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtensionTest.java
@@ -22,7 +22,6 @@ package org.eclipse.tractusx.edc.jsonld;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.system.injection.ObjectFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,18 +39,15 @@ import static org.mockito.Mockito.mock;
 @ExtendWith(DependencyInjectionExtension.class)
 public class JsonLdExtensionTest {
 
-    JsonLdExtension extension;
-
     JsonLd jsonLdService = mock(JsonLd.class);
 
     @BeforeEach
-    void setup(ObjectFactory factory, ServiceExtensionContext context) {
+    void setup(ServiceExtensionContext context) {
         context.registerService(JsonLd.class, jsonLdService);
-        extension = factory.constructInstance(JsonLdExtension.class);
     }
 
     @Test
-    void initialize(ServiceExtensionContext context) {
+    void initialize(ServiceExtensionContext context, JsonLdExtension extension) {
         extension.initialize(context);
         jsonLdService.registerCachedDocument(eq(CREDENTIALS_V_1), any(URI.class));
         jsonLdService.registerCachedDocument(eq(CREDENTIALS_SUMMARY_V_1), any(URI.class));

--- a/edc-controlplane/edc-runtime-memory/src/test/java/org/eclipse/tractusx/edc/vault/memory/VaultSeedExtensionTest.java
+++ b/edc-controlplane/edc-runtime-memory/src/test/java/org/eclipse/tractusx/edc/vault/memory/VaultSeedExtensionTest.java
@@ -24,8 +24,6 @@ import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.system.injection.ObjectFactory;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -41,27 +39,23 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
 class VaultSeedExtensionTest {
-    private VaultSeedExtension extension;
-    private ServiceExtensionContext context;
     private Monitor monitor;
 
     @BeforeEach
     void setup(ServiceExtensionContext context, ObjectFactory factory) {
-        this.context = context;
         monitor = mock(Monitor.class);
         context.registerService(Monitor.class, monitor);
         context.registerService(Vault.class, new InMemoryVault(monitor));
-        extension = factory.constructInstance(VaultSeedExtension.class);
     }
 
     @Test
-    void name() {
+    void name(VaultSeedExtension extension) {
         assertThat(extension.name()).isEqualTo("Vault Seed Extension");
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "key1:", "key1:value1", "key1:value1;", ";key1:value1", ";sdf;key1:value1" })
-    void createInMemVault_validString(String secret) {
+    @ValueSource(strings = {"key1:", "key1:value1", "key1:value1;", ";key1:value1", ";sdf;key1:value1"})
+    void createInMemVault_validString(String secret, ServiceExtensionContext context, VaultSeedExtension extension) {
         when(context.getSetting(eq(VaultSeedExtension.VAULT_MEMORY_SECRETS_PROPERTY), eq(null))).thenReturn(secret);
         extension.createInMemVault(context);
         verify(monitor, times(1)).debug(anyString());

--- a/edc-controlplane/edc-runtime-memory/src/test/java/org/eclipse/tractusx/edc/vault/memory/VaultSeedExtensionTest.java
+++ b/edc-controlplane/edc-runtime-memory/src/test/java/org/eclipse/tractusx/edc/vault/memory/VaultSeedExtensionTest.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -42,7 +43,7 @@ class VaultSeedExtensionTest {
     private Monitor monitor;
 
     @BeforeEach
-    void setup(ServiceExtensionContext context, ObjectFactory factory) {
+    void setup(ServiceExtensionContext context) {
         monitor = mock(Monitor.class);
         context.registerService(Monitor.class, monitor);
         context.registerService(Vault.class, new InMemoryVault(monitor));
@@ -54,7 +55,7 @@ class VaultSeedExtensionTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"key1:", "key1:value1", "key1:value1;", ";key1:value1", ";sdf;key1:value1"})
+    @ValueSource(strings = { "key1:", "key1:value1", "key1:value1;", ";key1:value1", ";sdf;key1:value1" })
     void createInMemVault_validString(String secret, ServiceExtensionContext context, VaultSeedExtension extension) {
         when(context.getSetting(eq(VaultSeedExtension.VAULT_MEMORY_SECRETS_PROPERTY), eq(null))).thenReturn(secret);
         extension.createInMemVault(context);

--- a/edc-extensions/edr/edr-api/src/test/java/org/eclipse/tractusx/edc/api/edr/EdrApiExtensionTest.java
+++ b/edc-extensions/edr/edr-api/src/test/java/org/eclipse/tractusx/edc/api/edr/EdrApiExtensionTest.java
@@ -44,18 +44,16 @@ public class EdrApiExtensionTest {
     private final ManagementApiTypeTransformerRegistry transformerRegistry = mock();
     private final WebService webService = mock(WebService.class);
     private final ManagementApiConfiguration configuration = mock(ManagementApiConfiguration.class);
-    private EdrApiExtension extension;
 
     @BeforeEach
     void setUp(ObjectFactory factory, ServiceExtensionContext context) {
         context.registerService(WebService.class, webService);
         context.registerService(ManagementApiTypeTransformerRegistry.class, transformerRegistry);
         context.registerService(ManagementApiConfiguration.class, configuration);
-        extension = factory.constructInstance(EdrApiExtension.class);
     }
 
     @Test
-    void initialize_ShouldConfigureTheController(ServiceExtensionContext context) {
+    void initialize_ShouldConfigureTheController(ServiceExtensionContext context, EdrApiExtension extension) {
         var alias = "context";
 
         when(configuration.getContextAlias()).thenReturn(alias);

--- a/edc-extensions/edr/edr-callback/src/test/java/org/eclipse/tractusx/edc/callback/InProcessCallbackRegistryExtensionTest.java
+++ b/edc-extensions/edr/edr-callback/src/test/java/org/eclipse/tractusx/edc/callback/InProcessCallbackRegistryExtensionTest.java
@@ -21,8 +21,6 @@ package org.eclipse.tractusx.edc.callback;
 
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.system.injection.ObjectFactory;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -31,16 +29,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(DependencyInjectionExtension.class)
 public class InProcessCallbackRegistryExtensionTest {
 
-    InProcessCallbackRegistryExtension extension;
-
-
-    @BeforeEach
-    void setUp(ObjectFactory factory, ServiceExtensionContext context) {
-        extension = factory.constructInstance(InProcessCallbackRegistryExtension.class);
-    }
-
     @Test
-    void shouldInitializeTheExtension(ServiceExtensionContext context) {
+    void shouldInitializeTheExtension(ServiceExtensionContext context, InProcessCallbackRegistryExtension extension) {
         assertThat(extension.callbackRegistry()).isInstanceOf(InProcessCallbackRegistryImpl.class);
     }
 }

--- a/edc-extensions/edr/edr-callback/src/test/java/org/eclipse/tractusx/edc/callback/LocalCallbackExtensionTest.java
+++ b/edc-extensions/edr/edr-callback/src/test/java/org/eclipse/tractusx/edc/callback/LocalCallbackExtensionTest.java
@@ -24,7 +24,6 @@ import org.eclipse.edc.connector.spi.callback.CallbackProtocolResolverRegistry;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.system.injection.ObjectFactory;
 import org.eclipse.tractusx.edc.spi.callback.InProcessCallback;
 import org.eclipse.tractusx.edc.spi.callback.InProcessCallbackRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,8 +40,6 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(DependencyInjectionExtension.class)
 public class LocalCallbackExtensionTest {
 
-    LocalCallbackExtension extension;
-
     RemoteMessageDispatcherRegistry dispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
 
     CallbackProtocolResolverRegistry resolverRegistry = mock(CallbackProtocolResolverRegistry.class);
@@ -50,16 +47,15 @@ public class LocalCallbackExtensionTest {
     InProcessCallbackRegistry inProcessCallbackRegistry = mock(InProcessCallbackRegistry.class);
 
     @BeforeEach
-    void setUp(ObjectFactory factory, ServiceExtensionContext context) {
+    void setUp(ServiceExtensionContext context) {
 
         context.registerService(RemoteMessageDispatcherRegistry.class, dispatcherRegistry);
         context.registerService(CallbackProtocolResolverRegistry.class, resolverRegistry);
         context.registerService(InProcessCallbackRegistry.class, inProcessCallbackRegistry);
-        extension = factory.constructInstance(LocalCallbackExtension.class);
     }
 
     @Test
-    void shouldInitializeTheExtension(ServiceExtensionContext context) {
+    void shouldInitializeTheExtension(ServiceExtensionContext context, LocalCallbackExtension extension) {
         extension.initialize(context);
 
         var captor = ArgumentCaptor.forClass(CallbackProtocolResolver.class);

--- a/edc-extensions/ssi/ssi-identity-core/src/test/java/org/eclipse/tractusx/edc/iam/ssi/identity/SsiIdentityServiceExtensionTest.java
+++ b/edc-extensions/ssi/ssi-identity-core/src/test/java/org/eclipse/tractusx/edc/iam/ssi/identity/SsiIdentityServiceExtensionTest.java
@@ -23,7 +23,6 @@ import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
-import org.eclipse.edc.spi.system.injection.ObjectFactory;
 import org.eclipse.tractusx.edc.iam.ssi.spi.SsiCredentialClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,17 +39,13 @@ public class SsiIdentityServiceExtensionTest {
 
     SsiIdentityServiceExtension extension;
 
-    ServiceExtensionContext context;
-
     @BeforeEach
-    void setup(ObjectFactory factory, ServiceExtensionContext context) {
-        this.context = context;
+    void setup(ServiceExtensionContext context) {
         context.registerService(SsiCredentialClient.class, mock(SsiCredentialClient.class));
-        extension = factory.constructInstance(SsiIdentityServiceExtension.class);
     }
 
     @Test
-    void initialize() {
+    void initialize(ServiceExtensionContext context, SsiIdentityServiceExtension extension) {
         var cfg = mock(Config.class);
         when(context.getConfig()).thenReturn(cfg);
         when(cfg.getString(ENDPOINT_AUDIENCE)).thenReturn("test");

--- a/edc-extensions/ssi/ssi-identity-extractor/src/test/java/org/eclipse/tractusx/edc/iam/ssi/identity/extractor/SsiIdentityExtractorExtensionTest.java
+++ b/edc-extensions/ssi/ssi-identity-extractor/src/test/java/org/eclipse/tractusx/edc/iam/ssi/identity/extractor/SsiIdentityExtractorExtensionTest.java
@@ -22,7 +22,6 @@ package org.eclipse.tractusx.edc.iam.ssi.identity.extractor;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.agent.ParticipantAgentService;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.system.injection.ObjectFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,18 +33,15 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(DependencyInjectionExtension.class)
 public class SsiIdentityExtractorExtensionTest {
 
-    SsiIdentityExtractorExtension extension;
-
     ParticipantAgentService participantAgentService = mock(ParticipantAgentService.class);
 
     @BeforeEach
-    void setup(ObjectFactory factory, ServiceExtensionContext context) {
+    void setup(ServiceExtensionContext context) {
         context.registerService(ParticipantAgentService.class, participantAgentService);
-        extension = factory.constructInstance(SsiIdentityExtractorExtension.class);
     }
 
     @Test
-    void initialize(ServiceExtensionContext context) {
+    void initialize(ServiceExtensionContext context, SsiIdentityExtractorExtension extension) {
         extension.initialize(context);
         verify(participantAgentService).register(isA(CredentialIdentityExtractor.class));
     }

--- a/edc-extensions/ssi/ssi-miw-credential-client/src/test/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwApiClientExtensionTest.java
+++ b/edc-extensions/ssi/ssi-miw-credential-client/src/test/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwApiClientExtensionTest.java
@@ -21,7 +21,6 @@ package org.eclipse.tractusx.edc.iam.ssi.miw;
 
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.system.injection.ObjectFactory;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.tractusx.edc.iam.ssi.miw.api.MiwApiClient;
 import org.eclipse.tractusx.edc.iam.ssi.miw.api.MiwApiClientImpl;
@@ -39,18 +38,16 @@ import static org.mockito.Mockito.when;
 public class SsiMiwApiClientExtensionTest {
 
     private final SsiMiwConfiguration cfg = mock(SsiMiwConfiguration.class);
-    private SsiMiwApiClientExtension extension;
 
     @BeforeEach
-    void setup(ObjectFactory factory, ServiceExtensionContext context) {
+    void setup(ServiceExtensionContext context) {
         context.registerService(SsiMiwConfiguration.class, cfg);
         context.registerService(MiwApiClient.class, mock(MiwApiClient.class));
         context.registerService(TypeManager.class, new TypeManager());
-        extension = factory.constructInstance(SsiMiwApiClientExtension.class);
     }
 
     @Test
-    void initialize(ServiceExtensionContext context) {
+    void initialize(ServiceExtensionContext context, SsiMiwApiClientExtension extension) {
         when(cfg.getUrl()).thenReturn("http://localhost");
         when(cfg.getAuthorityId()).thenReturn("id");
 

--- a/edc-extensions/ssi/ssi-miw-credential-client/src/test/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwConfigurationExtensionTest.java
+++ b/edc-extensions/ssi/ssi-miw-credential-client/src/test/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwConfigurationExtensionTest.java
@@ -22,8 +22,6 @@ package org.eclipse.tractusx.edc.iam.ssi.miw;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
-import org.eclipse.edc.spi.system.injection.ObjectFactory;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -42,18 +40,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(DependencyInjectionExtension.class)
 public class SsiMiwConfigurationExtensionTest {
 
-    private SsiMiwConfigurationExtension extension;
-
-    private ServiceExtensionContext context;
-
-    @BeforeEach
-    void setup(ObjectFactory factory, ServiceExtensionContext context) {
-        this.context = context;
-        extension = factory.constructInstance(SsiMiwConfigurationExtension.class);
-    }
-
     @Test
-    void initialize() {
+    void initialize(ServiceExtensionContext context, SsiMiwConfigurationExtension extension) {
         var url = "http://localhost:8080";
         var authorityId = "id";
         var authorityIssuer = "issuer";
@@ -78,7 +66,7 @@ public class SsiMiwConfigurationExtensionTest {
     }
 
     @Test
-    void initialize_withDefaultIssuer() {
+    void initialize_withDefaultIssuer(ServiceExtensionContext context, SsiMiwConfigurationExtension extension) {
         var url = "http://localhost:8080";
         var authorityId = "id";
 
@@ -102,7 +90,7 @@ public class SsiMiwConfigurationExtensionTest {
     }
 
     @Test
-    void initialize_withTrailingUrl() {
+    void initialize_withTrailingUrl(ServiceExtensionContext context, SsiMiwConfigurationExtension extension) {
         var url = "http://localhost:8080/";
         var authorityId = "id";
 

--- a/edc-extensions/ssi/ssi-miw-credential-client/src/test/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwCredentialClientExtensionTest.java
+++ b/edc-extensions/ssi/ssi-miw-credential-client/src/test/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwCredentialClientExtensionTest.java
@@ -21,7 +21,6 @@ package org.eclipse.tractusx.edc.iam.ssi.miw;
 
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.system.injection.ObjectFactory;
 import org.eclipse.tractusx.edc.iam.ssi.miw.api.MiwApiClient;
 import org.eclipse.tractusx.edc.iam.ssi.miw.credentials.SsiMiwCredentialClient;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,13 +36,12 @@ public class SsiMiwCredentialClientExtensionTest {
     SsiMiwCredentialClientExtension extension;
 
     @BeforeEach
-    void setup(ObjectFactory factory, ServiceExtensionContext context) {
+    void setup(ServiceExtensionContext context) {
         context.registerService(MiwApiClient.class, mock(MiwApiClient.class));
-        extension = factory.constructInstance(SsiMiwCredentialClientExtension.class);
     }
 
     @Test
-    void initialize() {
+    void initialize(SsiMiwCredentialClientExtension extension) {
         assertThat(extension.credentialVerifier()).isInstanceOf(SsiMiwCredentialClient.class);
     }
 

--- a/edc-extensions/ssi/ssi-miw-credential-client/src/test/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwOauth2ClientExtensionTest.java
+++ b/edc-extensions/ssi/ssi-miw-credential-client/src/test/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwOauth2ClientExtensionTest.java
@@ -24,7 +24,6 @@ import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
-import org.eclipse.edc.spi.system.injection.ObjectFactory;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.tractusx.edc.iam.ssi.miw.api.MiwApiClient;
 import org.eclipse.tractusx.edc.iam.ssi.miw.oauth2.MiwOauth2ClientConfiguration;
@@ -44,23 +43,17 @@ import static org.mockito.Mockito.when;
 @ExtendWith(DependencyInjectionExtension.class)
 public class SsiMiwOauth2ClientExtensionTest {
 
-    SsiMiwOauth2ClientExtension extension;
-
-    ServiceExtensionContext context;
-
     Vault vault = mock(Vault.class);
 
     @BeforeEach
-    void setup(ObjectFactory factory, ServiceExtensionContext context) {
-        this.context = context;
+    void setup(ServiceExtensionContext context) {
         context.registerService(MiwApiClient.class, mock(MiwApiClient.class));
         context.registerService(TypeManager.class, new TypeManager());
         context.registerService(Vault.class, vault);
-        extension = factory.constructInstance(SsiMiwOauth2ClientExtension.class);
     }
 
     @Test
-    void initialize() {
+    void initialize(ServiceExtensionContext context, SsiMiwOauth2ClientExtension extension) {
         var config = mock(Config.class);
         when(context.getConfig()).thenReturn(config);
         when(config.getString(TOKEN_URL)).thenReturn("url");
@@ -76,7 +69,7 @@ public class SsiMiwOauth2ClientExtensionTest {
     }
 
     @Test
-    void initialize_withTrailingUrl() {
+    void initialize_withTrailingUrl(ServiceExtensionContext context, SsiMiwOauth2ClientExtension extension) {
         var config = mock(Config.class);
         when(context.getConfig()).thenReturn(config);
         when(config.getString(TOKEN_URL)).thenReturn("http://localhost:8080/");

--- a/edc-extensions/ssi/ssi-miw-credential-client/src/test/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwValidationRuleExtensionTest.java
+++ b/edc-extensions/ssi/ssi-miw-credential-client/src/test/java/org/eclipse/tractusx/edc/iam/ssi/miw/SsiMiwValidationRuleExtensionTest.java
@@ -21,7 +21,6 @@ package org.eclipse.tractusx.edc.iam.ssi.miw;
 
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.system.injection.ObjectFactory;
 import org.eclipse.edc.token.spi.TokenValidationRulesRegistry;
 import org.eclipse.tractusx.edc.iam.ssi.miw.config.SsiMiwConfiguration;
 import org.eclipse.tractusx.edc.iam.ssi.miw.rule.SsiCredentialIssuerValidationRule;
@@ -42,17 +41,15 @@ public class SsiMiwValidationRuleExtensionTest {
 
     private final TokenValidationRulesRegistry registry = mock(TokenValidationRulesRegistry.class);
     private final SsiMiwConfiguration cfg = mock(SsiMiwConfiguration.class);
-    private SsiMiwValidationRuleExtension extension;
 
     @BeforeEach
-    void setup(ObjectFactory factory, ServiceExtensionContext context) {
+    void setup(ServiceExtensionContext context) {
         context.registerService(SsiMiwConfiguration.class, cfg);
         context.registerService(TokenValidationRulesRegistry.class, registry);
-        extension = factory.constructInstance(SsiMiwValidationRuleExtension.class);
     }
 
     @Test
-    void initialize(ServiceExtensionContext context) {
+    void initialize(ServiceExtensionContext context, SsiMiwValidationRuleExtension extension) {
         when(cfg.getAuthorityIssuer()).thenReturn("issuer");
 
         extension.initialize(context);


### PR DESCRIPTION
## WHAT

This PR introduces a refactorization of service extesion tests to remove unecessary instantiations of the ServiceExtensionContext and ObjectFactory.

## WHY

Refactor.

Closes #972
