### PR TITLE
Revert "chore(deps): bump aquasecurity/trivy-action from 0.12.0 to 0.17.0"

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.17.0
+        uses: aquasecurity/trivy-action@0.12.0
         with:
           scan-type: "config"
           # ignore-unfixed: true
@@ -102,7 +102,7 @@ jobs:
         ## the next two steps will only execute if the image exists check was successful
       - name: Run Trivy vulnerability scanner
         if: success() && steps.imageCheck.outcome != 'failure'
-        uses: aquasecurity/trivy-action@0.17.0
+        uses: aquasecurity/trivy-action@0.12.0
         with:
           image-ref: "tractusx/${{ matrix.image }}:sha-${{ needs.git-sha7.outputs.value }}"
           format: "sarif"


### PR DESCRIPTION
Reverts eclipse-tractusx/tractusx-edc#1031

Seems that 0.17.0 has some issue
https://github.com/eclipse-tractusx/tractusx-edc/actions/runs/7828940383