### PR TITLE
improvement(memory-edc): remove EDC_VAULT_SECRETS rewrite

### DIFF
--- a/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
+++ b/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
@@ -252,7 +252,7 @@ spec:
             ###########
 
             # see extension https://github.com/eclipse-tractusx/tractusx-edc/tree/develop/edc-extensions/hashicorp-vault
-            - name: "SECRETS"
+            - name: "EDC_VAULT_SECRETS"
               value: {{ .Values.vault.secrets | quote}}
 
             #####################

--- a/charts/tractusx-connector-memory/values.yaml
+++ b/charts/tractusx-connector-memory/values.yaml
@@ -18,7 +18,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 #################################################################################
 
-
 ---
 # Default values for eclipse-dataspace-connector.
 # This is a YAML-formatted file.
@@ -289,7 +288,7 @@ runtime:
     public: ""
     readiness: ""
 vault:
-  # secrets can be seeded by supplying them in a comma separated list key1:secret2,key2:secret2
+  # secrets can be seeded by supplying them in a semicolon separated list key1:secret2;key2:secret2
   secrets: ""
   secretNames:
     transferProxyTokenEncryptionAesKey: transfer-proxy-token-encryption-aes-key

--- a/edc-controlplane/edc-runtime-memory/README.md
+++ b/edc-controlplane/edc-runtime-memory/README.md
@@ -30,7 +30,7 @@ extension. When in doubt, check the extensions' README that will likely be in [t
 
 ```shell
 docker run \
-    -e SECRETS="key1:secret1,key2:secret2" \
+    -e SECRETS="key1:secret1;key2:secret2" \
     -p 8080:8080 -p 8181:8181 -p 8282:8282 -p 9090:9090 -p 9999:9999 \
     -v ${CONFIGURATION_PROPERTIES_FILE:-/dev/null}:/app/configuration.properties \
     -v ${LOGGING_PROPERTIES_FILE:-/dev/null}:/app/logging.properties \

--- a/edc-controlplane/edc-runtime-memory/README.md
+++ b/edc-controlplane/edc-runtime-memory/README.md
@@ -30,7 +30,7 @@ extension. When in doubt, check the extensions' README that will likely be in [t
 
 ```shell
 docker run \
-    -e SECRETS="key1:secret1;key2:secret2" \
+    -e EDC_VAULT_SECRETS="key1:secret1;key2:secret2" \
     -p 8080:8080 -p 8181:8181 -p 8282:8282 -p 9090:9090 -p 9999:9999 \
     -v ${CONFIGURATION_PROPERTIES_FILE:-/dev/null}:/app/configuration.properties \
     -v ${LOGGING_PROPERTIES_FILE:-/dev/null}:/app/logging.properties \

--- a/edc-controlplane/edc-runtime-memory/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-runtime-memory/src/main/docker/Dockerfile
@@ -47,6 +47,5 @@ COPY ${ADDITIONAL_FILES} ./
 
 HEALTHCHECK NONE
 
-# need the sh -c syntax so that the SECRETS variable gets expanded
 # use the "exec" syntax so that SIGINT reaches the JVM -> graceful termination
-CMD ["sh", "-c", "exec java -Dedc.fs.config=/app/configuration.properties -Dedc.vault.secrets=\"${SECRETS}\" -Djava.util.logging.config.file=/app/logging.properties -Djava.security.egd=file:/dev/urandom -jar edc-controlplane.jar"]
+CMD ["sh", "-c", "exec java -Dedc.fs.config=/app/configuration.properties -Djava.util.logging.config.file=/app/logging.properties -Djava.security.egd=file:/dev/urandom -jar edc-controlplane.jar"]


### PR DESCRIPTION
## WHAT

Removes the rewrite of ENV variable "SECRETS" to edc.vault.secrets and instead uses the EDC_VAULT_SECRETS directly in the memory chart and Dockerfile.

## WHY

With the current setup, this is the only ENV variable, that is rewritten. While checking the documentation of the edc components, this rewrite is not apparent. In short: I don't see any reason for it, except potential confusion.


## FURTHER NOTES

Also fixes the documentation regarding the seeding of secrets with semicolon separated k:v list

Closes #1039
