### PR TITLE
chore: make license header regex more permissive

### DIFF
--- a/resources/hashtag.header
+++ b/resources/hashtag.header
@@ -1,5 +1,5 @@
 ^#!
-^##{80}$
+^##+$
 ^#  Copyright \(c\) 20\d\d((,| -)20\d{2})? [A-Za-z].+\S$
 ^#$
 ^#  See the NOTICE file\(s\) distributed with this work for additional$
@@ -16,5 +16,5 @@
 ^#  under the License\.$
 ^#$
 ^#  SPDX-License-Identifier: Apache\-2\.0$
-^##{80}$
+^##+$
 ^$

--- a/resources/java.header
+++ b/resources/java.header
@@ -1,4 +1,4 @@
-^/\*{80}$
+^/\*+$
 ^ \* Copyright \(c\) 20\d\d((,| -)20\d{2})? [A-Za-z].+\S$
 ^ \*$
 ^ \* See the NOTICE file\(s\) distributed with this work for additional$
@@ -15,6 +15,6 @@
 ^ \* under the License\.$
 ^ \*$
 ^ \* SPDX-License-Identifier: Apache\-2\.0$
-^ \*{80}/$
+^ \*+/$
 ^$
 ^package


### PR DESCRIPTION
## WHAT

This PR changes the Checkstyle slightly. Previously it required the license header to be wrapped in 
multi-line comments, with a leading and trailing line of 80 `"*"` characters.

This has been reduced to require only a valid multi-line comment.

## WHY

IntelliJ has a feature to automatically add license headers, but it can't add the asterisk-line, which would cause
it to generate invalid license headers.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
