### PR TITLE
feat: add Dismantler constraint eval function

### DIFF
--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDynamicConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDynamicConstraintFunction.java
@@ -1,23 +1,21 @@
-/*
+/********************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
- *   Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *   See the NOTICE file(s) distributed with this work for additional
- *   information regarding copyright ownership.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *   This program and the accompanying materials are made available under the
- *   terms of the Apache License, Version 2.0 which is available at
- *   https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- *   License for the specific language governing permissions and limitations
- *   under the License.
- *
- *   SPDX-License-Identifier: Apache-2.0
- *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 package org.eclipse.tractusx.edc.policy.cx.common;
 

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDynamicConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDynamicConstraintFunction.java
@@ -47,7 +47,7 @@ public abstract class AbstractDynamicConstraintFunction implements DynamicAtomic
 
     protected boolean checkOperator(Operator actual, PolicyContext context, Collection<Operator> expectedOperators) {
         if (!expectedOperators.contains(actual)) {
-            context.reportProblem("Invalid operator: this constraint only allows the following operators: %s, but got '%s'.".formatted(EQUALITY_OPERATORS, actual));
+            context.reportProblem("Invalid operator: this constraint only allows the following operators: %s, but received '%s'.".formatted(EQUALITY_OPERATORS, actual));
             return false;
         }
         return true;
@@ -64,7 +64,7 @@ public abstract class AbstractDynamicConstraintFunction implements DynamicAtomic
             return Result.failure("ParticipantAgent did not contain a '%s' claim.".formatted(VC_CLAIM));
         }
         if (!(vcListClaim instanceof List)) {
-            return Result.failure("ParticipantAgent contains a '%s' claim, but the type is incorrect. Expected %s, got %s.".formatted(VC_CLAIM, List.class.getName(), vcListClaim.getClass().getName()));
+            return Result.failure("ParticipantAgent contains a '%s' claim, but the type is incorrect. Expected %s, received %s.".formatted(VC_CLAIM, List.class.getName(), vcListClaim.getClass().getName()));
         }
         var vcList = (List<VerifiableCredential>) vcListClaim;
         if (vcList.isEmpty()) {

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDynamicConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDynamicConstraintFunction.java
@@ -31,6 +31,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * This is a base class for dynamically bound Tractus-X constraint evaluation functions that implements some basic common functionality and defines some
+ * common constants
+ */
 public abstract class AbstractDynamicConstraintFunction implements DynamicAtomicConstraintFunction<Permission> {
     public static final String VC_CLAIM = "vc";
     public static final String ACTIVE = "active";

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDynamicConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDynamicConstraintFunction.java
@@ -1,0 +1,74 @@
+/*
+ *
+ *   Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ *
+ *   See the NOTICE file(s) distributed with this work for additional
+ *   information regarding copyright ownership.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Apache License, Version 2.0 which is available at
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *   License for the specific language governing permissions and limitations
+ *   under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.common;
+
+import org.eclipse.edc.identitytrust.model.VerifiableCredential;
+import org.eclipse.edc.policy.engine.spi.DynamicAtomicConstraintFunction;
+import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.agent.ParticipantAgent;
+import org.eclipse.edc.spi.result.Result;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+public abstract class AbstractDynamicConstraintFunction implements DynamicAtomicConstraintFunction<Permission> {
+    public static final String VC_CLAIM = "vc";
+    public static final String ACTIVE = "active";
+    public static final String CREDENTIAL_LITERAL = "Credential";
+    protected static final Collection<Operator> EQUALITY_OPERATORS = List.of(Operator.EQ, Operator.NEQ);
+
+    protected boolean checkOperator(Operator actual, PolicyContext context, Operator... expectedOperators) {
+        return checkOperator(actual, context, Arrays.asList(expectedOperators));
+    }
+
+    protected boolean checkOperator(Operator actual, PolicyContext context, Collection<Operator> expectedOperators) {
+        if (!expectedOperators.contains(actual)) {
+            context.reportProblem("Invalid operator: this constraint only allows the following operators: %s, but got '%s'.".formatted(EQUALITY_OPERATORS, actual));
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Extracts a {@link List} of {@link VerifiableCredential} objects from the {@link ParticipantAgent}. Credentials must be
+     * stored in the agent's claims map using the "vc" key.
+     */
+    protected Result<List<VerifiableCredential>> getCredentialList(ParticipantAgent agent) {
+        var vcListClaim = agent.getClaims().get(VC_CLAIM);
+
+        if (vcListClaim == null) {
+            return Result.failure("ParticipantAgent did not contain a '%s' claim.".formatted(VC_CLAIM));
+        }
+        if (!(vcListClaim instanceof List)) {
+            return Result.failure("ParticipantAgent contains a '%s' claim, but the type is incorrect. Expected %s, got %s.".formatted(VC_CLAIM, List.class.getName(), vcListClaim.getClass().getName()));
+        }
+        var vcList = (List<VerifiableCredential>) vcListClaim;
+        if (vcList.isEmpty()) {
+            return Result.failure("ParticipantAgent contains a '%s' claim but it did not contain any VerifiableCredentials.".formatted(VC_CLAIM));
+        }
+        return Result.success(vcList);
+    }
+
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/CredentialTypePredicate.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/CredentialTypePredicate.java
@@ -1,23 +1,21 @@
-/*
+/********************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
- *   Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *   See the NOTICE file(s) distributed with this work for additional
- *   information regarding copyright ownership.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *   This program and the accompanying materials are made available under the
- *   terms of the Apache License, Version 2.0 which is available at
- *   https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- *   License for the specific language governing permissions and limitations
- *   under the License.
- *
- *   SPDX-License-Identifier: Apache-2.0
- *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 package org.eclipse.tractusx.edc.policy.cx.common;
 

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/CredentialTypePredicate.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/CredentialTypePredicate.java
@@ -1,0 +1,39 @@
+/*
+ *
+ *   Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ *
+ *   See the NOTICE file(s) distributed with this work for additional
+ *   information regarding copyright ownership.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Apache License, Version 2.0 which is available at
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *   License for the specific language governing permissions and limitations
+ *   under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.common;
+
+import org.eclipse.edc.identitytrust.model.VerifiableCredential;
+
+import java.util.function.Predicate;
+
+public class CredentialTypePredicate implements Predicate<VerifiableCredential> {
+    private final String expectedType;
+
+    public CredentialTypePredicate(String expectedType) {
+        this.expectedType = expectedType;
+    }
+
+    @Override
+    public boolean test(VerifiableCredential credential) {
+        return credential.getTypes().contains(expectedType);
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/dismantler/DismantlerConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/dismantler/DismantlerConstraintFunction.java
@@ -1,0 +1,165 @@
+/********************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.policy.cx.dismantler;
+
+import org.eclipse.edc.identitytrust.model.VerifiableCredential;
+import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.agent.ParticipantAgent;
+import org.eclipse.tractusx.edc.policy.cx.common.AbstractDynamicConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.common.CredentialTypePredicate;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.Predicate;
+
+import static org.eclipse.edc.policy.model.Operator.EQ;
+import static org.eclipse.edc.policy.model.Operator.IN;
+import static org.eclipse.edc.policy.model.Operator.IS_ANY_OF;
+import static org.eclipse.edc.policy.model.Operator.IS_NONE_OF;
+import static org.eclipse.edc.policy.model.Operator.NEQ;
+import static org.eclipse.tractusx.edc.iam.ssi.spi.jsonld.CredentialsNamespaces.CX_NS_1_0;
+
+public class DismantlerConstraintFunction extends AbstractDynamicConstraintFunction {
+
+    public static final String ALLOWED_VEHICLE_BRANDS = CX_NS_1_0 + "allowedVehicleBrands";
+    private static final String DISMANTLER_LITERAL = "Dismantler";
+    private static final String ALLOWED_ACTIVITIES = CX_NS_1_0 + "activityType";
+
+    @SuppressWarnings({ "SuspiciousMethodCalls" })
+    @Override
+    public boolean evaluate(Object leftOperand, Operator operator, Object rightOperand, Permission permission, PolicyContext context) {
+        Predicate<VerifiableCredential> predicate = c -> false;
+
+        // make sure the ParticipantAgent is there
+        var participantAgent = context.getContextData(ParticipantAgent.class);
+        if (participantAgent == null) {
+            context.reportProblem("Required PolicyContext data not found: " + ParticipantAgent.class.getName());
+            return false;
+        }
+
+        // check if the participant agent contains the correct data
+        var vcListResult = getCredentialList(participantAgent);
+        if (vcListResult.failed()) { // couldn't extract credential list from agent
+            context.reportProblem(vcListResult.getFailureDetail());
+            return false;
+        }
+
+        if (leftOperand.equals(DISMANTLER_LITERAL)) { // only checks for presence
+            if (!checkOperator(operator, context, EQUALITY_OPERATORS)) {
+                return false;
+            }
+            if (!ACTIVE.equals(rightOperand)) {
+                context.reportProblem("Right-operand must be equal to '%s', but was '%s'".formatted(ACTIVE, rightOperand));
+                return false;
+            }
+            predicate = new CredentialTypePredicate(DISMANTLER_LITERAL + CREDENTIAL_LITERAL);
+            if (operator == NEQ) {
+                predicate = predicate.negate();
+            }
+        } else if (leftOperand.equals(DISMANTLER_LITERAL + ".activityType")) {
+            if (rightOperand instanceof String) {
+                if (!checkOperator(operator, context, EQUALITY_OPERATORS)) {
+                    return false;
+                }
+            } else if (rightOperand instanceof Iterable<?>) {
+                if (!checkOperator(operator, context, List.of(EQ, NEQ, IN, IS_ANY_OF, IS_NONE_OF))) {
+                    return false;
+                }
+            } else {
+                context.reportProblem("Invalid right-operand type: expected String or List, but got: %s".formatted(rightOperand.getClass().getName()));
+                return false;
+            }
+
+            var allowedActivities = getList(rightOperand);
+            // the filter predicate is determined by the operator
+            predicate = credential -> credential.getCredentialSubject().stream().anyMatch(subject -> {
+                var activitiesFromCredential = getList(subject.getClaims().getOrDefault(ALLOWED_ACTIVITIES, List.of()));
+                return switch (operator) {
+                    case EQ -> activitiesFromCredential.equals(allowedActivities);
+                    case NEQ -> !activitiesFromCredential.equals(allowedActivities);
+                    case IN ->
+                            new HashSet<>(allowedActivities).containsAll(activitiesFromCredential); //IntelliJ says Hashset has better performance
+                    case IS_ANY_OF -> !intersect(allowedActivities, activitiesFromCredential).isEmpty();
+                    case IS_NONE_OF -> intersect(allowedActivities, activitiesFromCredential).isEmpty();
+                    default -> false;
+                };
+            });
+
+        } else if (leftOperand.equals(DISMANTLER_LITERAL + ".allowedBrands")) {
+            if (rightOperand instanceof String) {
+                if (!checkOperator(operator, context, EQUALITY_OPERATORS)) {
+                    return false;
+                }
+            } else if (rightOperand instanceof Iterable<?>) {
+                if (!checkOperator(operator, context, List.of(EQ, NEQ, IN, IS_ANY_OF, IS_NONE_OF))) {
+                    return false;
+                }
+            } else {
+                context.reportProblem("Invalid right-operand type: expected String or List, but got: %s".formatted(rightOperand.getClass().getName()));
+                return false;
+            }
+
+            var allowedBrands = getList(rightOperand);
+
+            // the filter predicate is determined by the operator
+            predicate = credential -> credential.getCredentialSubject().stream().anyMatch(subject -> {
+                var brandsFromCredential = getList(subject.getClaims().getOrDefault(ALLOWED_VEHICLE_BRANDS, List.of()));
+                return switch (operator) {
+                    case EQ -> brandsFromCredential.equals(allowedBrands);
+                    case NEQ -> !brandsFromCredential.equals(allowedBrands);
+                    case IN ->
+                            new HashSet<>(allowedBrands).containsAll(brandsFromCredential); //IntelliJ says Hashset has better performance
+                    case IS_ANY_OF -> !intersect(allowedBrands, brandsFromCredential).isEmpty();
+                    case IS_NONE_OF -> intersect(allowedBrands, brandsFromCredential).isEmpty();
+                    default -> false;
+                };
+            });
+        } else {
+            context.reportProblem("Invalid left-operand: must be 'Dismantler[.activityType | .allowedBrands ], but was '%s'".formatted(leftOperand));
+            return false;
+        }
+
+
+        return !vcListResult.getContent().stream().filter(predicate)
+                .toList().isEmpty();
+    }
+
+    @Override
+    public boolean canHandle(Object leftOperand) {
+        return leftOperand instanceof String && ((String) leftOperand).startsWith(DISMANTLER_LITERAL);
+    }
+
+    private List<?> intersect(List<?> list1, List<?> list2) {
+        list1.retainAll(list2);
+        return list1;
+    }
+
+    private List<?> getList(Object object) {
+        if (object instanceof Iterable<?> iterable) {
+            var list = new ArrayList<>();
+            iterable.iterator().forEachRemaining(list::add);
+            return list;
+        }
+        return List.of(object);
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/dismantler/DismantlerConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/dismantler/DismantlerConstraintFunction.java
@@ -117,17 +117,17 @@ public class DismantlerConstraintFunction extends AbstractDynamicConstraintFunct
     @NotNull
     private Predicate<VerifiableCredential> getCredentialPredicate(String credentialSubjectProperty, Operator operator, Object rightOperand) {
         Predicate<VerifiableCredential> predicate;
-        var allowedActivities = getList(rightOperand);
+        var allowedValues = getList(rightOperand);
         // the filter predicate is determined by the operator
         predicate = credential -> credential.getCredentialSubject().stream().anyMatch(subject -> {
-            var activitiesFromCredential = getList(subject.getClaims().getOrDefault(credentialSubjectProperty, List.of()));
+            var claimsFromCredential = getList(subject.getClaims().getOrDefault(credentialSubjectProperty, List.of()));
             return switch (operator) {
-                case EQ -> activitiesFromCredential.equals(allowedActivities);
-                case NEQ -> !activitiesFromCredential.equals(allowedActivities);
+                case EQ -> claimsFromCredential.equals(allowedValues);
+                case NEQ -> !claimsFromCredential.equals(allowedValues);
                 case IN ->
-                        new HashSet<>(allowedActivities).containsAll(activitiesFromCredential); //IntelliJ says Hashset has better performance
-                case IS_ANY_OF -> !intersect(allowedActivities, activitiesFromCredential).isEmpty();
-                case IS_NONE_OF -> intersect(allowedActivities, activitiesFromCredential).isEmpty();
+                        new HashSet<>(allowedValues).containsAll(claimsFromCredential); //IntelliJ says Hashset has better performance
+                case IS_ANY_OF -> !intersect(allowedValues, claimsFromCredential).isEmpty();
+                case IS_NONE_OF -> intersect(allowedValues, claimsFromCredential).isEmpty();
                 default -> false;
             };
         });
@@ -144,7 +144,7 @@ public class DismantlerConstraintFunction extends AbstractDynamicConstraintFunct
         } else if (rightOperand instanceof Iterable<?>) {
             return !checkOperator(operator, context, List.of(EQ, NEQ, IN, IS_ANY_OF, IS_NONE_OF));
         } else {
-            context.reportProblem("Invalid right-operand type: expected String or List, but got: %s".formatted(rightOperand.getClass().getName()));
+            context.reportProblem("Invalid right-operand type: expected String or List, but received: %s".formatted(rightOperand.getClass().getName()));
             return true;
         }
     }

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/CredentialFunctions.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/CredentialFunctions.java
@@ -1,23 +1,21 @@
-/*
+/********************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
- *   Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *   See the NOTICE file(s) distributed with this work for additional
- *   information regarding copyright ownership.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *   This program and the accompanying materials are made available under the
- *   terms of the Apache License, Version 2.0 which is available at
- *   https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- *   License for the specific language governing permissions and limitations
- *   under the License.
- *
- *   SPDX-License-Identifier: Apache-2.0
- *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 package org.eclipse.tractusx.edc.policy.cx;
 

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/CredentialFunctions.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/CredentialFunctions.java
@@ -1,0 +1,77 @@
+/*
+ *
+ *   Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ *
+ *   See the NOTICE file(s) distributed with this work for additional
+ *   information regarding copyright ownership.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Apache License, Version 2.0 which is available at
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *   License for the specific language governing permissions and limitations
+ *   under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.eclipse.tractusx.edc.policy.cx;
+
+import org.eclipse.edc.identitytrust.model.CredentialSubject;
+import org.eclipse.edc.identitytrust.model.Issuer;
+import org.eclipse.edc.identitytrust.model.VerifiableCredential;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class CredentialFunctions {
+
+    public static VerifiableCredential.Builder createCredential(String type, String version) {
+        return VerifiableCredential.Builder.newInstance()
+                .types(List.of("VerifiableCredential", type))
+                .id(UUID.randomUUID().toString())
+                .issuer(new Issuer(UUID.randomUUID().toString(), Map.of("prop1", "val1")))
+                .expirationDate(Instant.now().plus(365, ChronoUnit.DAYS))
+                .issuanceDate(Instant.now())
+                .credentialSubject(CredentialSubject.Builder.newInstance()
+                        .id("subject-id")
+                        .claim("https://w3id.org/catenax/credentials/v1.0.0/holderIdentifier", "did:web:holder")
+                        .claim("https://w3id.org/catenax/credentials/v1.0.0/contractVersion", version)
+                        .claim("https://w3id.org/catenax/credentials/v1.0.0/contractTemplate", "https://public.catena-x.org/contracts/pcf.v1.pdf")
+                        .build());
+    }
+
+    public static VerifiableCredential.Builder createPcfCredential() {
+        return createCredential("PcfCredential", "1.0.0");
+    }
+
+    public static VerifiableCredential.Builder createDismantlerCredential(String... brands) {
+        return createDismantlerCredential(Arrays.asList(brands), "vehicleDismantle");
+    }
+
+    public static VerifiableCredential.Builder createDismantlerCredential(Collection<String> brands, String... activityType) {
+        var at = activityType.length == 1 ? activityType[0] : List.of(activityType);
+        return VerifiableCredential.Builder.newInstance()
+                .types(List.of("VerifiableCredential", "DismantlerCredential"))
+                .id(UUID.randomUUID().toString())
+                .issuer(new Issuer(UUID.randomUUID().toString(), Map.of("prop1", "val1")))
+                .expirationDate(Instant.now().plus(365, ChronoUnit.DAYS))
+                .issuanceDate(Instant.now())
+                .credentialSubject(CredentialSubject.Builder.newInstance()
+                        .id("subject-id")
+                        .claim("https://w3id.org/catenax/credentials/v1.0.0/holderIdentifier", "did:web:holder")
+                        .claim("https://w3id.org/catenax/credentials/v1.0.0/allowedVehicleBrands", brands)
+                        .claim("https://w3id.org/catenax/credentials/v1.0.0/activityType", at)
+                        .build());
+    }
+
+}

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/dismantler/DismantlerConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/dismantler/DismantlerConstraintFunctionTest.java
@@ -1,21 +1,21 @@
-/**
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
- * <p>
+/********************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
- * <p>
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations
  * under the License.
- * <p>
+ *
  * SPDX-License-Identifier: Apache-2.0
- */
+ ********************************************************************************/
 
 package org.eclipse.tractusx.edc.policy.cx.dismantler;
 

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/dismantler/DismantlerConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/dismantler/DismantlerConstraintFunctionTest.java
@@ -89,7 +89,7 @@ class DismantlerConstraintFunctionTest {
     void evaluate_vcClaimNotList() {
         when(participantAgent.getClaims()).thenReturn(Map.of("vc", new Object()));
         assertThat(function.evaluate("Dismantler", Operator.EQ, "active", null, context)).isFalse();
-        verify(context).reportProblem(eq("ParticipantAgent contains a 'vc' claim, but the type is incorrect. Expected java.util.List, got java.lang.Object."));
+        verify(context).reportProblem(eq("ParticipantAgent contains a 'vc' claim, but the type is incorrect. Expected java.util.List, received java.lang.Object."));
     }
 
     @Nested
@@ -259,7 +259,7 @@ class DismantlerConstraintFunctionTest {
 
             assertThat(illegalOp).allSatisfy(op -> {
                 assertThat(function.evaluate("Dismantler.allowedBrands", op, List.of("Gaz", "Moskvich"), null, context)).isFalse();
-                verify(context).reportProblem("Invalid operator: this constraint only allows the following operators: [EQ, NEQ], but got '%s'.".formatted(op));
+                verify(context).reportProblem("Invalid operator: this constraint only allows the following operators: [EQ, NEQ], but received '%s'.".formatted(op));
             });
         }
 
@@ -274,7 +274,7 @@ class DismantlerConstraintFunctionTest {
 
             assertThat(invalidOperators).allSatisfy(op -> {
                 assertThat(function.evaluate("Dismantler.allowedBrands", op, "Moskvich", null, context)).isFalse();
-                verify(context).reportProblem("Invalid operator: this constraint only allows the following operators: [EQ, NEQ], but got '%s'.".formatted(op));
+                verify(context).reportProblem("Invalid operator: this constraint only allows the following operators: [EQ, NEQ], but received '%s'.".formatted(op));
             });
         }
 
@@ -283,7 +283,7 @@ class DismantlerConstraintFunctionTest {
         void evaluate_righOpInvalidType() {
             when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Gaz", "Yugo").build())));
             assertThat(function.evaluate("Dismantler.allowedBrands", IN, Map.of("foo", "bar"), null, context)).isFalse();
-            verify(context).reportProblem(startsWith("Invalid right-operand type: expected String or List, but got:"));
+            verify(context).reportProblem(startsWith("Invalid right-operand type: expected String or List, but received:"));
         }
     }
 
@@ -425,7 +425,7 @@ class DismantlerConstraintFunctionTest {
 
             assertThat(invalidOperators).allSatisfy(op -> {
                 assertThat(function.evaluate("Dismantler.activityType", op, "vehicleDismantle", null, context)).isFalse();
-                verify(context).reportProblem("Invalid operator: this constraint only allows the following operators: [EQ, NEQ], but got '%s'.".formatted(op));
+                verify(context).reportProblem("Invalid operator: this constraint only allows the following operators: [EQ, NEQ], but received '%s'.".formatted(op));
             });
         }
 
@@ -434,7 +434,7 @@ class DismantlerConstraintFunctionTest {
         void evaluate_righOpInvalidType() {
             when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle").build())));
             assertThat(function.evaluate("Dismantler.activityType", IN, Map.of("foo", "bar"), null, context)).isFalse();
-            verify(context).reportProblem(startsWith("Invalid right-operand type: expected String or List, but got:"));
+            verify(context).reportProblem(startsWith("Invalid right-operand type: expected String or List, but received:"));
         }
     }
 }

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/dismantler/DismantlerConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/dismantler/DismantlerConstraintFunctionTest.java
@@ -1,0 +1,440 @@
+/**
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ * <p>
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * <p>
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.dismantler;
+
+import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.spi.agent.ParticipantAgent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.policy.model.Operator.IN;
+import static org.eclipse.tractusx.edc.policy.cx.CredentialFunctions.createDismantlerCredential;
+import static org.eclipse.tractusx.edc.policy.cx.CredentialFunctions.createPcfCredential;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DismantlerConstraintFunctionTest {
+
+    private final DismantlerConstraintFunction function = new DismantlerConstraintFunction();
+    private final PolicyContext context = mock();
+    private ParticipantAgent participantAgent;
+
+    @BeforeEach
+    void setup() {
+        participantAgent = mock(ParticipantAgent.class);
+        when(context.getContextData(eq(ParticipantAgent.class)))
+                .thenReturn(participantAgent);
+    }
+
+    @Test
+    void evaluate_leftOperandInvalid() {
+        when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Tatra", "Moskvich").build())));
+        assertThat(function.evaluate("foobar", Operator.EQ, "active", null, context)).isFalse();
+        verify(context).reportProblem(eq("Invalid left-operand: must be 'Dismantler[.activityType | .allowedBrands ], but was 'foobar'"));
+    }
+
+    @Test
+    void evaluate_noParticipantAgentOnContext() {
+        when(context.getContextData(eq(ParticipantAgent.class))).thenReturn(null);
+        assertThat(function.evaluate("Dismantler", Operator.EQ, "active", null, context)).isFalse();
+        verify(context).reportProblem("Required PolicyContext data not found: org.eclipse.edc.spi.agent.ParticipantAgent");
+    }
+
+    @Test
+    void evaluate_noVcClaimOnParticipantAgent() {
+        assertThat(function.evaluate("Dismantler", Operator.EQ, "active", null, context)).isFalse();
+        verify(context).reportProblem(eq("ParticipantAgent did not contain a 'vc' claim."));
+    }
+
+    @Test
+    void evaluate_vcClaimEmpty() {
+        when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of()));
+        assertThat(function.evaluate("Dismantler", Operator.EQ, "active", null, context)).isFalse();
+        verify(context).reportProblem(eq("ParticipantAgent contains a 'vc' claim but it did not contain any VerifiableCredentials."));
+    }
+
+    @Test
+    void evaluate_vcClaimNotList() {
+        when(participantAgent.getClaims()).thenReturn(Map.of("vc", new Object()));
+        assertThat(function.evaluate("Dismantler", Operator.EQ, "active", null, context)).isFalse();
+        verify(context).reportProblem(eq("ParticipantAgent contains a 'vc' claim, but the type is incorrect. Expected java.util.List, got java.lang.Object."));
+    }
+
+    @Nested
+    class Active {
+        @Test
+        void evaluate_eq_satisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Tatra", "Moskvich").build())));
+            assertThat(function.evaluate("Dismantler", Operator.EQ, "active", null, context)).isTrue();
+        }
+
+        @Test
+        void evaluate_eq_notSatisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createPcfCredential().build())));
+            assertThat(function.evaluate("Dismantler", Operator.EQ, "active", null, context)).isFalse();
+        }
+
+        @Test
+        void evaluate_neq_satisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createPcfCredential().build())));
+            assertThat(function.evaluate("Dismantler", Operator.NEQ, "active", null, context)).isTrue();
+        }
+
+        @Test
+        void evaluate_neq_notSatisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Yugo", "Tatra").build())));
+            assertThat(function.evaluate("Dismantler", Operator.NEQ, "active", null, context)).isFalse();
+        }
+
+        @Test
+        void evaluate_invalidOperators() {
+            var invalidOperators = new ArrayList<>(Arrays.asList(Operator.values()));
+            invalidOperators.remove(Operator.EQ);
+            invalidOperators.remove(Operator.NEQ);
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createPcfCredential().build())));
+
+            assertThat(invalidOperators).allSatisfy(invalidOperator -> assertThat(function.evaluate("Dismantler", invalidOperator, "active", null, context)).isFalse());
+
+        }
+
+        @Test
+        void evaluate_rightOperandInvalid() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createPcfCredential().build())));
+            assertThat(function.evaluate("Dismantler", Operator.EQ, "invalid", null, context)).isFalse();
+            verify(context).reportProblem("Right-operand must be equal to 'active', but was 'invalid'");
+        }
+    }
+
+    @Nested
+    class AllowedBrands {
+
+        @DisplayName("Constraint (list) must match credential EXACTLY")
+        @Test
+        void evaluate_eq_list() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Tatra", "Moskvich").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.EQ, List.of("Tatra", "Moskvich"), null, context)).isTrue();
+        }
+
+        @DisplayName("Constraint (list) must credential EXACTLY - failure")
+        @Test
+        void evaluate_eq_list_notSatisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Tatra", "Moskvich", "Lada").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.EQ, List.of("Tatra", "Moskvich"), null, context)).isFalse();
+            verify(context, never()).reportProblem(anyString());
+        }
+
+        @DisplayName("Constraint (scalar) must match credential EXACTLY")
+        @Test
+        void evaluate_eq_scalar() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Yugo").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.EQ, "Yugo", null, context)).isTrue();
+        }
+
+        @DisplayName("Constraint (scalar) must credential EXACTLY - failure")
+        @Test
+        void evaluate_eq_scalar_notSatisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Tatra").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.EQ, "Yugo", null, context)).isFalse();
+            verify(context, never()).reportProblem(anyString());
+        }
+
+        @DisplayName("Constraint and credential must be DISJOINT")
+        @Test
+        void evaluate_neq_satisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Tatra", "Moskvich").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.NEQ, List.of("Lada", "Yugo"), null, context)).isTrue();
+
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Tatra", "Moskvich", "Yugo", "Lada").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.NEQ, List.of("Lada", "Yugo"), null, context)).isTrue();
+        }
+
+        @DisplayName("Constraint and credential must be DISJOINT - failure")
+        @Test
+        void evaluate_neq_notSatisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Lada", "Yugo").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.NEQ, List.of("Lada", "Yugo"), null, context)).isFalse();
+        }
+
+        @DisplayName("Constraint and credential must INTERSECT")
+        @Test
+        void evaluate_isAnyOf_satisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Lada").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.IS_ANY_OF, List.of("Tatra", "Moskvich", "Lada"), null, context)).isTrue();
+
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Moskvich", "Tatra").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.IS_ANY_OF, List.of("Lada", "Moskvich"), null, context)).isTrue();
+        }
+
+        @DisplayName("Constraint and credential must INTERSECT - failure")
+        @Test
+        void evaluate_isAnyOf_notSatisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Gaz").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.IS_ANY_OF, List.of("Tatra", "Moskvich", "Lada"), null, context)).isFalse();
+
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Gaz", "Yugo").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.IS_ANY_OF, List.of("Tatra", "Moskvich", "Lada"), null, context)).isFalse();
+
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential().build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.IS_ANY_OF, List.of("Tatra", "Moskvich", "Lada"), null, context)).isFalse();
+
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Moskvich", "Tatra").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.IS_ANY_OF, List.of(), null, context)).isFalse();
+        }
+
+        @DisplayName("Constraint and credential must NOT INTERSECT")
+        @Test
+        void evaluate_isNoneOf_satisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Gaz", "Yugo").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.IS_NONE_OF, List.of("Tatra", "Moskvich", "Lada"), null, context)).isTrue();
+
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Gaz", "Yugo").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.IS_NONE_OF, List.of(), null, context)).isTrue();
+
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential().build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.IS_NONE_OF, List.of("Tatra", "Moskvich", "Lada"), null, context)).isTrue();
+        }
+
+        @DisplayName("Constraint and credential must NOT INTERSECT - failure")
+        @Test
+        void evaluate_isNoneOf_notSatisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Gaz", "Yugo").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", Operator.IS_NONE_OF, List.of("Tatra", "Moskvich", "Yugo"), null, context)).isFalse();
+
+        }
+
+        @DisplayName("Brand list from credential must be FULLY CONTAINED within constraint")
+        @Test
+        void evaluate_in_satisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Gaz", "Yugo").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", IN, List.of("Gaz", "Moskvich", "Yugo", "Lada"), null, context)).isTrue();
+
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Gaz").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", IN, List.of("Gaz"), null, context)).isTrue();
+        }
+
+        @DisplayName("Brand list from credential must be FULLY CONTAINED within constraint - failure")
+        @Test
+        void evaluate_in_notSatisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Gaz", "Yugo").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", IN, List.of("Gaz", "Moskvich", "Yugo", "Lada"), null, context)).isTrue();
+        }
+
+        @DisplayName("Illegal operator when constraint contains a list value")
+        @Test
+        void evaluate_illegalOperator_constraintIsList() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Gaz", "Yugo").build())));
+            var illegalOp = List.of(Operator.HAS_PART, Operator.GEQ, Operator.LEQ, Operator.GT, Operator.LT, Operator.IS_ALL_OF);
+
+            assertThat(illegalOp).allSatisfy(op -> {
+                assertThat(function.evaluate("Dismantler.allowedBrands", op, List.of("Gaz", "Moskvich"), null, context)).isFalse();
+                verify(context).reportProblem("Invalid operator: this constraint only allows the following operators: [EQ, NEQ], but got '%s'.".formatted(op));
+            });
+        }
+
+        @DisplayName("Illegal operator when constraint contains a scalar value")
+        @Test
+        void evaluate_illegalOperator_constraintIsScalar() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Gaz", "Yugo").build())));
+
+            var invalidOperators = new ArrayList<>(Arrays.asList(Operator.values()));
+            invalidOperators.remove(Operator.EQ);
+            invalidOperators.remove(Operator.NEQ);
+
+            assertThat(invalidOperators).allSatisfy(op -> {
+                assertThat(function.evaluate("Dismantler.allowedBrands", op, "Moskvich", null, context)).isFalse();
+                verify(context).reportProblem("Invalid operator: this constraint only allows the following operators: [EQ, NEQ], but got '%s'.".formatted(op));
+            });
+        }
+
+        @DisplayName("Constraint right-operand has an invalid type")
+        @Test
+        void evaluate_righOpInvalidType() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential("Gaz", "Yugo").build())));
+            assertThat(function.evaluate("Dismantler.allowedBrands", IN, Map.of("foo", "bar"), null, context)).isFalse();
+            verify(context).reportProblem(startsWith("Invalid right-operand type: expected String or List, but got:"));
+        }
+    }
+
+    @Nested
+    class ActivityType {
+        private final Collection<String> brands = List.of("Tatra", "Yugo");
+
+        @DisplayName("Constraint (list) must match credential EXACTLY")
+        @Test
+        void evaluate_eq_list() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle", "vehicleScrap").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.EQ, List.of("vehicleDismantle", "vehicleScrap"), null, context)).isTrue();
+        }
+
+        @DisplayName("Constraint (list) must credential EXACTLY - failure")
+        @Test
+        void evaluate_eq_list_notSatisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle", "vehicleScrap").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.EQ, List.of("vehicleRefurbish"), null, context)).isFalse();
+            verify(context, never()).reportProblem(anyString());
+        }
+
+        @DisplayName("Constraint (scalar) must match credential EXACTLY")
+        @Test
+        void evaluate_eq_scalar() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.EQ, "vehicleDismantle", null, context)).isTrue();
+        }
+
+        @DisplayName("Constraint (scalar) must credential EXACTLY - failure")
+        @Test
+        void evaluate_eq_scalar_notSatisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.EQ, "vehicleScrap", null, context)).isFalse();
+            verify(context, never()).reportProblem(anyString());
+        }
+
+        @DisplayName("Constraint and credential must be DISJOINT")
+        @Test
+        void evaluate_neq_satisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.NEQ, "vehicleScrap", null, context)).isTrue();
+
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.NEQ, List.of("vehicleScrap", "vehicleRefurbish"), null, context)).isTrue();
+        }
+
+        @DisplayName("Constraint and credential must be DISJOINT - failure")
+        @Test
+        void evaluate_neq_notSatisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.NEQ, "vehicleDismantle", null, context)).isFalse();
+
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.NEQ, List.of("vehicleDismantle", "vehicleRefurbish"), null, context)).isTrue();
+        }
+
+        @DisplayName("Constraint and credential must INTERSECT")
+        @Test
+        void evaluate_isAnyOf_satisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle", "vehicleScrap").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.IS_ANY_OF, List.of("vehicleDismantle", "vehicleRefurbish"), null, context)).isTrue();
+        }
+
+        @DisplayName("Constraint and credential must INTERSECT - failure")
+        @Test
+        void evaluate_isAnyOf_notSatisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle", "vehicleScrap").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.IS_ANY_OF, List.of("vehicleCrush", "vehicleRefurbish"), null, context)).isFalse();
+
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle", "vehicleScrap").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.IS_ANY_OF, List.of(), null, context)).isFalse();
+
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands).build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.IS_ANY_OF, List.of("vehicleCrush", "vehicleRefurbish"), null, context)).isFalse();
+        }
+
+        @DisplayName("Constraint and credential must NOT INTERSECT")
+        @Test
+        void evaluate_isNoneOf_satisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle", "vehicleScrap").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.IS_NONE_OF, List.of("vehicleRefurbish"), null, context)).isTrue();
+
+
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle", "vehicleScrap").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.IS_NONE_OF, List.of(), null, context)).isTrue();
+
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands).build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.IS_NONE_OF, List.of("vehicleRefurbish"), null, context)).isTrue();
+        }
+
+        @DisplayName("Constraint and credential must NOT INTERSECT - failure")
+        @Test
+        void evaluate_isNoneOf_notSatisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle", "vehicleRefurbish").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.IS_NONE_OF, List.of("vehicleRefurbish"), null, context)).isFalse();
+        }
+
+        @DisplayName("Activity list from credential must be FULLY CONTAINED within constraint")
+        @Test
+        void evaluate_in_satisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleRefurbish").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.IN, List.of("vehicleRefurbish", "vehicleDismantle"), null, context)).isTrue();
+
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.IN, List.of("vehicleDismantle"), null, context)).isTrue();
+        }
+
+        @DisplayName("Activity list from credential must be FULLY CONTAINED within constraint - failure")
+        @Test
+        void evaluate_in_notSatisfied() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleRefurbish", "vehicleScrap").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.IN, List.of("vehicleRefurbish", "vehicleDismantle"), null, context)).isFalse();
+
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleScrap").build())));
+            assertThat(function.evaluate("Dismantler.activityType", Operator.IN, List.of("vehicleRefurbish", "vehicleDismantle"), null, context)).isFalse();
+
+        }
+
+        @DisplayName("Illegal operator when constraint contains a list value")
+        @Test
+        void evaluate_illegalOperator_constraintIsList() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle").build())));
+            var illegalOp = List.of(Operator.HAS_PART, Operator.GEQ, Operator.LEQ, Operator.GT, Operator.LT, Operator.IS_ALL_OF);
+
+            assertThat(illegalOp).allSatisfy(op -> {
+                assertThat(function.evaluate("Dismantler.activityType", op, List.of("vehicleDismantle"), null, context)).isFalse();
+            });
+        }
+
+        @DisplayName("Illegal operator when constraint contains a scalar value")
+        @Test
+        void evaluate_illegalOperator_constraintIsScalar() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle").build())));
+
+            var invalidOperators = new ArrayList<>(Arrays.asList(Operator.values()));
+            invalidOperators.remove(Operator.EQ);
+            invalidOperators.remove(Operator.NEQ);
+
+            assertThat(invalidOperators).allSatisfy(op -> {
+                assertThat(function.evaluate("Dismantler.activityType", op, "vehicleDismantle", null, context)).isFalse();
+                verify(context).reportProblem("Invalid operator: this constraint only allows the following operators: [EQ, NEQ], but got '%s'.".formatted(op));
+            });
+        }
+
+        @DisplayName("Constraint right-operand has an invalid type")
+        @Test
+        void evaluate_righOpInvalidType() {
+            when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of(createDismantlerCredential(brands, "vehicleDismantle").build())));
+            assertThat(function.evaluate("Dismantler.activityType", IN, Map.of("foo", "bar"), null, context)).isFalse();
+            verify(context).reportProblem(startsWith("Invalid right-operand type: expected String or List, but got:"));
+        }
+    }
+}

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/framework/FrameworkAgreementConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/framework/FrameworkAgreementConstraintFunctionTest.java
@@ -64,7 +64,7 @@ class FrameworkAgreementConstraintFunctionTest {
     @Test
     void evaluate_invalidOperator() {
         assertThat(function.evaluate("FrameworkAgreement.foobar", Operator.HAS_PART, "irrelevant", permission, context)).isFalse();
-        verify(context).reportProblem(eq("Invalid operator: this constraint only allows the following operators: [EQ, NEQ], but got 'HAS_PART'."));
+        verify(context).reportProblem(eq("Invalid operator: this constraint only allows the following operators: [EQ, NEQ], but received 'HAS_PART'."));
         verifyNoMoreInteractions(context);
     }
 
@@ -90,7 +90,7 @@ class FrameworkAgreementConstraintFunctionTest {
                 "vc", new Object()
         ));
         assertThat(function.evaluate("FrameworkAgreement.foobar", Operator.EQ, "active:0.0.1", permission, context)).isFalse();
-        verify(context).reportProblem(eq("ParticipantAgent contains a 'vc' claim, but the type is incorrect. Expected java.util.List, got java.lang.Object."));
+        verify(context).reportProblem(eq("ParticipantAgent contains a 'vc' claim, but the type is incorrect. Expected java.util.List, received java.lang.Object."));
     }
 
     @Test


### PR DESCRIPTION
## WHAT

This PR adds a Dismantler constraint evaluation function.

## WHY

Support for all required Tractus-X policy constraints

## FURTHER NOTES
- even though the spec only requires that `activityType` is a String, this evaluation function also supports it being a list-type.
- introduces a base class for dynamic constraint functions to share common functionality


Closes # <-- _insert Issue number if one exists_
