### PR TITLE
feat: add Token RefreshAPI to data plane

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -4,13 +4,18 @@ maven/mavencentral/com.apicatalog/iron-verifiable-credentials/0.8.1, Apache-2.0,
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.1, Apache-2.0, approved, #8912
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.3, Apache-2.0, approved, #8912
+maven/mavencentral/com.apicatalog/titanium-json-ld/1.4.0, , restricted, clearlydefined
 maven/mavencentral/com.azure/azure-core-http-netty/1.13.11, MIT AND Apache-2.0, approved, #7948
 maven/mavencentral/com.azure/azure-core-http-netty/1.14.0, MIT AND Apache-2.0, approved, #13238
+maven/mavencentral/com.azure/azure-core-http-netty/1.14.1, MIT AND Apache-2.0, approved, #13238
 maven/mavencentral/com.azure/azure-core/1.45.1, MIT AND Apache-2.0, approved, #11845
 maven/mavencentral/com.azure/azure-core/1.46.0, MIT AND Apache-2.0, approved, #13234
+maven/mavencentral/com.azure/azure-core/1.47.0, , restricted, clearlydefined
 maven/mavencentral/com.azure/azure-identity/1.11.2, MIT AND Apache-2.0, approved, #13237
+maven/mavencentral/com.azure/azure-identity/1.11.3, MIT AND Apache-2.0, approved, #13237
 maven/mavencentral/com.azure/azure-json/1.1.0, MIT AND Apache-2.0, approved, #10547
 maven/mavencentral/com.azure/azure-security-keyvault-secrets/4.7.3, MIT, approved, #10868
+maven/mavencentral/com.azure/azure-security-keyvault-secrets/4.8.0, , restricted, clearlydefined
 maven/mavencentral/com.azure/azure-storage-blob/12.25.2, MIT, approved, #13400
 maven/mavencentral/com.azure/azure-storage-common/12.24.2, MIT, approved, #13402
 maven/mavencentral/com.azure/azure-storage-internal-avro/12.10.2, MIT, approved, #13399
@@ -20,9 +25,11 @@ maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.1, Apache
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.2, Apache-2.0, approved, #7947
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.3, Apache-2.0, approved, #7947
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.1, Apache-2.0, approved, #11606
+maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.2, Apache-2.0, approved, #11606
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.13.5, Apache-2.0, approved, #2133
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.1, MIT AND Apache-2.0, approved, #7932
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.16.1, Apache-2.0 AND MIT, approved, #11602
+maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.16.2, Apache-2.0 AND MIT, approved, #11602
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.13.4.2, Apache-2.0, approved, #2134
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.13.5, Apache-2.0, approved, #2134
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.2, Apache-2.0, approved, #4105
@@ -30,26 +37,30 @@ maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.1, Apache-2.
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.2, Apache-2.0, approved, #7934
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.3, Apache-2.0, approved, #7934
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.1, Apache-2.0, approved, #11605
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.2, Apache-2.0, approved, #11605
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-toml/2.15.2, Apache-2.0, approved, #9160
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-toml/2.16.1, Apache-2.0, approved, #13145
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-toml/2.16.2, Apache-2.0, approved, #13145
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.13.5, Apache-2.0, approved, #3768
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.16.1, Apache-2.0, approved, #12438
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.16.2, Apache-2.0, approved, #12438
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.1, Apache-2.0, approved, #8802
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.2, Apache-2.0, approved, #8802
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.16.1, Apache-2.0, approved, #11855
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.16.2, Apache-2.0, approved, #11855
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.16.1, Apache-2.0, approved, #11854
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.16.2, Apache-2.0, approved, #11854
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.1, Apache-2.0, approved, #7930
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.2, Apache-2.0, approved, #7930
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.1, Apache-2.0, approved, #11853
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.16.1, Apache-2.0, approved, #11851
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.2, Apache-2.0, approved, #11853
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.16.2, Apache-2.0, approved, #11851
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.1, Apache-2.0, approved, #9236
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.2, Apache-2.0, approved, #9236
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.16.1, Apache-2.0, approved, #11858
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.16.2, Apache-2.0, approved, #11858
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.15.3, Apache-2.0, approved, #9241
-maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.16.1, Apache-2.0, approved, #11856
+maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.16.2, Apache-2.0, approved, #11856
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.15.1, Apache-2.0, approved, #7929
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.16.1, Apache-2.0, approved, #11852
+maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.16.2, Apache-2.0, approved, #11852
 maven/mavencentral/com.fasterxml.woodstox/woodstox-core/6.5.1, Apache-2.0, approved, #7950
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.5, Apache-2.0, approved, #10346
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.6, Apache-2.0, approved, #10346
@@ -286,6 +297,7 @@ maven/mavencentral/org.eclipse.edc/data-plane-http-oauth2-core/0.5.2-SNAPSHOT, A
 maven/mavencentral/org.eclipse.edc/data-plane-http-oauth2/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-http-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-http/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/data-plane-public-api-v2/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-public-api/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-selector-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-selector-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc

--- a/edc-dataplane/edc-dataplane-base/build.gradle.kts
+++ b/edc-dataplane/edc-dataplane-base/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     runtimeOnly(project(":edc-extensions:dataplane:dataplane-proxy:edc-dataplane-proxy-provider-api"))
     runtimeOnly(project(":edc-extensions:dataplane:dataplane-proxy:edc-dataplane-proxy-provider-core"))
     runtimeOnly(project(":edc-extensions:dataplane:dataplane-token-refresh:token-refresh-core"))
+    runtimeOnly(project(":edc-extensions:dataplane:dataplane-token-refresh:token-refresh-api"))
 
     runtimeOnly(libs.edc.jsonld) // needed by the DataPlaneSignalingApi
     runtimeOnly(libs.edc.identity.core.did) // for the DID Public Key Resolver
@@ -43,7 +44,9 @@ dependencies {
 
     runtimeOnly(libs.edc.dpf.api.control)
     runtimeOnly(libs.edc.dpf.api.signaling)
-    runtimeOnly(libs.edc.dpf.api.public)
+
+    runtimeOnly(libs.edc.dpf.api.public.v1)
+    runtimeOnly(libs.edc.dpf.api.public.v2)
     runtimeOnly(libs.edc.core.connector)
     runtimeOnly(libs.edc.boot)
 

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/build.gradle.kts
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/build.gradle.kts
@@ -1,5 +1,5 @@
-/********************************************************************************
- * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,23 +15,22 @@
  * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- ********************************************************************************/
+ */
 
 plugins {
     `java-library`
+    `maven-publish`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
 }
 
 dependencies {
+    api(project(":spi:tokenrefresh-spi"))
+    implementation(libs.edc.spi.core)
+    implementation(libs.edc.spi.web)
+    implementation(libs.jakarta.rsApi)
 
-    testImplementation(project(":spi:tokenrefresh-spi"))
-    testImplementation(project(":edc-tests:e2e-tests"))
     testImplementation(libs.edc.junit)
     testImplementation(libs.restAssured)
-
-    testImplementation(libs.edc.dpf.http)
-    testImplementation(libs.edc.spi.identity.did)
-    testImplementation(libs.nimbus.jwt)
+    testImplementation(testFixtures(libs.edc.core.jersey))
 }
-
-
 

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/api/TokenRefreshApiExtension.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/api/TokenRefreshApiExtension.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.dataplane.tokenrefresh.api;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.tractusx.edc.dataplane.tokenrefresh.api.v1.TokenRefreshApiController;
+import org.eclipse.tractusx.edc.dataplane.tokenrefresh.spi.DataPlaneTokenRefreshService;
+
+import static org.eclipse.tractusx.edc.dataplane.tokenrefresh.api.TokenRefreshApiExtension.NAME;
+
+@Extension(value = NAME)
+public class TokenRefreshApiExtension implements ServiceExtension {
+
+    public static final String NAME = "DataPlane Token Refresh API Extension";
+    private static final String PUBLIC_API_CONTEXT = "public";
+    @Inject
+    private DataPlaneTokenRefreshService refreshService;
+
+    @Inject
+    private WebService webService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var controller = new TokenRefreshApiController(refreshService);
+        webService.registerResource(PUBLIC_API_CONTEXT, controller);
+    }
+}

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/api/v1/TokenRefreshApi.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/api/v1/TokenRefreshApi.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.dataplane.tokenrefresh.api.v1;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.eclipse.edc.web.spi.ApiErrorDetail;
+import org.eclipse.tractusx.edc.dataplane.tokenrefresh.spi.model.TokenResponse;
+
+@SecurityScheme(name = "Authentication",
+        description = "Self-Issued ID token containing an access_token",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT")
+@OpenAPIDefinition(info = @Info(description = "With this API clients can refresh their access token for a provider's HTTP data plane using an authentication token and a refresh token.", title = "Token Refresh API"))
+@Tag(name = "Token Refresh API")
+public interface TokenRefreshApi {
+
+    @Operation(description = "Resolves all groups for a particular BPN",
+            parameters = { @Parameter(name = "grant_type", description = "The grant type. Must be \"refresh_token\""),
+                    @Parameter(name = "refresh_token", description = "The refresh token") },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The access token and refresh token were updated. Expiry should be " +
+                            "interpreted as starting from the time of message reception, allowing for some leeway.",
+                            content = @Content(schema = @Schema(implementation = TokenResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "The token could not be refreshed due to an authentication error, either the refresh token or the Authorization header were invalid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed, query parameters were missing, etc.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    TokenResponse refreshToken(String grantType, String refreshToken, String bearerToken);
+}

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/api/v1/TokenRefreshApiController.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/api/v1/TokenRefreshApiController.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.dataplane.tokenrefresh.api.v1;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.edc.web.spi.exception.AuthenticationFailedException;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
+import org.eclipse.tractusx.edc.dataplane.tokenrefresh.spi.DataPlaneTokenRefreshService;
+import org.eclipse.tractusx.edc.dataplane.tokenrefresh.spi.model.TokenResponse;
+
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+
+@Produces({ MediaType.APPLICATION_JSON })
+@Path("/token")
+public class TokenRefreshApiController implements TokenRefreshApi {
+    private static final String REFRESH_TOKEN_GRANT = "refresh_token";
+    private final DataPlaneTokenRefreshService tokenRefreshService;
+
+    public TokenRefreshApiController(DataPlaneTokenRefreshService tokenRefreshService) {
+        this.tokenRefreshService = tokenRefreshService;
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Override
+    public TokenResponse refreshToken(@QueryParam("grant_type") String grantType,
+                                      @QueryParam("refresh_token") String refreshToken,
+                                      @HeaderParam(AUTHORIZATION) String bearerToken) {
+        if (!REFRESH_TOKEN_GRANT.equals(grantType)) {
+            throw new InvalidRequestException("Grant type MUST be '%s' but was '%s'".formatted(REFRESH_TOKEN_GRANT, grantType));
+        }
+
+        return tokenRefreshService.refreshToken(refreshToken, bearerToken)
+                .orElseThrow(f -> new AuthenticationFailedException(f.getFailureDetail()));
+    }
+}

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,20 @@
+#################################################################################
+#  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+org.eclipse.tractusx.edc.dataplane.tokenrefresh.api.TokenRefreshApiExtension

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/api/v1/TokenRefreshApiControllerTest.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/api/v1/TokenRefreshApiControllerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.dataplane.tokenrefresh.api.v1;
+
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.eclipse.tractusx.edc.dataplane.tokenrefresh.spi.DataPlaneTokenRefreshService;
+import org.eclipse.tractusx.edc.dataplane.tokenrefresh.spi.model.TokenResponse;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static io.restassured.RestAssured.given;
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TokenRefreshApiControllerTest extends RestControllerTestBase {
+
+    private final DataPlaneTokenRefreshService refreshService = mock();
+
+    @DisplayName("Expect HTTP 400 when no Authorization header is present")
+    @Test
+    void refresh_noAuthHeader_expect401() {
+        baseRequest()
+                .queryParam("grant_type", "refresh_token")
+                .queryParam("refresh_token", "foo-token")
+                /* missing: .header(AUTHORIZATION, "auth-token") */
+                .contentType(ContentType.URLENC)
+                .then()
+                .statusCode(401);
+    }
+
+    @DisplayName("Expect HTTP 200 when the token was successfully refreshed")
+    @Test
+    void refresh_expect200() {
+        when(refreshService.refreshToken(any(), any())).thenReturn(Result.success(new TokenResponse("new-accesstoken", "new-refreshtoken", 3000L, "bearer")));
+        baseRequest()
+                .queryParam("grant_type", "refresh_token")
+                .queryParam("refresh_token", "foo-token")
+                .header(AUTHORIZATION, "auth-token")
+                .contentType(ContentType.URLENC)
+                .then()
+                .statusCode(200)
+                .body(Matchers.isA(TokenResponse.class));
+    }
+
+    @DisplayName("Expect HTTP 400 when an invalid grant type was provided")
+    @ParameterizedTest(name = "Invalid grant_type: {0}")
+    @ValueSource(strings = { "REFRESH_TOKEN", "refreshToken", "invalid_grant", "client_credentials", "" })
+    @NullSource
+    void refresh_invalidGrantType_expect400(String grant) {
+        baseRequest()
+                .queryParam("grant_type", grant)
+                .queryParam("refresh_token", "foo-token")
+                .header(AUTHORIZATION, "auth-token")
+                .contentType(ContentType.URLENC)
+                .then()
+                .statusCode(400);
+    }
+
+    @DisplayName("Expect HTTP 400 when an invalid refresh token was provided")
+    @ParameterizedTest(name = "Invalid refresh_token: {0}")
+    @NullSource
+    @EmptySource
+    void refresh_invalidRefreshToken_expect400(String refreshToken) {
+        baseRequest()
+                .queryParam("grant_type", "refresh_token")
+                .queryParam("refresh_token", refreshToken)
+                .header(AUTHORIZATION, "auth-token")
+                .contentType(ContentType.URLENC)
+                .then()
+                .statusCode(400);
+    }
+
+    @DisplayName("Expect HTTP 400 when one of the query params was missing")
+    @Test
+    void refresh_queryParamsMissing() {
+        baseRequest()
+                .queryParam("grant_type", "refresh_token")
+                .header(AUTHORIZATION, "auth-token")
+                .contentType(ContentType.URLENC)
+                .then()
+                .statusCode(400);
+
+        baseRequest()
+                .queryParam("refresh_token", "foo-token")
+                .header(AUTHORIZATION, "auth-token")
+                .contentType(ContentType.URLENC)
+                .then()
+                .statusCode(400);
+    }
+
+    @DisplayName("Expect HTTP 401 if the auth header or refresh token are invalid")
+    @Test
+    void refresh_tokenInvalid_expect401() {
+        when(refreshService.refreshToken(any(), any())).thenReturn(Result.failure("Invalid auth token"));
+
+        baseRequest()
+                .queryParam("grant_type", "refresh_token")
+                .queryParam("refresh_token", "foo-token")
+                .header(AUTHORIZATION, "auth-token")
+                .contentType(ContentType.URLENC)
+                .then()
+                .statusCode(401)
+                .body(containsString("Invalid auth token"));
+    }
+
+    @Override
+    protected Object controller() {
+        return new TokenRefreshApiController(refreshService);
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port)
+                .basePath("/token")
+                .when();
+    }
+
+}

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceExtension.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceExtension.java
@@ -30,6 +30,7 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.token.JwtGenerationService;
 import org.eclipse.edc.token.spi.TokenValidationService;
+import org.eclipse.tractusx.edc.dataplane.tokenrefresh.spi.DataPlaneTokenRefreshService;
 import org.jetbrains.annotations.NotNull;
 
 import java.security.PrivateKey;
@@ -50,15 +51,31 @@ public class DataPlaneTokenRefreshServiceExtension implements ServiceExtension {
 
     @Inject
     private PrivateKeyResolver privateKeyResolver;
+    private DataPlaneTokenRefreshServiceImpl tokenRefreshService;
 
     @Override
     public String name() {
         return NAME;
     }
 
+    // exposes the service as access token service
     @Provider
-    public DataPlaneAccessTokenService createRefreshAccessTokenService(ServiceExtensionContext context) {
-        return new DataPlaneTokenRefreshServiceImpl(tokenValidationService, didPkResolver, accessTokenDataStore, new JwtGenerationService(), getPrivateKeySupplier(context), context.getMonitor(), "foo.bar");
+    public DataPlaneAccessTokenService createAccessTokenService(ServiceExtensionContext context) {
+        return getTokenRefreshService(context);
+    }
+
+    // exposes the service as pure refresh service
+    @Provider
+    public DataPlaneTokenRefreshService createRefreshTokenService(ServiceExtensionContext context) {
+        return getTokenRefreshService(context);
+    }
+
+    @NotNull
+    private DataPlaneTokenRefreshServiceImpl getTokenRefreshService(ServiceExtensionContext context) {
+        if (tokenRefreshService == null) {
+            tokenRefreshService = new DataPlaneTokenRefreshServiceImpl(tokenValidationService, didPkResolver, accessTokenDataStore, new JwtGenerationService(), getPrivateKeySupplier(context), context.getMonitor(), "foo.bar");
+        }
+        return tokenRefreshService;
     }
 
     @NotNull

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -160,7 +160,8 @@ edc-dpf-azblob = { module = "org.eclipse.edc:data-plane-azure-storage", version.
 edc-dpf-http = { module = "org.eclipse.edc:data-plane-http", version.ref = "edc" }
 edc-dpf-oauth2 = { module = "org.eclipse.edc:data-plane-http-oauth2", version.ref = "edc" }
 edc-dpf-api-control = { module = "org.eclipse.edc:data-plane-control-api", version.ref = "edc" }
-edc-dpf-api-public = { module = "org.eclipse.edc:data-plane-public-api", version.ref = "edc" }
+edc-dpf-api-public-v1 = { module = "org.eclipse.edc:data-plane-public-api", version.ref = "edc" }
+edc-dpf-api-public-v2 = { module = "org.eclipse.edc:data-plane-public-api-v2", version.ref = "edc" }
 
 edc-dpf-api-signaling = { module = "org.eclipse.edc:data-plane-signaling-api", version.ref = "edc" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -63,6 +63,7 @@ include(":edc-extensions:dataplane:dataplane-proxy:edc-dataplane-proxy-provider-
 include(":edc-extensions:dataplane:dataplane-proxy:edc-dataplane-proxy-provider-api")
 include(":edc-extensions:dataplane:dataplane-selector-configuration")
 include(":edc-extensions:dataplane:dataplane-token-refresh:token-refresh-core")
+include(":edc-extensions:dataplane:dataplane-token-refresh:token-refresh-api")
 
 // test modules
 include(":edc-tests:e2e-tests")


### PR DESCRIPTION
## WHAT

This PR adds the Refresh API to the dataplane, effectively exposing the possibility to refresh dataplane access tokens.

The Refresh API is registered into th `"public"` context, thus it is available under `POST <HOST>:<PUBLIC_API_PORT>/<PUBLIC_API_PATH>/v1/token`. 
Using all defaults, that is:

```
POST http://localhost:8185/api/v1/public/token
```

or - using the v2 endpoint:

```
POST http://localhost:8185/api/v2/public/token
```

using the V2 endpoint is **highly encouraged** as the V1 endpoint will not use data plane signaling, access tokens or token refresh!

## WHY

Short-lived tokens are a security best-practice
## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
