### PR TITLE
feature(api): Update NegotiateEdrRequestDto

### DIFF
--- a/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/EdrApiExtension.java
+++ b/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/EdrApiExtension.java
@@ -20,6 +20,7 @@
 package org.eclipse.tractusx.edc.api.edr;
 
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration;
+import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectToContractOfferTransformer;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -67,9 +68,10 @@ public class EdrApiExtension implements ServiceExtension {
         var mgmtApiTransformerRegistry = transformerRegistry.forContext("management-api");
         mgmtApiTransformerRegistry.register(new NegotiateEdrRequestDtoToNegotiatedEdrRequestTransformer());
         mgmtApiTransformerRegistry.register(new JsonObjectToNegotiateEdrRequestDtoTransformer());
+        mgmtApiTransformerRegistry.register(new JsonObjectToContractOfferTransformer());
         mgmtApiTransformerRegistry.register(new JsonObjectFromEndpointDataReferenceEntryTransformer());
         mgmtApiTransformerRegistry.register(new EndpointDataReferenceToDataAddressTransformer());
-        validatorRegistry.register(EDR_REQUEST_DTO_TYPE, NegotiateEdrRequestDtoValidator.instance());
+        validatorRegistry.register(EDR_REQUEST_DTO_TYPE, NegotiateEdrRequestDtoValidator.instance(context.getMonitor()));
         webService.registerResource(apiConfig.getContextAlias(), new EdrController(edrService, mgmtApiTransformerRegistry, validatorRegistry, monitor));
     }
 }

--- a/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/dto/NegotiateEdrRequestDto.java
+++ b/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/dto/NegotiateEdrRequestDto.java
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.edc.api.edr.dto;
 
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +38,7 @@ public class NegotiateEdrRequestDto {
     public static final String EDR_REQUEST_DTO_COUNTERPARTY_ID = EDC_NAMESPACE + "counterPartyId";
     public static final String EDR_REQUEST_DTO_PROVIDER_ID = EDC_NAMESPACE + "providerId";
     public static final String EDR_REQUEST_DTO_OFFER = EDC_NAMESPACE + "offer";
+    public static final String EDR_REQUEST_DTO_POLICY = EDC_NAMESPACE + "policy";
     public static final String EDR_REQUEST_DTO_CALLBACK_ADDRESSES = EDC_NAMESPACE + "callbackAddresses";
 
     private String counterPartyAddress;
@@ -45,7 +47,9 @@ public class NegotiateEdrRequestDto {
 
     private String providerId;
 
+    @Deprecated(since = "0.6.1")
     private ContractOfferDescription offer;
+    private ContractOffer contractOffer;
     private List<CallbackAddress> callbackAddresses = new ArrayList<>();
 
     private NegotiateEdrRequestDto() {
@@ -72,8 +76,13 @@ public class NegotiateEdrRequestDto {
         return callbackAddresses;
     }
 
+    @Deprecated(since = "0.6.1")
     public ContractOfferDescription getOffer() {
         return offer;
+    }
+
+    public ContractOffer getContractOffer() {
+        return contractOffer;
     }
 
     public static final class Builder {
@@ -98,8 +107,14 @@ public class NegotiateEdrRequestDto {
             return this;
         }
 
+        @Deprecated(since = "0.6.1")
         public Builder offer(ContractOfferDescription offer) {
             dto.offer = offer;
+            return this;
+        }
+
+        public Builder contractOffer(ContractOffer contractOffer) {
+            dto.contractOffer = contractOffer;
             return this;
         }
 

--- a/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/schema/EdrSchema.java
+++ b/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/schema/EdrSchema.java
@@ -43,10 +43,38 @@ public class EdrSchema {
             @Schema(deprecated = true, description = "please use providerId instead")
             String connectorId,
             String providerId,
+            @Deprecated(since = "0.6.1")
+            @Schema(deprecated = true, description = "please use policy instead")
             ContractNegotiationApi.ContractOfferDescriptionSchema offer,
+            ManagementApiSchema.PolicySchema policy,
             List<ManagementApiSchema.CallbackAddressSchema> callbackAddresses) {
 
         public static final String NEGOTIATE_EDR_REQUEST_EXAMPLE = """
+                {
+                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@type": "NegotiateEdrRequestDto",
+                    "counterPartyAddress": "http://provider-address",
+                    "protocol": "dataspace-protocol-http",
+                    "providerId": "provider-id",
+                    "policy": {
+                        "@context": "http://www.w3.org/ns/odrl.jsonld",
+                        "@type": "Set",
+                        "@id": "policy-id",
+                        "target": "asset-id",
+                        "permission": [{
+                            "action": "display"
+                        }]
+                    },
+                    "callbackAddresses": [{
+                        "transactional": false,
+                        "uri": "http://callback/url",
+                        "events": ["contract.negotiation", "transfer.process"]
+                    }]
+                }
+                """;
+
+        @Deprecated(since = "0.6.1")
+        public static final String NEGOTIATE_EDR_REQUEST_DEPRECATED_EXAMPLE = """
                 {
                     "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@type": "NegotiateEdrRequestDto",

--- a/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/transform/JsonObjectToNegotiateEdrRequestDtoTransformer.java
+++ b/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/transform/JsonObjectToNegotiateEdrRequestDtoTransformer.java
@@ -24,6 +24,7 @@ import jakarta.json.JsonValue;
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto;
 import org.jetbrains.annotations.NotNull;
@@ -35,6 +36,7 @@ import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_RE
 import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_COUNTERPARTY_ADDRESS;
 import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_COUNTERPARTY_ID;
 import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_OFFER;
+import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_POLICY;
 import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_PROTOCOL;
 import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_PROVIDER_ID;
 import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_TYPE;
@@ -76,6 +78,9 @@ public class JsonObjectToNegotiateEdrRequestDtoTransformer extends AbstractJsonL
             case EDR_REQUEST_DTO_OFFER:
                 transformArrayOrObject(value, ContractOfferDescription.class, builder::offer, context);
                 break;
+            case EDR_REQUEST_DTO_POLICY:
+                transformArrayOrObject(value, ContractOffer.class, builder::contractOffer, context);
+                break;
             default:
                 context.problem()
                         .unexpectedType()
@@ -88,6 +93,7 @@ public class JsonObjectToNegotiateEdrRequestDtoTransformer extends AbstractJsonL
                         .expected(EDR_REQUEST_DTO_PROVIDER_ID)
                         .expected(EDR_REQUEST_DTO_CALLBACK_ADDRESSES)
                         .expected(EDR_REQUEST_DTO_OFFER)
+                        .expected(EDR_REQUEST_DTO_POLICY)
                         .report();
                 break;
         }

--- a/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/transform/NegotiateEdrRequestDtoToNegotiatedEdrRequestTransformer.java
+++ b/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/transform/NegotiateEdrRequestDtoToNegotiatedEdrRequestTransformer.java
@@ -41,11 +41,17 @@ public class NegotiateEdrRequestDtoToNegotiatedEdrRequestTransformer implements 
 
     @Override
     public @Nullable NegotiateEdrRequest transform(@NotNull NegotiateEdrRequestDto object, @NotNull TransformerContext context) {
-        var contractOffer = ContractOffer.Builder.newInstance()
-                .id(object.getOffer().getOfferId())
-                .assetId(object.getOffer().getAssetId())
-                .policy(object.getOffer().getPolicy())
-                .build();
+        ContractOffer contractOffer = null;
+
+        if (object.getContractOffer() != null) {
+            contractOffer = object.getContractOffer();
+        } else if (object.getOffer() != null) {
+            contractOffer = ContractOffer.Builder.newInstance()
+                    .id(object.getOffer().getOfferId())
+                    .assetId(object.getOffer().getAssetId())
+                    .policy(object.getOffer().getPolicy())
+                    .build();
+        }
 
         return NegotiateEdrRequest.Builder.newInstance()
                 .connectorId(object.getCounterPartyId())
@@ -54,10 +60,6 @@ public class NegotiateEdrRequestDtoToNegotiatedEdrRequestTransformer implements 
                 .offer(contractOffer)
                 .callbackAddresses(object.getCallbackAddresses())
                 .build();
-    }
-
-    private String getId(String value, String defaultValue) {
-        return value != null ? value : defaultValue;
     }
 
 }

--- a/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/validation/NegotiateEdrRequestDtoValidator.java
+++ b/edc-extensions/edr/edr-api/src/main/java/org/eclipse/tractusx/edc/api/edr/validation/NegotiateEdrRequestDtoValidator.java
@@ -20,17 +20,22 @@
 package org.eclipse.tractusx.edc.api.edr.validation;
 
 import jakarta.json.JsonObject;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.validator.jsonobject.JsonLdPath;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryObject;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
+import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
 
+import static java.lang.String.format;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.ASSET_ID;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.OFFER_ID;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.POLICY;
 import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_COUNTERPARTY_ADDRESS;
 import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_OFFER;
 import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_PROTOCOL;
+import static org.eclipse.tractusx.edc.api.edr.dto.NegotiateEdrRequestDto.EDR_REQUEST_DTO_TYPE;
 
 
 public class NegotiateEdrRequestDtoValidator {
@@ -38,16 +43,43 @@ public class NegotiateEdrRequestDtoValidator {
     private NegotiateEdrRequestDtoValidator() {
     }
 
-    public static Validator<JsonObject> instance() {
+    public static Validator<JsonObject> instance(Monitor monitor) {
         return JsonObjectValidator.newValidator()
                 .verify(EDR_REQUEST_DTO_COUNTERPARTY_ADDRESS, MandatoryValue::new)
                 .verify(EDR_REQUEST_DTO_PROTOCOL, MandatoryValue::new)
-                .verify(EDR_REQUEST_DTO_OFFER, MandatoryObject::new)
-                .verifyObject(EDR_REQUEST_DTO_OFFER, v -> v
-                        .verify(OFFER_ID, MandatoryValue::new)
-                        .verify(ASSET_ID, MandatoryValue::new)
-                        .verify(POLICY, MandatoryObject::new)
-                )
+                .verify(path -> new MandatoryOfferOrPolicy(path, monitor))
                 .build();
+    }
+
+    private record MandatoryOfferOrPolicy(JsonLdPath path, Monitor monitor) implements Validator<JsonObject> {
+        @Override
+        public ValidationResult validate(JsonObject input) {
+            if (input.containsKey(EDR_REQUEST_DTO_OFFER)) {
+                monitor.warning(format("The attribute %s has been deprecated in type %s, please use %s",
+                        EDR_REQUEST_DTO_OFFER, EDR_REQUEST_DTO_TYPE, POLICY));
+                return new OfferValidator(path.append(EDR_REQUEST_DTO_OFFER)).validate(input);
+            }
+            return new EdrPolicyValidator(path).validate(input);
+        }
+    }
+
+    private record OfferValidator(JsonLdPath path) implements Validator<JsonObject> {
+        @Override
+        public ValidationResult validate(JsonObject input) {
+            return JsonObjectValidator.newValidator()
+                    .verifyObject(EDR_REQUEST_DTO_OFFER, v -> v
+                            .verify(OFFER_ID, MandatoryValue::new)
+                            .verify(ASSET_ID, MandatoryValue::new)
+                            .verify(POLICY, MandatoryObject::new)
+                    ).build().validate(input);
+        }
+    }
+
+    private record EdrPolicyValidator(JsonLdPath path) implements Validator<JsonObject> {
+        @Override
+        public ValidationResult validate(JsonObject input) {
+            return JsonObjectValidator.newValidator()
+                    .verify(POLICY, MandatoryObject::new).build().validate(input);
+        }
     }
 }

--- a/edc-extensions/edr/edr-api/src/test/java/org/eclipse/tractusx/edc/api/edr/TestFunctions.java
+++ b/edc-extensions/edr/edr-api/src/test/java/org/eclipse/tractusx/edc/api/edr/TestFunctions.java
@@ -58,6 +58,13 @@ public class TestFunctions {
         return createOffer(UUID.randomUUID().toString(), UUID.randomUUID().toString());
     }
 
+    public static ContractOffer createContractOffer() {
+        return ContractOffer.Builder.newInstance()
+                .id("offerId")
+                .assetId("assetId")
+                .policy(Policy.Builder.newInstance().build()).build();
+    }
+
     public static JsonObject negotiationRequest() {
         return Json.createObjectBuilder()
                 .add(TYPE, NegotiateEdrRequestDto.EDR_REQUEST_DTO_TYPE)

--- a/edc-extensions/edr/edr-api/src/test/java/org/eclipse/tractusx/edc/api/edr/transform/NegotiateEdrRequestDtoToNegotiateEdrRequestTransformerTest.java
+++ b/edc-extensions/edr/edr-api/src/test/java/org/eclipse/tractusx/edc/api/edr/transform/NegotiateEdrRequestDtoToNegotiateEdrRequestTransformerTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.tractusx.edc.api.edr.TestFunctions.createContractOffer;
 import static org.eclipse.tractusx.edc.api.edr.TestFunctions.createOffer;
 import static org.mockito.Mockito.mock;
 
@@ -52,6 +53,31 @@ public class NegotiateEdrRequestDtoToNegotiateEdrRequestTransformerTest {
                 .connectorAddress("address")
                 .protocol("protocol")
                 .providerId("test-provider")
+                .contractOffer(createContractOffer())
+                .callbackAddresses(List.of(callback))
+                .build();
+
+        var request = transformer.transform(dto, context);
+
+        assertThat(request).isNotNull();
+        assertThat(request.getConnectorId()).isEqualTo("connectorId");
+        assertThat(request.getConnectorAddress()).isEqualTo("address");
+        assertThat(request.getProtocol()).isEqualTo("protocol");
+        assertThat(request.getOffer().getId()).isEqualTo("offerId");
+        assertThat(request.getOffer().getPolicy()).isNotNull();
+        assertThat(request.getCallbackAddresses()).hasSize(1);
+    }
+
+    @Test
+    void verify_transformDeprecatedOffer() {
+        var callback = CallbackAddress.Builder.newInstance()
+                .uri("local://test")
+                .build();
+        var dto = NegotiateEdrRequestDto.Builder.newInstance()
+                .counterPartyId("connectorId")
+                .connectorAddress("address")
+                .protocol("protocol")
+                .providerId("test-provider")
                 .offer(createOffer("offerId", "assetId"))
                 .callbackAddresses(List.of(callback))
                 .build();
@@ -68,13 +94,13 @@ public class NegotiateEdrRequestDtoToNegotiateEdrRequestTransformerTest {
     }
 
     @Test
-    void verify_transfor_withNoProviderId() {
+    void verify_transform_withNoProviderId() {
         var dto = NegotiateEdrRequestDto.Builder.newInstance()
                 .counterPartyId("connectorId")
                 .connectorAddress("address")
                 .protocol("protocol")
                 // do not set provider ID
-                .offer(createOffer("offerId", "assetId"))
+                .contractOffer(createContractOffer())
                 .build();
 
         var request = transformer.transform(dto, context);
@@ -90,7 +116,7 @@ public class NegotiateEdrRequestDtoToNegotiateEdrRequestTransformerTest {
                 .protocol("protocol")
                 // do not set consumer ID
                 .providerId("urn:connector:test-provider")
-                .offer(createOffer("offerId", "assetId"))
+                .contractOffer(createContractOffer())
                 .build();
 
         var request = transformer.transform(dto, context);


### PR DESCRIPTION
## WHAT

Changes `NegotiateEDRRequestDto` to use only `Policy` instead of `Offer`.

## WHY

Remove duplicate data in the api.

## FURTHER NOTES

Changes are similar to [3395](https://github.com/eclipse-edc/Connector/issues/3395) Upsteam.

Closes #936
