### PR TITLE
fix: use LocalPublicKeyService for data plane token verification

### DIFF
--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceExtension.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceExtension.java
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.edc.dataplane.tokenrefresh.core;
 import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAccessTokenService;
 import org.eclipse.edc.connector.dataplane.spi.store.AccessTokenDataStore;
 import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
+import org.eclipse.edc.keys.spi.LocalPublicKeyService;
 import org.eclipse.edc.keys.spi.PrivateKeyResolver;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -63,6 +64,8 @@ public class DataPlaneTokenRefreshServiceExtension implements ServiceExtension {
     private TokenValidationService tokenValidationService;
     @Inject
     private DidPublicKeyResolver didPkResolver;
+    @Inject
+    private LocalPublicKeyService localPublicKeyService;
     @Inject
     private AccessTokenDataStore accessTokenDataStore;
     @Inject
@@ -108,7 +111,7 @@ public class DataPlaneTokenRefreshServiceExtension implements ServiceExtension {
             var tokenExpiry = getExpiryConfig(context);
             monitor.debug("Token refresh endpoint: %s".formatted(refreshEndpoint));
             monitor.debug("Token refresh time tolerance: %d s".formatted(expiryTolerance));
-            tokenRefreshService = new DataPlaneTokenRefreshServiceImpl(clock, tokenValidationService, didPkResolver, accessTokenDataStore, new JwtGenerationService(),
+            tokenRefreshService = new DataPlaneTokenRefreshServiceImpl(clock, tokenValidationService, didPkResolver, localPublicKeyService, accessTokenDataStore, new JwtGenerationService(),
                     getPrivateKeySupplier(context), context.getMonitor(), refreshEndpoint, expiryTolerance, tokenExpiry,
                     () -> context.getConfig().getString(TOKEN_VERIFIER_PUBLIC_KEY_ALIAS), vault, typeManager.getMapper());
         }

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplComponentTest.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplComponentTest.java
@@ -34,6 +34,7 @@ import org.eclipse.edc.connector.dataplane.framework.store.InMemoryAccessTokenDa
 import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames;
+import org.eclipse.edc.keys.spi.LocalPublicKeyService;
 import org.eclipse.edc.query.CriterionOperatorRegistryImpl;
 import org.eclipse.edc.security.token.jwt.CryptoConverter;
 import org.eclipse.edc.spi.iam.TokenParameters;
@@ -69,6 +70,7 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
     public static final String CONSUMER_DID = "did:web:bob";
     public static final String PROVIDER_DID = "did:web:alice";
     private final DidPublicKeyResolver didPkResolverMock = mock();
+    private final LocalPublicKeyService localPublicKeyService = mock();
     private DataPlaneTokenRefreshServiceImpl tokenRefreshService;
     private InMemoryAccessTokenDataStore tokenDataStore;
     private ECKey consumerKey;
@@ -86,6 +88,7 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
         tokenRefreshService = new DataPlaneTokenRefreshServiceImpl(Clock.systemUTC(),
                 new TokenValidationServiceImpl(),
                 didPkResolverMock,
+                localPublicKeyService,
                 tokenDataStore,
                 new JwtGenerationService(),
                 () -> privateKey,
@@ -96,6 +99,9 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
                 () -> providerKey.getKeyID(),
                 new InMemoryVault(mock()),
                 new ObjectMapper());
+
+        when(localPublicKeyService.resolveKey(eq(consumerKey.getKeyID()))).thenReturn(Result.success(consumerKey.toPublicKey()));
+        when(localPublicKeyService.resolveKey(eq(providerKey.getKeyID()))).thenReturn(Result.success(providerKey.toPublicKey()));
 
         when(didPkResolverMock.resolveKey(eq(consumerKey.getKeyID()))).thenReturn(Result.success(consumerKey.toPublicKey()));
         when(didPkResolverMock.resolveKey(eq(providerKey.getKeyID()))).thenReturn(Result.success(providerKey.toPublicKey()));

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplTest.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.connector.dataplane.spi.AccessTokenData;
 import org.eclipse.edc.connector.dataplane.spi.store.AccessTokenDataStore;
 import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
+import org.eclipse.edc.keys.spi.LocalPublicKeyService;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.iam.TokenParameters;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
@@ -65,7 +66,10 @@ class DataPlaneTokenRefreshServiceImplTest {
     private final TokenValidationService tokenValidationService = mock();
     private final DidPublicKeyResolver didPublicKeyResolver = mock();
 
-    private final DataPlaneTokenRefreshServiceImpl accessTokenService = new DataPlaneTokenRefreshServiceImpl(Clock.systemUTC(), tokenValidationService, didPublicKeyResolver, accessTokenDataStore, tokenGenService, mock(), mock(),
+    private final LocalPublicKeyService localPublicKeyService = mock();
+
+    private final DataPlaneTokenRefreshServiceImpl accessTokenService = new DataPlaneTokenRefreshServiceImpl(Clock.systemUTC(),
+            tokenValidationService, didPublicKeyResolver, localPublicKeyService, accessTokenDataStore, tokenGenService, mock(), mock(),
             "https://example.com", 1, 300L,
             () -> "keyid", mock(), new ObjectMapper());
 


### PR DESCRIPTION
## WHAT

When validating the access token resolve the key id with the `LocalPublicKeyService`


## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #1161 
