### PR TITLE
feat: extract scopes only on relevant messages

### DIFF
--- a/edc-extensions/iatp/tx-iatp/build.gradle.kts
+++ b/edc-extensions/iatp/tx-iatp/build.gradle.kts
@@ -26,6 +26,9 @@ dependencies {
     implementation(libs.edc.spi.core)
     implementation(libs.edc.spi.policyengine)
     implementation(libs.edc.spi.identitytrust)
+    implementation(libs.edc.spi.contract)
+    implementation(libs.edc.spi.transfer)
+    implementation(libs.edc.spi.catalog)
     implementation(project(":spi:core-spi"))
     implementation(project(":core:core-utils"))
 

--- a/edc-extensions/iatp/tx-iatp/src/main/java/org/eclipse/tractusx/edc/iam/iatp/IatpScopeExtractorExtension.java
+++ b/edc-extensions/iatp/tx-iatp/src/main/java/org/eclipse/tractusx/edc/iam/iatp/IatpScopeExtractorExtension.java
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.edc.iam.iatp;
 import org.eclipse.edc.identitytrust.scope.ScopeExtractorRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.tractusx.edc.iam.iatp.scope.CredentialScopeExtractor;
@@ -36,6 +37,9 @@ public class IatpScopeExtractorExtension implements ServiceExtension {
     @Inject
     private ScopeExtractorRegistry scopeExtractorRegistry;
 
+    @Inject
+    private Monitor monitor;
+
     @Override
     public String name() {
         return NAME;
@@ -43,6 +47,6 @@ public class IatpScopeExtractorExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        scopeExtractorRegistry.registerScopeExtractor(new CredentialScopeExtractor());
+        scopeExtractorRegistry.registerScopeExtractor(new CredentialScopeExtractor(monitor));
     }
 }

--- a/edc-extensions/iatp/tx-iatp/src/main/java/org/eclipse/tractusx/edc/iam/iatp/scope/CredentialScopeExtractor.java
+++ b/edc-extensions/iatp/tx-iatp/src/main/java/org/eclipse/tractusx/edc/iam/iatp/scope/CredentialScopeExtractor.java
@@ -19,10 +19,17 @@
 
 package org.eclipse.tractusx.edc.iam.iatp.scope;
 
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferRequestMessage;
 import org.eclipse.edc.identitytrust.scope.ScopeExtractor;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.spi.iam.RequestContext;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 
+import java.util.Optional;
 import java.util.Set;
 
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
@@ -39,19 +46,39 @@ public class CredentialScopeExtractor implements ScopeExtractor {
     public static final String SCOPE_FORMAT = "%s:%s:read";
     public static final String CREDENTIAL_FORMAT = "%sCredential";
 
-    public CredentialScopeExtractor() {
+    private static final Set<Class<? extends RemoteMessage>> SUPPORTED_MESSAGES = Set.of(CatalogRequestMessage.class, ContractRequestMessage.class, TransferRequestMessage.class);
+
+    private final Monitor monitor;
+
+    public CredentialScopeExtractor(Monitor monitor) {
+        this.monitor = monitor;
     }
 
     @Override
     public Set<String> extractScopes(Object leftValue, Operator operator, Object rightValue, PolicyContext context) {
         Set<String> scopes = Set.of();
-        if (leftValue instanceof String leftOperand && leftOperand.startsWith(CX_POLICY_NS)) {
-            leftOperand = leftOperand.replace(CX_POLICY_NS, "");
-            var credentialType = extractCredentialType(leftOperand, rightValue);
-            scopes = Set.of(SCOPE_FORMAT.formatted(CREDENTIAL_TYPE_NAMESPACE, CREDENTIAL_FORMAT.formatted(capitalize(credentialType))));
 
+        var requestContext = context.getContextData(RequestContext.class);
+
+        if (requestContext != null) {
+            if (leftValue instanceof String leftOperand && leftOperand.startsWith(CX_POLICY_NS) && isMessageSupported(requestContext)) {
+                leftOperand = leftOperand.replace(CX_POLICY_NS, "");
+                var credentialType = extractCredentialType(leftOperand, rightValue);
+                scopes = Set.of(SCOPE_FORMAT.formatted(CREDENTIAL_TYPE_NAMESPACE, CREDENTIAL_FORMAT.formatted(capitalize(credentialType))));
+
+            }
+
+        } else {
+            monitor.warning("RequestContext not found in the PolicyContext: scope cannot be extracted from the policy. Defaulting to empty scopes");
         }
         return scopes;
+    }
+
+    private boolean isMessageSupported(RequestContext ctx) {
+        return Optional.ofNullable(ctx.getMessage())
+                .map(RemoteMessage::getClass)
+                .map(SUPPORTED_MESSAGES::contains)
+                .orElse(false);
     }
 
     /**

--- a/edc-extensions/iatp/tx-iatp/src/test/java/org/eclipse/tractusx/edc/iam/iatp/scope/CredentialScopeExtractorTest.java
+++ b/edc-extensions/iatp/tx-iatp/src/test/java/org/eclipse/tractusx/edc/iam/iatp/scope/CredentialScopeExtractorTest.java
@@ -19,31 +19,67 @@
 
 package org.eclipse.tractusx.edc.iam.iatp.scope;
 
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreementMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferRequestMessage;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferTerminationMessage;
 import org.eclipse.edc.policy.engine.spi.PolicyContextImpl;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.iam.RequestContext;
 import org.eclipse.edc.spi.iam.TokenParameters;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 import org.eclipse.tractusx.edc.edr.spi.CoreConstants;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.tractusx.edc.iam.iatp.TxIatpConstants.CREDENTIAL_TYPE_NAMESPACE;
 import static org.eclipse.tractusx.edc.iam.iatp.scope.CredentialScopeExtractor.FRAMEWORK_CREDENTIAL_PREFIX;
+import static org.mockito.Mockito.mock;
 
 public class CredentialScopeExtractorTest {
 
+    private final Monitor monitor = mock();
     private CredentialScopeExtractor extractor;
 
     @BeforeEach
     void setup() {
-        extractor = new CredentialScopeExtractor();
+        extractor = new CredentialScopeExtractor(monitor);
     }
 
-    @Test
-    void verify_extractScopes() {
+    @DisplayName("Scope extractor with supported messages")
+    @ParameterizedTest(name = "{1}")
+    @ArgumentsSource(SupportedMessages.class)
+    void verify_extractScopes(RemoteMessage message) {
         var builder = TokenParameters.Builder.newInstance();
-        var ctx = PolicyContextImpl.Builder.newInstance().additional(TokenParameters.Builder.class, builder).build();
+        var requestContext = RequestContext.Builder.newInstance().message(message).direction(RequestContext.Direction.Egress).build();
+        var ctx = PolicyContextImpl.Builder.newInstance().additional(TokenParameters.Builder.class, builder).additional(RequestContext.class, requestContext).build();
         var scopes = extractor.extractScopes(CoreConstants.CX_POLICY_NS + FRAMEWORK_CREDENTIAL_PREFIX + ".pfc", null, null, ctx);
         assertThat(scopes).contains(CREDENTIAL_TYPE_NAMESPACE + ":PfcCredential:read");
+    }
+
+
+    @DisplayName("Scope extractor with not supported messages")
+    @ParameterizedTest(name = "{1}")
+    @ArgumentsSource(NotSupportedMessages.class)
+    void verify_extractScopes_isEmpty_whenNotSupportedMessages(RemoteMessage message) {
+        var builder = TokenParameters.Builder.newInstance();
+        var requestContext = RequestContext.Builder.newInstance().message(message).direction(RequestContext.Direction.Egress).build();
+        var ctx = PolicyContextImpl.Builder.newInstance().additional(TokenParameters.Builder.class, builder).additional(RequestContext.class, requestContext).build();
+        var scopes = extractor.extractScopes(CoreConstants.CX_POLICY_NS + FRAMEWORK_CREDENTIAL_PREFIX + ".pfc", null, null, ctx);
+        assertThat(scopes).isEmpty();
     }
 
     @Test
@@ -52,5 +88,28 @@ public class CredentialScopeExtractorTest {
         var ctx = PolicyContextImpl.Builder.newInstance().additional(TokenParameters.Builder.class, builder).build();
         var scopes = extractor.extractScopes("wrong", null, null, ctx);
         assertThat(scopes).isEmpty();
+    }
+
+    private static class SupportedMessages implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
+            var offer = ContractOffer.Builder.newInstance().id("id").assetId("assetId").policy(Policy.Builder.newInstance().build()).build();
+            return Stream.of(
+                    Arguments.of(CatalogRequestMessage.Builder.newInstance().build()),
+                    Arguments.of(ContractRequestMessage.Builder.newInstance().contractOffer(offer).callbackAddress("cb").build()),
+                    Arguments.of(TransferRequestMessage.Builder.newInstance().callbackAddress("cb").build())
+            );
+        }
+    }
+
+    private static class NotSupportedMessages implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
+            return Stream.of(
+                    Arguments.of(ContractNegotiationTerminationMessage.Builder.newInstance().build()),
+                    Arguments.of(ContractAgreementMessage.Builder.newInstance().counterPartyAddress("cb").contractAgreement(mock()).build()),
+                    Arguments.of(TransferTerminationMessage.Builder.newInstance().counterPartyAddress("pd").build())
+            );
+        }
     }
 }

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/helpers/DimHelper.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/helpers/DimHelper.java
@@ -35,7 +35,7 @@ public interface DimHelper {
      * @param name The participant name
      * @return The composed {@link DimParticipant}
      */
-    static DimParticipant configureParticipant(String name) {
+    static DimParticipant configureParticipant(String name, String bdrsUrl) {
         var bpn = getEnv(format("DIM_%s_BPN", name));
         var dimUrl = getEnv(format("DIM_%s_DIM_URL", name));
         var stsUrl = getEnv(format("DIM_%s_STS_URL", name));
@@ -51,6 +51,7 @@ public interface DimHelper {
                 .dimUri(URI.create(dimUrl))
                 .trustedIssuer(trustedIssuer)
                 .did(did)
+                .bdrsUri(URI.create(bdrsUrl))
                 .build();
     }
 

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/lifecycle/DimParticipant.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/lifecycle/DimParticipant.java
@@ -33,10 +33,13 @@ public class DimParticipant extends TractusxIatpParticipantBase {
 
     protected URI dimUri;
 
+    protected URI bdrsUri;
+
     @Override
     public Map<String, String> iatpConfiguration(TractusxIatpParticipantBase... others) {
         var config = new HashMap<>(super.iatpConfiguration(others));
         config.put("edc.iam.sts.dim.url", dimUri.toString());
+        config.put("tx.iam.iatp.bdrs.server.url", bdrsUri.toString());
         config.put("edc.transfer.proxy.token.verifier.publickey.alias", getKeyId());
         return config;
     }
@@ -56,10 +59,16 @@ public class DimParticipant extends TractusxIatpParticipantBase {
             return self();
         }
 
+        public Builder bdrsUri(URI bdrsUri) {
+            participant.bdrsUri = bdrsUri;
+            return self();
+        }
+
         @Override
         public DimParticipant build() {
             super.build();
             Objects.requireNonNull(participant.dimUri, "DIM URI should not be null");
+            Objects.requireNonNull(participant.bdrsUri, "BDRS URI should not be null");
             return participant;
         }
     }

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/catalog/DimCatalogIntegrationTest.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/catalog/DimCatalogIntegrationTest.java
@@ -53,7 +53,7 @@ import static org.mockserver.model.HttpRequest.request;
 @Disabled
 public class DimCatalogIntegrationTest {
 
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final Integer BDRS_PORT = getFreePort();
     private static final String BDRS_URL = "http://localhost:%s/api".formatted(BDRS_PORT);
 
@@ -86,7 +86,7 @@ public class DimCatalogIntegrationTest {
 
         var bas = new ByteArrayOutputStream();
         try (var gzip = new GZIPOutputStream(bas)) {
-            gzip.write(mapper.writeValueAsBytes(data));
+            gzip.write(MAPPER.writeValueAsBytes(data));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/DimHttpPullTransferIntegrationTest.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/DimHttpPullTransferIntegrationTest.java
@@ -19,30 +19,75 @@
 
 package org.eclipse.tractusx.edc.tests.transfer;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.tractusx.edc.lifecycle.DimParticipant;
 import org.eclipse.tractusx.edc.lifecycle.ParticipantRuntime;
 import org.eclipse.tractusx.edc.tag.DimIntegrationTest;
 import org.eclipse.tractusx.edc.tests.participant.TractusxParticipantBase;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpResponse;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.zip.GZIPOutputStream;
+
+import static org.eclipse.edc.util.io.Ports.getFreePort;
 import static org.eclipse.tractusx.edc.helpers.DimHelper.configureParticipant;
 import static org.eclipse.tractusx.edc.lifecycle.Runtimes.dimRuntime;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PLATO_NAME;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.SOKRATES_NAME;
+import static org.mockserver.model.HttpRequest.request;
 
 @DimIntegrationTest
 @Disabled
 public class DimHttpPullTransferIntegrationTest extends HttpConsumerPullBaseTest {
 
-    protected static final DimParticipant SOKRATES = configureParticipant(SOKRATES_NAME);
-    protected static final DimParticipant PLATO = configureParticipant(PLATO_NAME);
-
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final Integer BDRS_PORT = getFreePort();
+    private static final String BDRS_URL = "http://localhost:%s/api".formatted(BDRS_PORT);
+    protected static final DimParticipant SOKRATES = configureParticipant(SOKRATES_NAME, BDRS_URL);
+    protected static final DimParticipant PLATO = configureParticipant(PLATO_NAME, BDRS_URL);
     @RegisterExtension
     protected static final ParticipantRuntime PLATO_RUNTIME = dimRuntime(PLATO.getName(), PLATO.iatpConfiguration(SOKRATES));
-
     @RegisterExtension
     protected static final ParticipantRuntime SOKRATES_RUNTIME = dimRuntime(SOKRATES.getName(), SOKRATES.iatpConfiguration(PLATO));
+    private static ClientAndServer bdrsServer;
+
+    @BeforeAll
+    static void beforeAll() {
+        bdrsServer = ClientAndServer.startClientAndServer(BDRS_PORT);
+        bdrsServer.when(request()
+                        .withMethod("GET")
+                        .withPath("/api/bpn-directory"))
+                .respond(HttpResponse.response()
+                        .withHeader("Content-Encoding", "gzip")
+                        .withBody(createGzipStream())
+                        .withStatusCode(200));
+
+    }
+
+    private static byte[] createGzipStream() {
+        var data = Map.of(SOKRATES.getBpn(), SOKRATES.getDid(),
+                PLATO.getBpn(), PLATO.getDid());
+
+        var bas = new ByteArrayOutputStream();
+        try (var gzip = new GZIPOutputStream(bas)) {
+            gzip.write(mapper.writeValueAsBytes(data));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return bas.toByteArray();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        bdrsServer.stop();
+    }
 
     @Override
     public TractusxParticipantBase plato() {

--- a/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/DimHttpPullTransferIntegrationTest.java
+++ b/edc-tests/e2e-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/DimHttpPullTransferIntegrationTest.java
@@ -47,7 +47,7 @@ import static org.mockserver.model.HttpRequest.request;
 @Disabled
 public class DimHttpPullTransferIntegrationTest extends HttpConsumerPullBaseTest {
 
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final Integer BDRS_PORT = getFreePort();
     private static final String BDRS_URL = "http://localhost:%s/api".formatted(BDRS_PORT);
     protected static final DimParticipant SOKRATES = configureParticipant(SOKRATES_NAME, BDRS_URL);
@@ -77,7 +77,7 @@ public class DimHttpPullTransferIntegrationTest extends HttpConsumerPullBaseTest
 
         var bas = new ByteArrayOutputStream();
         try (var gzip = new GZIPOutputStream(bas)) {
-            gzip.write(mapper.writeValueAsBytes(data));
+            gzip.write(MAPPER.writeValueAsBytes(data));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/transfer/HttpConsumerPullBaseTest.java
+++ b/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/transfer/HttpConsumerPullBaseTest.java
@@ -51,7 +51,7 @@ public abstract class HttpConsumerPullBaseTest implements ParticipantAwareTest {
     public static final String MOCK_BACKEND_PATH = "/mock/api";
     protected ClientAndServer server;
 
-    private String privateBackendUrl;
+    protected String privateBackendUrl;
 
 
     @BeforeEach

--- a/edc-tests/edc-controlplane/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/AbstractIatpConsumerPullTest.java
+++ b/edc-tests/edc-controlplane/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/AbstractIatpConsumerPullTest.java
@@ -19,22 +19,44 @@
 
 package org.eclipse.tractusx.edc.tests.transfer;
 
+import jakarta.json.Json;
 import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
+import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.tractusx.edc.tests.participant.TractusxParticipantBase;
 import org.eclipse.tractusx.edc.tests.transfer.iatp.harness.DataspaceIssuer;
 import org.eclipse.tractusx.edc.tests.transfer.iatp.harness.IatpParticipant;
 import org.eclipse.tractusx.edc.tests.transfer.iatp.harness.StsParticipant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockserver.verify.VerificationTimes;
 
+import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.pollinterval.FibonacciPollInterval.fibonacci;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_CREDENTIAL_NS;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PLATO_BPN;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PLATO_NAME;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.SOKRATES_BPN;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.SOKRATES_NAME;
 import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.frameworkPolicy;
+import static org.eclipse.tractusx.edc.tests.helpers.TransferProcessHelperFunctions.createProxyRequest;
+import static org.eclipse.tractusx.edc.tests.participant.TractusxParticipantBase.ASYNC_TIMEOUT;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
 
 public abstract class AbstractIatpConsumerPullTest extends HttpConsumerPullBaseTest {
 
@@ -80,9 +102,127 @@ public abstract class AbstractIatpConsumerPullTest extends HttpConsumerPullBaseT
         return SOKRATES;
     }
 
+
+    @DisplayName("Contract policy is fulfilled")
+    @ParameterizedTest(name = "{1}")
+    @ArgumentsSource(ValidContractPolicyProvider.class)
+    void transferData_whenContractPolicyFulfilled(JsonObject contractPolicy, String description) {
+        var assetId = "api-asset-1";
+
+        var authCodeHeaderName = "test-authkey";
+        var authCode = "test-authcode";
+
+        Map<String, Object> dataAddress = Map.of(
+                "baseUrl", privateBackendUrl,
+                "type", "HttpData",
+                "contentType", "application/json",
+                "authKey", authCodeHeaderName,
+                "authCode", authCode
+        );
+
+        PLATO.createAsset(assetId, Map.of(), dataAddress);
+
+        var accessPolicyId = PLATO.createPolicyDefinition(createAccessPolicy(SOKRATES.getBpn()));
+        var contractPolicyId = PLATO.createPolicyDefinition(contractPolicy);
+        PLATO.createContractDefinition(assetId, "def-1", accessPolicyId, contractPolicyId);
+        var transferProcessId = SOKRATES.requestAsset(PLATO, assetId, Json.createObjectBuilder().build(), createProxyRequest(), "HttpData-PULL");
+
+        var edr = new AtomicReference<JsonObject>();
+
+        // wait until transfer process completes
+        await().pollInterval(fibonacci())
+                .atMost(ASYNC_TIMEOUT)
+                .untilAsserted(() -> {
+                    var tpState = SOKRATES.getTransferProcessState(transferProcessId);
+                    assertThat(tpState).isNotNull().isEqualTo(TransferProcessStates.STARTED.toString());
+                });
+
+        // wait until EDC is available on the consumer side
+        server.when(request().withMethod("GET").withPath(MOCK_BACKEND_PATH)).respond(response().withStatusCode(200).withBody("test response"));
+        await().pollInterval(fibonacci())
+                .atMost(ASYNC_TIMEOUT)
+                .untilAsserted(() -> {
+                    edr.set(SOKRATES.edrs().getEdr(transferProcessId));
+                    assertThat(edr).isNotNull();
+                });
+
+        // pull data out of provider's backend service:
+        // Prov-DP -> Prov-backend
+        assertThat(sokrates().data().pullData(edr.get(), Map.of())).isEqualTo("test response");
+
+        server.verify(request()
+                .withPath(MOCK_BACKEND_PATH)
+                .withHeader("Edc-Contract-Agreement-Id")
+                .withHeader("Edc-Bpn", sokrates().getBpn())
+                .withMethod("GET"), VerificationTimes.exactly(1));
+    }
+
+    @DisplayName("Contract policy is NOT fulfilled")
+    @ParameterizedTest(name = "{1}")
+    @ArgumentsSource(InvalidContractPolicyProvider.class)
+    void transferData_whenContractPolicyNotFulfilled(JsonObject contractPolicy, String description) throws IOException {
+        var assetId = "api-asset-1";
+
+        var authCodeHeaderName = "test-authkey";
+        var authCode = "test-authcode";
+
+        Map<String, Object> dataAddress = Map.of(
+                "baseUrl", privateBackendUrl,
+                "type", "HttpData",
+                "contentType", "application/json",
+                "authKey", authCodeHeaderName,
+                "authCode", authCode
+        );
+
+        PLATO.createAsset(assetId, Map.of(), dataAddress);
+
+        var accessPolicyId = PLATO.createPolicyDefinition(createAccessPolicy(SOKRATES.getBpn()));
+        var contractPolicyId = PLATO.createPolicyDefinition(contractPolicy);
+        PLATO.createContractDefinition(assetId, "def-1", accessPolicyId, contractPolicyId);
+        var negotiationId = SOKRATES.initContractNegotiation(PLATO, assetId);
+
+        await().pollInterval(fibonacci())
+                .atMost(ASYNC_TIMEOUT)
+                .untilAsserted(() -> {
+                    var contractNegotiationState = SOKRATES.getContractNegotiationState(negotiationId);
+                    assertThat(contractNegotiationState).isEqualTo("TERMINATED");
+                });
+    }
+
     @Override
     protected JsonObject createContractPolicy(String bpn) {
-        return frameworkPolicy(Map.of(CX_POLICY_NS + "Membership", "active"));
+        return frameworkPolicy(Map.of(CX_CREDENTIAL_NS + "Membership", "active"));
+    }
+
+    private static class ValidContractPolicyProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
+            return Stream.of(
+                    Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "Membership", "active")), "MembershipCredential"),
+                    Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "FrameworkAgreement.pcf", "active")), "PCF Use Case (legacy notation)"),
+                    Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "FrameworkAgreement", "pcf")), "PCF Use Case (new notation)"),
+                    Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "Dismantler", "active")), "Dismantler Credential"),
+                    Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "Dismantler.activityType", "vehicleDismantle")), "Dismantler Cred (activity type)"),
+                    Arguments.of(frameworkPolicy(CX_POLICY_NS + "Dismantler.allowedBrands", Operator.IS_ANY_OF, List.of("Moskvich", "Tatra")), "Dismantler allowedBrands (IS_ANY_OF, one intersects)"),
+                    Arguments.of(frameworkPolicy(CX_POLICY_NS + "Dismantler.allowedBrands", Operator.EQ, List.of("Moskvich", "Lada")), "Dismantler allowedBrands (EQ, exact match)"),
+                    Arguments.of(frameworkPolicy(CX_POLICY_NS + "Dismantler.allowedBrands", Operator.IS_NONE_OF, List.of("Yugo", "Tatra")), "Dismantler allowedBrands (IS_NONE_OF, no intersect)"),
+                    Arguments.of(frameworkPolicy(CX_POLICY_NS + "Dismantler.allowedBrands", Operator.IN, List.of("Moskvich", "Tatra", "Yugo", "Lada")), "Dismantler allowedBrands (IN, fully contained)")
+            );
+        }
+    }
+
+    private static class InvalidContractPolicyProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
+            return Stream.of(
+                    Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "FrameworkAgreement.sustainability", "active")), "Sustainability Use Case (legacy notation)"),
+                    Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "FrameworkAgreement", "traceability")), "Traceability Use Case (new notation)"),
+                    Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "Dismantler.activityType", "vehicleScrap")), "Dismantler activityType does not match"),
+                    Arguments.of(frameworkPolicy(CX_POLICY_NS + "Dismantler.allowedBrands", Operator.NEQ, List.of("Moskvich", "Lada")), "Dismantler allowedBrands (NEQ, but is equal)"),
+                    Arguments.of(frameworkPolicy(CX_POLICY_NS + "Dismantler.allowedBrands", Operator.IS_NONE_OF, List.of("Yugo", "Lada")), "Dismantler allowedBrands (IS_NONE_OF, but is one contains)"),
+                    Arguments.of(frameworkPolicy(CX_POLICY_NS + "Dismantler.allowedBrands", Operator.IN, List.of("Moskvich", "Tatra", "Yugo")), "Dismantler allowedBrands (IN, but not subset)")
+            );
+        }
     }
 
 }

--- a/edc-tests/runtime/iatp/runtime-memory-iatp-dim-ih/build.gradle.kts
+++ b/edc-tests/runtime/iatp/runtime-memory-iatp-dim-ih/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
         exclude(module = "bdrs-client")
     }
     implementation(project(":core:json-ld-core"))
+    implementation(project(":edc-extensions:cx-policy"))
     implementation(project(":edc-extensions:iatp:tx-iatp"))
     implementation(project(":edc-extensions:iatp:tx-iatp-sts-dim"))
 


### PR DESCRIPTION
## WHAT

Runs the policy extractor only on those messages Egress/Ingress:

- CatalogRequestMessage
- ContractRequestMessage
- TransferRequestMessage

that are the messages where the policy evaluation is done in the provider side and needs to be working with the required credentials (from policy).

In addition in this PR

- Restored IATP tests with policy combination 
- Adapted DIM integration test to use a mocked version of BDRS server

Closes #1175 
