### PR TITLE
feat: inject the audience(DID) as additional property

### DIFF
--- a/edc-controlplane/edc-controlplane-base/build.gradle.kts
+++ b/edc-controlplane/edc-controlplane-base/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     runtimeOnly(libs.edc.core.identitytrust)
     runtimeOnly(project(":edc-extensions:iatp:tx-iatp-sts-dim"))
     runtimeOnly(project(":edc-extensions:bdrs-client"))
-
+    runtimeOnly(project(":edc-extensions:data-flow-properties-provider"))
 
     runtimeOnly(libs.edc.core.connector)
     runtimeOnly(libs.edc.core.controlplane)

--- a/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientAudienceMapper.java
+++ b/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientAudienceMapper.java
@@ -17,18 +17,26 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-plugins {
-    `maven-publish`
-    `java-library`
-}
+package org.eclipse.tractusx.edc.identity.mapper;
 
-dependencies {
-    implementation(project(":core:core-utils"))
-    implementation(project(":spi:bdrs-client-spi"))
-    implementation(libs.edc.spi.core)
-    implementation(libs.edc.spi.http)
+import org.eclipse.edc.spi.iam.AudienceResolver;
+import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
 
-    testImplementation(libs.netty.mockserver)
-    testImplementation(libs.edc.junit)
-    testImplementation(libs.awaitility)
+/**
+ * An incoming {@link RemoteMessage} is mapped to a DID by calling {@link BdrsClient#resolve(String)} with the {@link RemoteMessage#getCounterPartyId()}
+ */
+class BdrsClientAudienceMapper implements AudienceResolver {
+
+    private final BdrsClient client;
+
+    BdrsClientAudienceMapper(BdrsClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public String resolve(RemoteMessage remoteMessage) {
+        return client.resolve(remoteMessage.getCounterPartyId());
+    }
+
 }

--- a/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientExtension.java
+++ b/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientExtension.java
@@ -24,11 +24,11 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.spi.iam.AudienceResolver;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.tractusx.edc.core.utils.RequiredConfigWarnings;
+import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
 
 import static org.eclipse.tractusx.edc.identity.mapper.BdrsClientExtension.NAME;
 
@@ -54,13 +54,13 @@ public class BdrsClientExtension implements ServiceExtension {
     }
 
     @Provider
-    public AudienceResolver getBdrsAudienceResolver(ServiceExtensionContext context) {
+    public BdrsClient getBdrsClient(ServiceExtensionContext context) {
         var baseUrl = context.getConfig().getString(BDRS_SERVER_URL_PROPERTY, null);
         if (baseUrl == null) {
             RequiredConfigWarnings.warningNotPresent(context.getMonitor(), BDRS_SERVER_URL_PROPERTY);
         }
         var cacheValidity = context.getConfig().getInteger(BDRS_SERVER_CACHE_VALIDITY_PERIOD, DEFAULT_BDRS_CACHE_VALIDITY);
-        return new BdrsClient(baseUrl, cacheValidity, httpClient, context.getMonitor(), typeManager.getMapper());
+        return new BdrsClientImpl(baseUrl, cacheValidity, httpClient, context.getMonitor(), typeManager.getMapper());
     }
 
 }

--- a/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientImpl.java
+++ b/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientImpl.java
@@ -24,9 +24,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.Request;
 import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.spi.EdcException;
-import org.eclipse.edc.spi.iam.AudienceResolver;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -37,12 +36,11 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.zip.GZIPInputStream;
 
 /**
- * Holds a local cache of BPN-to-DID mapping entries. An incoming {@link RemoteMessage} is mapped by looking up the {@link RemoteMessage#getCounterPartyId()}
- * property in that map.
+ * Holds a local cache of BPN-to-DID mapping entries.
  * <p>
- * The local cache expires after a configurable time, at which point {@link BdrsClient#resolve(RemoteMessage)} requests will hit the server again.
+ * The local cache expires after a configurable time, at which point {@link BdrsClientImpl#resolve(String)}} requests will hit the server again.
  */
-class BdrsClient implements AudienceResolver {
+class BdrsClientImpl implements BdrsClient {
     private static final TypeReference<Map<String, String>> MAP_REF = new TypeReference<>() {
     };
     private final String serverUrl;
@@ -54,7 +52,7 @@ class BdrsClient implements AudienceResolver {
     private Map<String, String> cache = new HashMap<>();
     private Instant lastCacheUpdate;
 
-    BdrsClient(String baseUrl, int cacheValidity, EdcHttpClient httpClient, Monitor monitor, ObjectMapper mapper) {
+    BdrsClientImpl(String baseUrl, int cacheValidity, EdcHttpClient httpClient, Monitor monitor, ObjectMapper mapper) {
         this.serverUrl = baseUrl;
         this.cacheValidity = cacheValidity;
         this.httpClient = httpClient;
@@ -63,8 +61,7 @@ class BdrsClient implements AudienceResolver {
     }
 
     @Override
-    public String resolve(RemoteMessage remoteMessage) {
-        var bpn = remoteMessage.getCounterPartyId();
+    public String resolve(String bpn) {
         String value;
         lock.readLock().lock();
         try {

--- a/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientMapperExtension.java
+++ b/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientMapperExtension.java
@@ -17,18 +17,31 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-plugins {
-    `maven-publish`
-    `java-library`
-}
+package org.eclipse.tractusx.edc.identity.mapper;
 
-dependencies {
-    implementation(project(":core:core-utils"))
-    implementation(project(":spi:bdrs-client-spi"))
-    implementation(libs.edc.spi.core)
-    implementation(libs.edc.spi.http)
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.iam.AudienceResolver;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
 
-    testImplementation(libs.netty.mockserver)
-    testImplementation(libs.edc.junit)
-    testImplementation(libs.awaitility)
+import static org.eclipse.tractusx.edc.identity.mapper.BdrsClientExtension.NAME;
+
+@Extension(value = NAME)
+public class BdrsClientMapperExtension implements ServiceExtension {
+
+    @Inject
+    private BdrsClient bdrsClient;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider
+    public AudienceResolver getBdrsAudienceResolver() {
+        return new BdrsClientAudienceMapper(bdrsClient);
+    }
+
 }

--- a/edc-extensions/bdrs-client/src/test/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientAudienceMapperTest.java
+++ b/edc-extensions/bdrs-client/src/test/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientAudienceMapperTest.java
@@ -1,0 +1,74 @@
+/********************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.identity.mapper;
+
+import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BdrsClientAudienceMapperTest {
+
+    private final BdrsClient client = mock();
+
+    private final BdrsClientAudienceMapper clientAudienceMapper = new BdrsClientAudienceMapper(client);
+
+    @Test
+    void resolve() {
+
+        when(client.resolve("bpn1")).thenReturn("did:web:did1");
+
+        var did = clientAudienceMapper.resolve(new TestMessage("bpn1"));
+
+        assertThat(did).isEqualTo("did:web:did1");
+
+    }
+
+    @Test
+    void resolve_notFound() {
+
+        when(client.resolve("bpn1")).thenReturn(null);
+
+        var did = clientAudienceMapper.resolve(new TestMessage("bpn1"));
+
+        assertThat(did).isNull();
+
+    }
+
+    private record TestMessage(String bpn) implements RemoteMessage {
+        @Override
+        public String getProtocol() {
+            return "test-proto";
+        }
+
+        @Override
+        public String getCounterPartyAddress() {
+            return "http://bpn1";
+        }
+
+        @Override
+        public String getCounterPartyId() {
+            return bpn;
+        }
+    }
+}

--- a/edc-extensions/bdrs-client/src/test/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientImplExtensionTest.java
+++ b/edc-extensions/bdrs-client/src/test/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientImplExtensionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.identity.mapper;
+
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.eclipse.tractusx.edc.identity.mapper.BdrsClientExtension.BDRS_SERVER_URL_PROPERTY;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class BdrsClientImplExtensionTest {
+
+    private final Monitor monitor = mock();
+
+    @BeforeEach
+    void setup(ServiceExtensionContext context) {
+        context.registerService(Monitor.class, monitor);
+    }
+
+    @Test
+    void createClient_whenUrlMissing_expectLogError(ServiceExtensionContext context, BdrsClientExtension extension) {
+        var cfg = mock(Config.class);
+        when(context.getConfig()).thenReturn(cfg);
+        when(cfg.getString(eq(BDRS_SERVER_URL_PROPERTY), isNull())).thenReturn(null);
+
+        extension.getBdrsClient(context);
+        verify(monitor).severe(eq("Mandatory config value missing: 'tx.iam.iatp.bdrs.server.url'. This runtime will not be fully operational! Starting with v0.7.x this will be a runtime error."));
+
+    }
+}

--- a/edc-extensions/bdrs-client/src/test/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientMapperExtensionTest.java
+++ b/edc-extensions/bdrs-client/src/test/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientMapperExtensionTest.java
@@ -17,18 +17,30 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-plugins {
-    `maven-publish`
-    `java-library`
-}
+package org.eclipse.tractusx.edc.identity.mapper;
 
-dependencies {
-    implementation(project(":core:core-utils"))
-    implementation(project(":spi:bdrs-client-spi"))
-    implementation(libs.edc.spi.core)
-    implementation(libs.edc.spi.http)
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-    testImplementation(libs.netty.mockserver)
-    testImplementation(libs.edc.junit)
-    testImplementation(libs.awaitility)
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class BdrsClientMapperExtensionTest {
+
+    private final Monitor monitor = mock();
+
+    @BeforeEach
+    void setup(ServiceExtensionContext context) {
+        context.registerService(Monitor.class, monitor);
+    }
+
+    @Test
+    void createMapper(BdrsClientMapperExtension extension) {
+        assertThat(extension.getBdrsAudienceResolver()).isInstanceOf(BdrsClientAudienceMapper.class);
+    }
 }

--- a/edc-extensions/data-flow-properties-provider/build.gradle.kts
+++ b/edc-extensions/data-flow-properties-provider/build.gradle.kts
@@ -23,12 +23,8 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":core:core-utils"))
+    implementation(libs.edc.spi.transfer)
     implementation(project(":spi:bdrs-client-spi"))
-    implementation(libs.edc.spi.core)
-    implementation(libs.edc.spi.http)
 
-    testImplementation(libs.netty.mockserver)
     testImplementation(libs.edc.junit)
-    testImplementation(libs.awaitility)
 }

--- a/edc-extensions/data-flow-properties-provider/src/main/java/org/eclipse/tractusx/edc/flow/TxDataFlowPropertiesProvider.java
+++ b/edc-extensions/data-flow-properties-provider/src/main/java/org/eclipse/tractusx/edc/flow/TxDataFlowPropertiesProvider.java
@@ -1,0 +1,55 @@
+/********************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.flow;
+
+import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowPropertiesProvider;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.response.ResponseStatus;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
+
+import java.util.Map;
+
+/**
+ * Extension of {@link DataFlowPropertiesProvider} which provides additional properties in the {@link DataFlowStartMessage}
+ * like the DID of the counter-party BPN. The resolution is made with the {@link BdrsClient}
+ */
+public class TxDataFlowPropertiesProvider implements DataFlowPropertiesProvider {
+
+    private static final String AUDIENCE_PROPERTY = "audience";
+
+    private final BdrsClient bdrsClient;
+
+    public TxDataFlowPropertiesProvider(BdrsClient bdrsClient) {
+        this.bdrsClient = bdrsClient;
+    }
+
+    @Override
+    public StatusResult<Map<String, String>> propertiesFor(TransferProcess transferProcess, Policy policy) {
+        var did = bdrsClient.resolve(policy.getAssignee());
+        if (did != null) {
+            return StatusResult.success(Map.of(AUDIENCE_PROPERTY, did));
+        } else {
+            return StatusResult.failure(ResponseStatus.FATAL_ERROR, "Failed to fetch did for BPN %s".formatted(policy.getAssignee()));
+        }
+    }
+}

--- a/edc-extensions/data-flow-properties-provider/src/main/java/org/eclipse/tractusx/edc/flow/TxDataFlowPropertiesProviderExtension.java
+++ b/edc-extensions/data-flow-properties-provider/src/main/java/org/eclipse/tractusx/edc/flow/TxDataFlowPropertiesProviderExtension.java
@@ -17,18 +17,27 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-plugins {
-    `maven-publish`
-    `java-library`
-}
+package org.eclipse.tractusx.edc.flow;
 
-dependencies {
-    implementation(project(":core:core-utils"))
-    implementation(project(":spi:bdrs-client-spi"))
-    implementation(libs.edc.spi.core)
-    implementation(libs.edc.spi.http)
+import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowPropertiesProvider;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
 
-    testImplementation(libs.netty.mockserver)
-    testImplementation(libs.edc.junit)
-    testImplementation(libs.awaitility)
+import static org.eclipse.tractusx.edc.flow.TxDataFlowPropertiesProviderExtension.NAME;
+
+@Extension(NAME)
+public class TxDataFlowPropertiesProviderExtension implements ServiceExtension {
+
+    protected static final String NAME = "Tractus-X Data flow properties provider extension";
+
+    @Inject
+    private BdrsClient bdrsClient;
+
+    @Provider
+    public DataFlowPropertiesProvider dataFlowPropertiesProvider() {
+        return new TxDataFlowPropertiesProvider(bdrsClient);
+    }
 }

--- a/edc-extensions/data-flow-properties-provider/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/edc-extensions/data-flow-properties-provider/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -17,5 +17,4 @@
 #  SPDX-License-Identifier: Apache-2.0
 #################################################################################
 
-org.eclipse.tractusx.edc.identity.mapper.BdrsClientExtension
-org.eclipse.tractusx.edc.identity.mapper.BdrsClientMapperExtension
+org.eclipse.tractusx.edc.flow.TxDataFlowPropertiesProviderExtension

--- a/edc-extensions/data-flow-properties-provider/src/test/java/org/eclipse/tractusx/edc/flow/TxDataFlowPropertiesProviderExtensionTest.java
+++ b/edc-extensions/data-flow-properties-provider/src/test/java/org/eclipse/tractusx/edc/flow/TxDataFlowPropertiesProviderExtensionTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+/********************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,27 +15,22 @@
  * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- */
+ ********************************************************************************/
 
-package org.eclipse.tractusx.edc.identity.mapper;
+package org.eclipse.tractusx.edc.flow;
 
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.system.configuration.Config;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.eclipse.tractusx.edc.identity.mapper.BdrsClientExtension.BDRS_SERVER_URL_PROPERTY;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
-class BdrsClientExtensionTest {
+class TxDataFlowPropertiesProviderExtensionTest {
 
     private final Monitor monitor = mock();
 
@@ -45,13 +40,7 @@ class BdrsClientExtensionTest {
     }
 
     @Test
-    void createClient_whenUrlMissing_expectLogError(ServiceExtensionContext context, BdrsClientExtension extension) {
-        var cfg = mock(Config.class);
-        when(context.getConfig()).thenReturn(cfg);
-        when(cfg.getString(eq(BDRS_SERVER_URL_PROPERTY), isNull())).thenReturn(null);
-
-        extension.getBdrsAudienceResolver(context);
-        verify(monitor).severe(eq("Mandatory config value missing: 'tx.iam.iatp.bdrs.server.url'. This runtime will not be fully operational! Starting with v0.7.x this will be a runtime error."));
-
+    void createMapper(TxDataFlowPropertiesProviderExtension extension) {
+        assertThat(extension.dataFlowPropertiesProvider()).isInstanceOf(TxDataFlowPropertiesProvider.class);
     }
 }

--- a/edc-extensions/data-flow-properties-provider/src/test/java/org/eclipse/tractusx/edc/flow/TxDataFlowPropertiesProviderTest.java
+++ b/edc-extensions/data-flow-properties-provider/src/test/java/org/eclipse/tractusx/edc/flow/TxDataFlowPropertiesProviderTest.java
@@ -1,0 +1,62 @@
+/********************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.flow;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
+import org.junit.jupiter.api.Test;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TxDataFlowPropertiesProviderTest {
+
+    private final BdrsClient client = mock();
+    private final TxDataFlowPropertiesProvider provider = new TxDataFlowPropertiesProvider(client);
+
+
+    @Test
+    void propertiesFor() {
+
+        var bpn = "bpn";
+        var did = "did";
+
+        when(client.resolve(bpn)).thenReturn(did);
+        var result = provider.propertiesFor(TransferProcess.Builder.newInstance().build(), Policy.Builder.newInstance().assignee(bpn).build());
+
+        assertThat(result).isSucceeded().satisfies(properties -> {
+            Assertions.assertThat(properties).containsEntry("audience", did);
+        });
+    }
+
+    @Test
+    void propertiesFor_fails_whenResolutionIsNull() {
+
+        var bpn = "bpn";
+
+        when(client.resolve(bpn)).thenReturn(null);
+        var result = provider.propertiesFor(TransferProcess.Builder.newInstance().build(), Policy.Builder.newInstance().assignee(bpn).build());
+
+        assertThat(result).isFailed().withFailMessage("Failed to fetch did for BPN %s".formatted(bpn));
+    }
+}

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImpl.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImpl.java
@@ -43,6 +43,7 @@ import org.eclipse.edc.token.spi.TokenDecorator;
 import org.eclipse.edc.token.spi.TokenGenerationService;
 import org.eclipse.edc.token.spi.TokenValidationRule;
 import org.eclipse.edc.token.spi.TokenValidationService;
+import org.eclipse.tractusx.edc.dataplane.tokenrefresh.core.rules.AuthTokenAudienceRule;
 import org.eclipse.tractusx.edc.dataplane.tokenrefresh.core.rules.ClaimIsPresentRule;
 import org.eclipse.tractusx.edc.dataplane.tokenrefresh.core.rules.IssuerEqualsSubjectRule;
 import org.eclipse.tractusx.edc.dataplane.tokenrefresh.core.rules.RefreshTokenValidationRule;
@@ -119,8 +120,8 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
         authenticationTokenValidationRules = List.of(new IssuerEqualsSubjectRule(),
                 new ClaimIsPresentRule(AUDIENCE), // we don't check the contents, only it is present
                 new ClaimIsPresentRule(ACCESS_TOKEN_CLAIM),
-                new ClaimIsPresentRule(TOKEN_ID_CLAIM)
-                /*new AuthTokenAudienceRule(accessTokenDataStore)*/);
+                new ClaimIsPresentRule(TOKEN_ID_CLAIM),
+                new AuthTokenAudienceRule(accessTokenDataStore));
         accessTokenAuthorizationRules = List.of(new IssuerEqualsSubjectRule(),
                 new ClaimIsPresentRule(AUDIENCE),
                 new ClaimIsPresentRule(TOKEN_ID_CLAIM),
@@ -147,9 +148,7 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
     public Result<TokenResponse> refreshToken(String refreshToken, String authenticationToken) {
 
         authenticationToken = authenticationToken.replace("Bearer", "").trim();
-
-        // 1. validate authentication token
-        monitor.warning(" TOKEN REFRESH :: TEMPORARILY DISABLED RULE AuthTokenAudienceRule UNTIL THE 'audience' PROPERTY IS FORWARDED TO DATAPLANES%n");
+        
         var authTokenRes = tokenValidationService.validate(authenticationToken, publicKeyResolver, authenticationTokenValidationRules);
         if (authTokenRes.failed()) {
             return Result.failure("Authentication token validation failed: %s".formatted(authTokenRes.getFailureDetail()));

--- a/edc-tests/edc-controlplane/fixtures/build.gradle.kts
+++ b/edc-tests/edc-controlplane/fixtures/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     testFixturesApi(project(":edc-extensions:edr:edr-api-v2"))
     testFixturesApi(project(":spi:core-spi"))
     testFixturesApi(project(":spi:tokenrefresh-spi"))
+    testFixturesApi(project(":spi:bdrs-client-spi"))
 
     testFixturesApi(libs.edc.spi.core)
     testFixturesApi(libs.edc.spi.policy)

--- a/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/runtimes/BeforeInitCallback.java
+++ b/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/runtimes/BeforeInitCallback.java
@@ -1,5 +1,5 @@
-/********************************************************************************
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,20 +15,18 @@
  * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- ********************************************************************************/
+ */
 
-plugins {
-    `maven-publish`
-    `java-library`
-}
+package org.eclipse.tractusx.edc.tests.runtimes;
 
-dependencies {
-    implementation(project(":core:core-utils"))
-    implementation(project(":spi:bdrs-client-spi"))
-    implementation(libs.edc.spi.core)
-    implementation(libs.edc.spi.http)
+import org.eclipse.edc.junit.extensions.EdcExtension;
 
-    testImplementation(libs.netty.mockserver)
-    testImplementation(libs.edc.junit)
-    testImplementation(libs.awaitility)
+/**
+ * Callback invoked before the runtime boots with extensions of {@link EdcExtension}. This will allow injecting
+ * custom mock services directly in the tests rather than extending the {@link EdcExtension} with custom mocks
+ */
+@FunctionalInterface
+public interface BeforeInitCallback {
+
+    void beforeInit(EdcExtension runtime);
 }

--- a/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/runtimes/ParticipantRuntime.java
+++ b/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/runtimes/ParticipantRuntime.java
@@ -36,6 +36,7 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 import org.eclipse.edc.token.JwtGenerationService;
+import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
 import org.eclipse.tractusx.edc.tests.MockBpnIdentityService;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -54,12 +55,15 @@ public class ParticipantRuntime extends EdcRuntimeExtension implements BeforeAll
     private DataWiper wiper;
 
     public ParticipantRuntime(String moduleName, String runtimeName, String bpn, Map<String, String> properties) {
+        this(moduleName, runtimeName, bpn, properties, null);
+    }
+
+    public ParticipantRuntime(String moduleName, String runtimeName, String bpn, Map<String, String> properties, BeforeInitCallback beforeInitCallback) {
         super(moduleName, runtimeName, properties);
         this.properties = properties;
-        if (!properties.containsKey("tx.ssi.miw.url")) {
-            this.registerServiceMock(IdentityService.class, new MockBpnIdentityService(bpn));
-            this.registerServiceMock(AudienceResolver.class, RemoteMessage::getCounterPartyAddress);
-        }
+        this.registerServiceMock(IdentityService.class, new MockBpnIdentityService(bpn));
+        this.registerServiceMock(AudienceResolver.class, RemoteMessage::getCounterPartyAddress);
+        this.registerServiceMock(BdrsClient.class, (s) -> s);
         var kid = properties.get("edc.iam.issuer.id") + "#key-1";
         try {
             runtimeKeyPair = new ECKeyGenerator(Curve.P_256).keyID(kid).generate();
@@ -70,6 +74,10 @@ public class ParticipantRuntime extends EdcRuntimeExtension implements BeforeAll
             registerServiceMock(DidPublicKeyResolver.class, keyId -> Result.success(KeyPool.forId(keyId).getPublic()));
         } catch (JOSEException e) {
             throw new RuntimeException(e);
+        }
+
+        if (beforeInitCallback != null) {
+            beforeInitCallback.beforeInit(this);
         }
     }
 

--- a/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/runtimes/Runtimes.java
+++ b/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/runtimes/Runtimes.java
@@ -24,7 +24,11 @@ import java.util.Map;
 public interface Runtimes {
 
     static ParticipantRuntime memoryRuntime(String runtimeName, String bpn, Map<String, String> properties) {
-        return new ParticipantRuntime(":edc-tests:runtime:runtime-memory", runtimeName, bpn, properties);
+        return memoryRuntime(runtimeName, bpn, properties, null);
+    }
+
+    static ParticipantRuntime memoryRuntime(String runtimeName, String bpn, Map<String, String> properties, BeforeInitCallback callback) {
+        return new ParticipantRuntime(":edc-tests:runtime:runtime-memory", runtimeName, bpn, properties, callback);
     }
 
     static PgParticipantRuntime pgRuntime(String runtimeName, String bpn, Map<String, String> properties) {

--- a/edc-tests/edc-controlplane/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/iatp/runtime/IatpParticipantRuntime.java
+++ b/edc-tests/edc-controlplane/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/iatp/runtime/IatpParticipantRuntime.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.security.token.jwt.CryptoConverter;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
 import org.eclipse.tractusx.edc.tests.runtimes.DataWiper;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -46,6 +47,7 @@ public class IatpParticipantRuntime extends EdcRuntimeExtension implements Befor
         super(moduleName, runtimeName, properties);
         this.properties = properties;
         runtimeKeyPair = CryptoConverter.createJwk(runtimeKeypair);
+        this.registerServiceMock(BdrsClient.class, (s) -> s);
     }
 
     @Override

--- a/edc-tests/edc-controlplane/transfer-tests/build.gradle.kts
+++ b/edc-tests/edc-controlplane/transfer-tests/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 }
 
 dependencies {
+    testImplementation(project(":spi:bdrs-client-spi"))
     testImplementation(testFixtures(project(":edc-tests:edc-controlplane:fixtures")))
 
     testImplementation(libs.netty.mockserver)

--- a/edc-tests/edc-controlplane/transfer-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/TransferWithTokenRefreshTest.java
+++ b/edc-tests/edc-controlplane/transfer-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/TransferWithTokenRefreshTest.java
@@ -23,6 +23,8 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.EdcExtension;
+import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
 import org.eclipse.tractusx.edc.tests.participant.TransferParticipant;
 import org.eclipse.tractusx.edc.tests.runtimes.ParticipantRuntime;
 import org.junit.jupiter.api.AfterEach;
@@ -77,7 +79,7 @@ public class TransferWithTokenRefreshTest {
     private static final Long VERY_SHORT_TOKEN_EXPIRY = 3L;
 
     @RegisterExtension
-    protected static final ParticipantRuntime PLATO_RUNTIME = memoryRuntime(PLATO.getName(), PLATO.getBpn(), forConfig(PLATO.getConfiguration()));
+    protected static final ParticipantRuntime PLATO_RUNTIME = memoryRuntime(PLATO.getName(), PLATO.getBpn(), forConfig(PLATO.getConfiguration()), TransferWithTokenRefreshTest::platoInitiator);
     protected ClientAndServer server;
     private String privateBackendUrl;
 
@@ -87,6 +89,10 @@ public class TransferWithTokenRefreshTest {
         newConfig.put("edc.dataplane.token.expiry", String.valueOf(VERY_SHORT_TOKEN_EXPIRY));
         newConfig.put("edc.dataplane.token.expiry.tolerance", "0");
         return newConfig;
+    }
+
+    private static void platoInitiator(EdcExtension runtime) {
+        runtime.registerServiceMock(BdrsClient.class, (c) -> SOKRATES.getDid());
     }
 
     @BeforeEach

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ include(":spi:callback-spi")
 include(":spi:edr-spi")
 include(":spi:core-spi")
 include(":spi:tokenrefresh-spi")
+include(":spi:bdrs-client-spi")
 
 
 // core modules
@@ -49,6 +50,7 @@ include(":edc-extensions:edr:edr-callback")
 include(":edc-extensions:cx-policy")
 include(":edc-extensions:iatp:tx-iatp")
 include(":edc-extensions:iatp:tx-iatp-sts-dim")
+include(":edc-extensions:data-flow-properties-provider")
 
 // extensions - data plane
 include(":edc-extensions:dataplane:dataplane-proxy:edc-dataplane-proxy-consumer-api")

--- a/spi/bdrs-client-spi/build.gradle.kts
+++ b/spi/bdrs-client-spi/build.gradle.kts
@@ -18,17 +18,10 @@
  ********************************************************************************/
 
 plugins {
-    `maven-publish`
     `java-library`
+    `maven-publish`
 }
 
 dependencies {
-    implementation(project(":core:core-utils"))
-    implementation(project(":spi:bdrs-client-spi"))
     implementation(libs.edc.spi.core)
-    implementation(libs.edc.spi.http)
-
-    testImplementation(libs.netty.mockserver)
-    testImplementation(libs.edc.junit)
-    testImplementation(libs.awaitility)
 }

--- a/spi/bdrs-client-spi/src/main/java/org/eclipse/tractusx/edc/spi/identity/mapper/BdrsClient.java
+++ b/spi/bdrs-client-spi/src/main/java/org/eclipse/tractusx/edc/spi/identity/mapper/BdrsClient.java
@@ -17,18 +17,21 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-plugins {
-    `maven-publish`
-    `java-library`
-}
+package org.eclipse.tractusx.edc.spi.identity.mapper;
 
-dependencies {
-    implementation(project(":core:core-utils"))
-    implementation(project(":spi:bdrs-client-spi"))
-    implementation(libs.edc.spi.core)
-    implementation(libs.edc.spi.http)
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 
-    testImplementation(libs.netty.mockserver)
-    testImplementation(libs.edc.junit)
-    testImplementation(libs.awaitility)
+/**
+ * Interface for resolving BPNs to DIDs
+ */
+@ExtensionPoint
+public interface BdrsClient {
+
+    /**
+     * Resolve the input BPN to a DID
+     *
+     * @param bpn The participantID (BPN)
+     * @return The resolved DID if found, null otherwise
+     */
+    String resolve(String bpn);
 }


### PR DESCRIPTION
## WHAT

 Inject the audience(DID) as additional property in the `DataFlowStartMessage` for later verification in refresh token.
The DID is resolved via implementation of `BdrsClient`

- The `BdrsClient` has been renamed to `BdrsClientImpl` and an SPI `BdrsClient` was introduced.
- The integration with the `AudienceMapper` now it's done in `BdrsClientAudienceMapper`
- In the custom `DataFlowPropertiesProvider` the `BdrsClient` is injected for resolving BPN -> DID and setting the additional property `audience` for token renewal checks 
- The `ParticipantRuntime` has been enriched for injecting custom mock services directly from the tests (Runtime creation)

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #1186 
