### PR TITLE
chore: improve github release config

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -21,15 +21,23 @@
 ---
 changelog:
   exclude:
+    labels:
+      - dependencies
     authors:
-      - dependabot[bot]
+      - 'dependabot[bot]'
   categories:
+    - title: Breaking changes
+      labels:
+        - breaking-change
     - title: Bugfixes
       labels:
         - bug
     - title: New Features & Improvements
       labels:
-        - "*"
+        - enhancement
     - title: Documentation
       labels:
         - documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -319,13 +319,13 @@ maven/mavencentral/org.awaitility/awaitility/4.2.0, Apache-2.0, approved, #14178
 maven/mavencentral/org.awaitility/awaitility/4.2.1, Apache-2.0, approved, #14178
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.72, MIT, approved, #3789
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.77, MIT, approved, #11593
-maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.78, None, restricted, #14235
+maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.78, MIT, approved, #14235
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.72, MIT AND CC0-1.0, approved, #3538
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.77, MIT AND CC0-1.0, approved, #11595
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78, MIT AND CC0-1.0, approved, #14237
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.72, MIT, approved, #3790
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.77, MIT, approved, #11596
-maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.78, None, restricted, #14238
+maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.78, MIT, approved, #14238
 maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined
@@ -532,7 +532,7 @@ maven/mavencentral/org.eclipse.jetty/jetty-util/11.0.20, EPL-2.0 OR Apache-2.0, 
 maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.20, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.20, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.flywaydb/flyway-core/10.11.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.flywaydb/flyway-database-postgresql/10.11.0, , restricted, clearlydefined
+maven/mavencentral/org.flywaydb/flyway-database-postgresql/10.11.0, Apache-2.0, approved, #14239
 maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/3.0.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-locator/3.0.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish


### PR DESCRIPTION
## WHAT

Improves the categorization of issues in automatically generated release notes. This new config matches the one we have in upstream EDC.

## WHY

Avoid bloated and hard-to-read release notes

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
