### PR TITLE
fix: typo in providedId filter mapping

### DIFF
--- a/edc-extensions/dataplane/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/asset/ConsumerAssetRequestController.java
+++ b/edc-extensions/dataplane/dataplane-proxy/edc-dataplane-proxy-consumer-api/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/consumer/api/asset/ConsumerAssetRequestController.java
@@ -78,7 +78,7 @@ public class ConsumerAssetRequestController implements ConsumerAssetRequestApi {
 
 
     private final Map<String, Function<AssetRequest, String>> mappers = Map.of(
-            "provider", AssetRequest::getProviderId,
+            "providerId", AssetRequest::getProviderId,
             "transferProcessId", AssetRequest::getTransferProcessId,
             "assetId", AssetRequest::getAssetId);
 

--- a/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/ParticipantConsumerDataPlaneApi.java
+++ b/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/ParticipantConsumerDataPlaneApi.java
@@ -1,0 +1,54 @@
+/********************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.tests;
+
+import io.restassured.http.ContentType;
+import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * E2E test helper for fetching the data
+ */
+public class ParticipantConsumerDataPlaneApi {
+
+
+    private final Participant.Endpoint dataPlaneProxy;
+
+    public ParticipantConsumerDataPlaneApi(Participant.Endpoint dataPlaneProxy) {
+
+        this.dataPlaneProxy = dataPlaneProxy;
+    }
+
+
+    public String pullData(Map<String, String> body) {
+        var response = dataPlaneProxy.baseRequest()
+                .body(body)
+                .contentType(ContentType.JSON)
+                .post("/proxy/aas/request");
+
+        assertThat(response.statusCode()).isBetween(200, 300);
+        return response.body().asString();
+    }
+
+}

--- a/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java
+++ b/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.edc.tests.participant;
 import jakarta.json.Json;
 import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
 import org.eclipse.tractusx.edc.tests.IdentityParticipant;
+import org.eclipse.tractusx.edc.tests.ParticipantConsumerDataPlaneApi;
 import org.eclipse.tractusx.edc.tests.ParticipantDataApi;
 import org.eclipse.tractusx.edc.tests.ParticipantEdrApi;
 import org.jetbrains.annotations.NotNull;
@@ -47,14 +48,16 @@ public abstract class TractusxParticipantBase extends IdentityParticipant {
     public static final String API_KEY = "testkey";
     public static final Duration ASYNC_TIMEOUT = ofSeconds(60);
     public static final Duration ASYNC_POLL_INTERVAL = ofSeconds(1);
+    protected final URI dataPlaneProxy = URI.create("http://localhost:" + getFreePort());
     private final URI controlPlaneDefault = URI.create("http://localhost:" + getFreePort());
     private final URI controlPlaneControl = URI.create("http://localhost:" + getFreePort() + "/control");
     private final URI backendProviderProxy = URI.create("http://localhost:" + getFreePort() + "/events");
-    private final URI dataPlaneProxy = URI.create("http://localhost:" + getFreePort());
     private final URI dataPlanePublic = URI.create("http://localhost:" + getFreePort() + "/public");
 
     protected ParticipantEdrApi edrs;
     protected ParticipantDataApi data;
+    protected ParticipantConsumerDataPlaneApi dataPlane;
+
     protected String did;
 
     public void createAsset(String id) {
@@ -121,6 +124,14 @@ public abstract class TractusxParticipantBase extends IdentityParticipant {
         return data;
     }
 
+
+    /**
+     * Returns the consumer data plane api for fetching data via consumer proxy
+     */
+    public ParticipantConsumerDataPlaneApi dataPlane() {
+        return dataPlane;
+    }
+
     /**
      * Stores BPN groups
      */
@@ -172,6 +183,7 @@ public abstract class TractusxParticipantBase extends IdentityParticipant {
 
             this.participant.edrs = new ParticipantEdrApi(participant);
             this.participant.data = new ParticipantDataApi();
+            this.participant.dataPlane = new ParticipantConsumerDataPlaneApi(new Endpoint(this.participant.dataPlaneProxy, Map.of("x-api-key", API_KEY)));
             return participant;
         }
     }

--- a/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/transfer/HttpConsumerPullBaseTest.java
+++ b/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/transfer/HttpConsumerPullBaseTest.java
@@ -106,8 +106,59 @@ public abstract class HttpConsumerPullBaseTest implements ParticipantAwareTest {
                 .withHeader("Edc-Contract-Agreement-Id")
                 .withHeader("Edc-Bpn", sokrates().getBpn())
                 .withMethod("GET"), VerificationTimes.exactly(1));
-
+        
     }
+
+
+    @Test
+    void transferData_privateBackend_withConsumerDataPlane() {
+        var assetId = "api-asset-1";
+
+
+        Map<String, Object> dataAddress = Map.of(
+                "baseUrl", privateBackendUrl,
+                "type", "HttpData",
+                "contentType", "application/json"
+        );
+
+        plato().createAsset(assetId, Map.of(), dataAddress);
+
+        var accessPolicyId = plato().createPolicyDefinition(createAccessPolicy(sokrates().getBpn()));
+        var contractPolicyId = plato().createPolicyDefinition(createContractPolicy(sokrates().getBpn()));
+        plato().createContractDefinition(assetId, "def-1", accessPolicyId, contractPolicyId);
+        var transferProcessId = sokrates().requestAsset(plato(), assetId, Json.createObjectBuilder().build(), createProxyRequest(), "HttpData-PULL");
+
+        var edr = new AtomicReference<JsonObject>();
+
+        // wait until transfer process completes
+        await().pollInterval(fibonacci())
+                .atMost(ASYNC_TIMEOUT)
+                .untilAsserted(() -> {
+                    var tpState = sokrates().getTransferProcessState(transferProcessId);
+                    assertThat(tpState).isNotNull().isEqualTo(TransferProcessStates.STARTED.toString());
+                });
+
+        // wait until EDC is available on the consumer side
+        server.when(request().withMethod("GET").withPath(MOCK_BACKEND_PATH)).respond(response().withStatusCode(200).withBody("test response"));
+        await().pollInterval(fibonacci())
+                .atMost(ASYNC_TIMEOUT)
+                .untilAsserted(() -> {
+                    edr.set(sokrates().edrs().getEdr(transferProcessId));
+                    assertThat(edr).isNotNull();
+                });
+
+
+        // pull data out of provider's backend service:
+        //Consumer-DP -> Prov-DP -> Prov-backend
+        assertThat(sokrates().dataPlane().pullData(Map.of("transferProcessId", transferProcessId))).isEqualTo("test response");
+
+        server.verify(request()
+                .withPath(MOCK_BACKEND_PATH)
+                .withHeader("Edc-Contract-Agreement-Id")
+                .withHeader("Edc-Bpn", sokrates().getBpn())
+                .withMethod("GET"), VerificationTimes.exactly(1));
+    }
+
 
     @AfterEach
     void teardown() {


### PR DESCRIPTION
## WHAT

Fixes fetching data when providing additional `providerId` property as  filtering

## WHY

bugfix

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #1202 
