### PR TITLE
feat: add Authorization header to BDRS request

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -144,9 +144,9 @@ maven/mavencentral/dev.failsafe/failsafe/3.3.2, Apache-2.0, approved, #9268
 maven/mavencentral/info.picocli/picocli/4.7.5, Apache-2.0, approved, #4365
 maven/mavencentral/io.github.classgraph/classgraph/4.8.154, MIT, approved, CQ22530
 maven/mavencentral/io.github.classgraph/classgraph/4.8.165, MIT, approved, CQ22530
-maven/mavencentral/io.micrometer/micrometer-commons/1.12.4, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #11679
-maven/mavencentral/io.micrometer/micrometer-core/1.12.4, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #11678
-maven/mavencentral/io.micrometer/micrometer-observation/1.12.4, Apache-2.0, approved, #11680
+maven/mavencentral/io.micrometer/micrometer-commons/1.12.5, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #11679
+maven/mavencentral/io.micrometer/micrometer-core/1.12.5, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #11678
+maven/mavencentral/io.micrometer/micrometer-observation/1.12.5, Apache-2.0, approved, #11680
 maven/mavencentral/io.netty/netty-buffer/4.1.100.Final, Apache-2.0, approved, CQ21842
 maven/mavencentral/io.netty/netty-buffer/4.1.101.Final, Apache-2.0, approved, CQ21842
 maven/mavencentral/io.netty/netty-buffer/4.1.108.Final, Apache-2.0, approved, CQ21842
@@ -318,13 +318,10 @@ maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
 maven/mavencentral/org.awaitility/awaitility/4.2.0, Apache-2.0, approved, #14178
 maven/mavencentral/org.awaitility/awaitility/4.2.1, Apache-2.0, approved, #14178
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.72, MIT, approved, #3789
-maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.77, MIT, approved, #11593
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.78, MIT, approved, #14235
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.72, MIT AND CC0-1.0, approved, #3538
-maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.77, MIT AND CC0-1.0, approved, #11595
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78, MIT AND CC0-1.0, approved, #14237
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.72, MIT, approved, #3790
-maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.77, MIT, approved, #11596
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.78, MIT, approved, #14238
 maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined

--- a/core/core-utils/src/main/java/org/eclipse/tractusx/edc/core/utils/RequiredConfigWarnings.java
+++ b/core/core-utils/src/main/java/org/eclipse/tractusx/edc/core/utils/RequiredConfigWarnings.java
@@ -23,7 +23,7 @@ import org.eclipse.edc.spi.monitor.Monitor;
 
 public class RequiredConfigWarnings {
 
-    public static void warningNotPresent(Monitor monitor, String missingConfig) {
+    public static void missingMandatoryProperty(Monitor monitor, String missingConfig) {
         monitor.severe("Mandatory config value missing: '%s'. This runtime will not be fully operational! Starting with v0.7.x this will be a runtime error.".formatted(missingConfig));
     }
 }

--- a/edc-extensions/bdrs-client/build.gradle.kts
+++ b/edc-extensions/bdrs-client/build.gradle.kts
@@ -25,8 +25,12 @@ plugins {
 dependencies {
     implementation(project(":core:core-utils"))
     implementation(project(":spi:bdrs-client-spi"))
+    implementation(project(":spi:core-spi"))
+    implementation(libs.edc.spi.boot)
     implementation(libs.edc.spi.core)
     implementation(libs.edc.spi.http)
+    implementation(libs.edc.spi.identitytrust)
+    implementation(libs.edc.spi.jwt) //JwtRegisteredClaimNames
 
     testImplementation(libs.netty.mockserver)
     testImplementation(libs.edc.junit)

--- a/edc-extensions/bdrs-client/build.gradle.kts
+++ b/edc-extensions/bdrs-client/build.gradle.kts
@@ -30,7 +30,10 @@ dependencies {
     implementation(libs.edc.spi.core)
     implementation(libs.edc.spi.http)
     implementation(libs.edc.spi.identitytrust)
+    implementation(libs.edc.spi.identity.did)
     implementation(libs.edc.spi.jwt) //JwtRegisteredClaimNames
+
+    implementation(libs.edc.identity.trust.service)
 
     testImplementation(libs.netty.mockserver)
     testImplementation(libs.edc.junit)

--- a/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientExtension.java
+++ b/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientExtension.java
@@ -20,18 +20,23 @@
 package org.eclipse.tractusx.edc.identity.mapper;
 
 import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.iam.identitytrust.spi.CredentialServiceClient;
+import org.eclipse.edc.iam.identitytrust.spi.CredentialServiceUrlResolver;
+import org.eclipse.edc.iam.identitytrust.spi.SecureTokenService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Requires;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.tractusx.edc.core.utils.RequiredConfigWarnings;
 import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
 
+import static org.eclipse.tractusx.edc.core.utils.RequiredConfigWarnings.missingMandatoryProperty;
 import static org.eclipse.tractusx.edc.identity.mapper.BdrsClientExtension.NAME;
 
+@Requires(CredentialServiceUrlResolver.class)
 @Extension(value = NAME)
 public class BdrsClientExtension implements ServiceExtension {
     public static final String NAME = "BPN/DID Resolution Service Client Extension";
@@ -40,13 +45,26 @@ public class BdrsClientExtension implements ServiceExtension {
     @Setting(value = "Base URL of the BDRS service", required = true)
     public static final String BDRS_SERVER_URL_PROPERTY = "tx.iam.iatp.bdrs.server.url";
 
+    @Setting(value = "Base URL of the CredentialService, that belongs to this connector runtime. If not specified, the URL is resolved from this participant's DID document.")
+    public static final String CREDENTIAL_SERVICE_BASE_URL_PROPERTY = "tx.iam.iatp.credentialservice.url";
+
     @Setting(value = "Validity period in seconds for the cached BPN/DID mappings. After this period a new resolution request will hit the server.", defaultValue = DEFAULT_BDRS_CACHE_VALIDITY + "")
     public static final String BDRS_SERVER_CACHE_VALIDITY_PERIOD = "tx.iam.iatp.bdrs.cache.validity";
 
+    // this setting is already defined in IdentityAndTrustExtension
+    public static final String CONNECTOR_DID_PROPERTY = "edc.iam.issuer.id";
+
     @Inject
     private EdcHttpClient httpClient;
+
     @Inject
     private TypeManager typeManager;
+
+    @Inject
+    private SecureTokenService secureTokenService;
+
+    @Inject
+    private CredentialServiceClient credentialServiceClient;
 
     @Override
     public String name() {
@@ -56,11 +74,30 @@ public class BdrsClientExtension implements ServiceExtension {
     @Provider
     public BdrsClient getBdrsClient(ServiceExtensionContext context) {
         var baseUrl = context.getConfig().getString(BDRS_SERVER_URL_PROPERTY, null);
+        var monitor = context.getMonitor();
         if (baseUrl == null) {
-            RequiredConfigWarnings.warningNotPresent(context.getMonitor(), BDRS_SERVER_URL_PROPERTY);
+            missingMandatoryProperty(monitor, BDRS_SERVER_URL_PROPERTY);
         }
         var cacheValidity = context.getConfig().getInteger(BDRS_SERVER_CACHE_VALIDITY_PERIOD, DEFAULT_BDRS_CACHE_VALIDITY);
-        return new BdrsClientImpl(baseUrl, cacheValidity, httpClient, context.getMonitor(), typeManager.getMapper());
+
+        // get DID
+        var ownDid = context.getConfig().getString(CONNECTOR_DID_PROPERTY, null);
+        if (ownDid == null) {
+            missingMandatoryProperty(monitor, CONNECTOR_DID_PROPERTY);
+        }
+
+        // get CS URL
+        var url = context.getConfig().getString(CREDENTIAL_SERVICE_BASE_URL_PROPERTY, null);
+        if (url == null) {
+            monitor.warning("No config value found for '%s'. As a fallback, the credentialService URL from this connector's DID document will be resolved");
+            var resolver = context.getService(CredentialServiceUrlResolver.class);
+            url = resolver.resolve(ownDid).orElseThrow(f -> {
+                monitor.severe("Resolving the credentialService URL failed. This runtime won't be able to communicate with BDRS. Error: %s.");
+                return null;
+            });
+        }
+
+        return new BdrsClientImpl(baseUrl, cacheValidity, ownDid, url, httpClient, monitor, typeManager.getMapper(), secureTokenService, credentialServiceClient);
     }
 
 }

--- a/edc-extensions/bdrs-client/src/test/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientImplTest.java
+++ b/edc-extensions/bdrs-client/src/test/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientImplTest.java
@@ -66,6 +66,7 @@ import static org.mockserver.verify.VerificationTimes.never;
 
 class BdrsClientImplTest {
 
+    public static final String TEST_VP_CONTENT = "test-raw-vp";
     private final Monitor monitor = mock();
     private final ObjectMapper mapper = new ObjectMapper();
     private final SecureTokenService stsMock = mock();
@@ -86,7 +87,7 @@ class BdrsClientImplTest {
 
         client = new BdrsClientImpl("http://localhost:%d/api".formatted(bdrsServer.getPort()), 1,
                 "did:web:self",
-                "http://credential.service",
+                () -> "http://credential.service",
                 new EdcHttpClientImpl(new OkHttpClient(), RetryPolicy.ofDefaults(), monitor),
                 monitor,
                 mapper,
@@ -96,7 +97,7 @@ class BdrsClientImplTest {
         // prime STS and CS
         when(stsMock.createToken(anyMap(), notNull())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().token("my-fancy-sitoken").build()));
         when(csMock.requestPresentation(anyString(), anyString(), anyList()))
-                .thenReturn(Result.success(List.of(new VerifiablePresentationContainer("test-raw-vp", CredentialFormat.JWT, VerifiablePresentation.Builder.newInstance().type("VerifiableCredential").build()))));
+                .thenReturn(Result.success(List.of(new VerifiablePresentationContainer(TEST_VP_CONTENT, CredentialFormat.JWT, VerifiablePresentation.Builder.newInstance().type("VerifiableCredential").build()))));
 
     }
 
@@ -110,11 +111,7 @@ class BdrsClientImplTest {
         var did = client.resolve("bpn1");
         assertThat(did).isEqualTo("did:web:did1");
 
-        bdrsServer.verify(request()
-                        .withMethod("GET")
-                        .withPath("/api/bpn-directory")
-                        .withHeader("Accept-Encoding", "gzip"),
-                exactly(1));
+        verifyBdrsRequest(1);
     }
 
     @Test
@@ -124,11 +121,7 @@ class BdrsClientImplTest {
         assertThat(did1).isEqualTo("did:web:did1");
         assertThat(did2).isEqualTo("did:web:did2");
 
-        bdrsServer.verify(request()
-                        .withMethod("GET")
-                        .withPath("/api/bpn-directory")
-                        .withHeader("Accept-Encoding", "gzip"),
-                exactly(1));
+        verifyBdrsRequest(1);
     }
 
     @Test
@@ -142,11 +135,7 @@ class BdrsClientImplTest {
                     var did2 = client.resolve("bpn2"); // hits server as well, b/c cache is expired
                     assertThat(did2).isEqualTo("did:web:did2");
 
-                    bdrsServer.verify(request()
-                                    .withHeader("Accept-Encoding", "gzip")
-                                    .withMethod("GET")
-                                    .withPath("/api/bpn-directory"),
-                            exactly(2));
+                    verifyBdrsRequest(2);
                 });
 
     }
@@ -155,11 +144,7 @@ class BdrsClientImplTest {
     void getData_whenNotFound() {
         var did = client.resolve("bpn-notexist");
         assertThat(did).isNull();
-        bdrsServer.verify(request()
-                        .withMethod("GET")
-                        .withPath("/api/bpn-directory")
-                        .withHeader("Accept-Encoding", "gzip"),
-                exactly(1));
+        verifyBdrsRequest(1);
     }
 
     @ParameterizedTest(name = "HTTP Status {0}")
@@ -193,17 +178,13 @@ class BdrsClientImplTest {
     @Test
     void getData_whenPresentationQueryReturnsTooManyVps() {
         var presentations = List.of(
-                new VerifiablePresentationContainer("test-raw-vp-1", CredentialFormat.JWT, VerifiablePresentation.Builder.newInstance().type("VerifiableCredential").build()),
+                new VerifiablePresentationContainer(TEST_VP_CONTENT, CredentialFormat.JWT, VerifiablePresentation.Builder.newInstance().type("VerifiableCredential").build()),
                 new VerifiablePresentationContainer("test-raw-vp-2", CredentialFormat.JWT, VerifiablePresentation.Builder.newInstance().type("VerifiableCredential").build()));
 
         when(csMock.requestPresentation(anyString(), anyString(), anyList())).thenReturn(Result.success(presentations));
 
         assertThatNoException().isThrownBy(() -> client.resolve("bpn1"));
-        bdrsServer.verify(request()
-                        .withMethod("GET")
-                        .withPath("/api/bpn-directory")
-                        .withHeader("Accept-Encoding", "gzip"),
-                exactly(1));
+        verifyBdrsRequest(1);
         verify(monitor).warning("Expected exactly 1 VP, but found 2.");
     }
 
@@ -216,6 +197,15 @@ class BdrsClientImplTest {
                 .isInstanceOf(EdcException.class)
                 .hasMessage("Expected exactly 1 VP, but was empty");
         bdrsServer.verify(request(), never());
+    }
+
+    private void verifyBdrsRequest(int count) {
+        bdrsServer.verify(request()
+                        .withMethod("GET")
+                        .withPath("/api/bpn-directory")
+                        .withHeader("Authorization", "Bearer " + TEST_VP_CONTENT)
+                        .withHeader("Accept-Encoding", "gzip"),
+                exactly(count));
     }
 
     private byte[] createGzipStream() {

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceExtension.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceExtension.java
@@ -36,7 +36,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.token.JwtGenerationService;
 import org.eclipse.edc.token.spi.TokenValidationService;
-import org.eclipse.tractusx.edc.core.utils.RequiredConfigWarnings;
 import org.eclipse.tractusx.edc.spi.tokenrefresh.dataplane.DataPlaneTokenRefreshService;
 import org.jetbrains.annotations.NotNull;
 
@@ -44,6 +43,7 @@ import java.security.PrivateKey;
 import java.time.Clock;
 import java.util.function.Supplier;
 
+import static org.eclipse.tractusx.edc.core.utils.RequiredConfigWarnings.missingMandatoryProperty;
 import static org.eclipse.tractusx.edc.dataplane.tokenrefresh.core.DataPlaneTokenRefreshServiceExtension.NAME;
 
 @Extension(value = NAME)
@@ -141,7 +141,7 @@ public class DataPlaneTokenRefreshServiceExtension implements ServiceExtension {
     private String getOwnDid(ServiceExtensionContext context) {
         var did = context.getConfig().getString(PARTICIPANT_DID_PROPERTY, null);
         if (did == null) {
-            RequiredConfigWarnings.warningNotPresent(context.getMonitor().withPrefix("DataPlane Token Refresh"), PARTICIPANT_DID_PROPERTY);
+            missingMandatoryProperty(context.getMonitor().withPrefix("DataPlane Token Refresh"), PARTICIPANT_DID_PROPERTY);
         }
         return did;
     }

--- a/edc-extensions/iatp/tx-iatp-sts-dim/src/main/java/org/eclipse/tractusx/edc/iam/iatp/sts/dim/DimSecureTokenServiceExtension.java
+++ b/edc-extensions/iatp/tx-iatp-sts-dim/src/main/java/org/eclipse/tractusx/edc/iam/iatp/sts/dim/DimSecureTokenServiceExtension.java
@@ -33,7 +33,7 @@ import org.eclipse.tractusx.edc.core.utils.PathUtils;
 import org.eclipse.tractusx.edc.iam.iatp.sts.dim.oauth.DimOauth2Client;
 
 import static java.util.Optional.ofNullable;
-import static org.eclipse.tractusx.edc.core.utils.RequiredConfigWarnings.warningNotPresent;
+import static org.eclipse.tractusx.edc.core.utils.RequiredConfigWarnings.missingMandatoryProperty;
 
 @Extension(DimSecureTokenServiceExtension.NAME)
 public class DimSecureTokenServiceExtension implements ServiceExtension {
@@ -70,7 +70,7 @@ public class DimSecureTokenServiceExtension implements ServiceExtension {
                 .orElse(null);
 
         if (dimUrl == null) {
-            warningNotPresent(context.getMonitor().withPrefix("STS Client for DIM"), DIM_URL);
+            missingMandatoryProperty(context.getMonitor().withPrefix("STS Client for DIM"), DIM_URL);
         }
 
         return new DimSecureTokenService(httpClient, dimUrl, dimOauth2Client, typeManager.getMapper(), monitor);

--- a/edc-extensions/iatp/tx-iatp-sts-dim/src/main/java/org/eclipse/tractusx/edc/iam/iatp/sts/dim/DimStsConfigurationExtension.java
+++ b/edc-extensions/iatp/tx-iatp-sts-dim/src/main/java/org/eclipse/tractusx/edc/iam/iatp/sts/dim/DimStsConfigurationExtension.java
@@ -27,7 +27,7 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.tractusx.edc.core.utils.PathUtils;
 
 import static java.util.Optional.ofNullable;
-import static org.eclipse.tractusx.edc.core.utils.RequiredConfigWarnings.warningNotPresent;
+import static org.eclipse.tractusx.edc.core.utils.RequiredConfigWarnings.missingMandatoryProperty;
 
 /**
  * Configuration Extension for the STS OAuth2 client
@@ -62,13 +62,13 @@ public class DimStsConfigurationExtension implements ServiceExtension {
 
         var monitor = context.getMonitor().withPrefix("STS Client for DIM");
         if (tokenUrl == null) {
-            warningNotPresent(monitor, TOKEN_URL);
+            missingMandatoryProperty(monitor, TOKEN_URL);
         }
         if (clientId == null) {
-            warningNotPresent(monitor, CLIENT_ID);
+            missingMandatoryProperty(monitor, CLIENT_ID);
         }
         if (clientSecretAlias == null) {
-            warningNotPresent(monitor, CLIENT_SECRET_ALIAS);
+            missingMandatoryProperty(monitor, CLIENT_SECRET_ALIAS);
         }
 
         return new StsRemoteClientConfiguration(tokenUrl, clientId, clientSecretAlias);

--- a/edc-extensions/iatp/tx-iatp/src/main/java/org/eclipse/tractusx/edc/iam/iatp/IatpDefaultScopeExtension.java
+++ b/edc-extensions/iatp/tx-iatp/src/main/java/org/eclipse/tractusx/edc/iam/iatp/IatpDefaultScopeExtension.java
@@ -33,8 +33,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static org.eclipse.tractusx.edc.TxIatpConstants.DEFAULT_SCOPES;
 import static org.eclipse.tractusx.edc.iam.iatp.IatpDefaultScopeExtension.NAME;
-import static org.eclipse.tractusx.edc.iam.iatp.TxIatpConstants.DEFAULT_SCOPES;
 
 @Extension(NAME)
 public class IatpDefaultScopeExtension implements ServiceExtension {

--- a/edc-extensions/iatp/tx-iatp/src/main/java/org/eclipse/tractusx/edc/iam/iatp/scope/CredentialScopeExtractor.java
+++ b/edc-extensions/iatp/tx-iatp/src/main/java/org/eclipse/tractusx/edc/iam/iatp/scope/CredentialScopeExtractor.java
@@ -32,8 +32,8 @@ import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.eclipse.tractusx.edc.TxIatpConstants.CREDENTIAL_TYPE_NAMESPACE;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
-import static org.eclipse.tractusx.edc.iam.iatp.TxIatpConstants.CREDENTIAL_TYPE_NAMESPACE;
 
 /**
  * Extract credentials from the policy constraints

--- a/edc-extensions/iatp/tx-iatp/src/test/java/org/eclipse/tractusx/edc/iam/iatp/IatpDefaultScopeExtensionTest.java
+++ b/edc-extensions/iatp/tx-iatp/src/test/java/org/eclipse/tractusx/edc/iam/iatp/IatpDefaultScopeExtensionTest.java
@@ -34,11 +34,11 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.tractusx.edc.TxIatpConstants.DEFAULT_SCOPES;
 import static org.eclipse.tractusx.edc.iam.iatp.IatpDefaultScopeExtension.CATALOG_REQUEST_SCOPE;
 import static org.eclipse.tractusx.edc.iam.iatp.IatpDefaultScopeExtension.NEGOTIATION_REQUEST_SCOPE;
 import static org.eclipse.tractusx.edc.iam.iatp.IatpDefaultScopeExtension.TRANSFER_PROCESS_REQUEST_SCOPE;
 import static org.eclipse.tractusx.edc.iam.iatp.IatpDefaultScopeExtension.TX_IATP_DEFAULT_SCOPE_PREFIX;
-import static org.eclipse.tractusx.edc.iam.iatp.TxIatpConstants.DEFAULT_SCOPES;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;

--- a/edc-extensions/iatp/tx-iatp/src/test/java/org/eclipse/tractusx/edc/iam/iatp/scope/CredentialScopeExtractorTest.java
+++ b/edc-extensions/iatp/tx-iatp/src/test/java/org/eclipse/tractusx/edc/iam/iatp/scope/CredentialScopeExtractorTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.tractusx.edc.iam.iatp.TxIatpConstants.CREDENTIAL_TYPE_NAMESPACE;
+import static org.eclipse.tractusx.edc.TxIatpConstants.CREDENTIAL_TYPE_NAMESPACE;
 import static org.eclipse.tractusx.edc.iam.iatp.scope.CredentialScopeExtractor.FRAMEWORK_CREDENTIAL_PREFIX;
 import static org.mockito.Mockito.mock;
 

--- a/edc-extensions/tokenrefresh-handler/src/main/java/org/eclipse/tractusx/edc/common/tokenrefresh/TokenRefreshHandlerExtension.java
+++ b/edc-extensions/tokenrefresh-handler/src/main/java/org/eclipse/tractusx/edc/common/tokenrefresh/TokenRefreshHandlerExtension.java
@@ -61,7 +61,7 @@ public class TokenRefreshHandlerExtension implements ServiceExtension {
     private String getOwnDid(ServiceExtensionContext context) {
         var did = context.getConfig().getString(PARTICIPANT_DID_PROPERTY, null);
         if (did == null) {
-            RequiredConfigWarnings.warningNotPresent(context.getMonitor().withPrefix("Token Refresh Handler"), PARTICIPANT_DID_PROPERTY);
+            RequiredConfigWarnings.missingMandatoryProperty(context.getMonitor().withPrefix("Token Refresh Handler"), PARTICIPANT_DID_PROPERTY);
         }
         return did;
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ edc-ext-azure-cosmos-core = { module = "org.eclipse.edc:azure-cosmos-core", vers
 edc-ext-azure-test = { module = "org.eclipse.edc:azure-test", version.ref = "edc" }
 edc-ext-jsonld = { module = "org.eclipse.edc:json-ld", version.ref = "edc" }
 edc-validator-data-address-http-data = { module = "org.eclipse.edc:validator-data-address-http-data", version.ref = "edc" }
+edc-runtime-metamodel = { module = "org.eclipse.edc:runtime-metamodel", version.ref = "edc" }
 
 # EDC lib dependencies
 edc-lib-boot = { module = "org.eclipse.edc:boot-lib", version.ref = "edc" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ edc-spi-transaction-datasource = { module = "org.eclipse.edc:transaction-datasou
 edc-spi-transactionspi = { module = "org.eclipse.edc:transaction-spi", version.ref = "edc" }
 edc-spi-controlplane = { module = "org.eclipse.edc:control-plane-spi", version.ref = "edc" }
 edc-controlplane-apiclient = { module = "org.eclipse.edc:control-plane-api-client", version.ref = "edc" }
+edc-spi-boot = { module = "org.eclipse.edc:web-spi", version.ref = "edc" }
 edc-spi-web = { module = "org.eclipse.edc:web-spi", version.ref = "edc" }
 edc-spi-http = { module = "org.eclipse.edc:http-spi", version.ref = "edc" }
 edc-spi-keys = { module = "org.eclipse.edc:keys-spi", version.ref = "edc" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -137,6 +137,7 @@ edc-core-did = { module = "org.eclipse.edc:identity-did-core", version.ref = "ed
 edc-identity-did-web = { module = "org.eclipse.edc:identity-did-web", version.ref = "edc" }
 edc-identity-vc-ldp = { module = "org.eclipse.edc:ldp-verifiable-credentials", version.ref = "edc" }
 edc-identity-vc-jwt = { module = "org.eclipse.edc:jwt-verifiable-credentials", version.ref = "edc" }
+edc-identity-trust-service = { module = "org.eclipse.edc:identity-trust-service", version.ref = "edc" }
 edc-identity-trust-transform = { module = "org.eclipse.edc:identity-trust-transform", version.ref = "edc" }
 edc-identity-trust-issuers-configuration = { module = "org.eclipse.edc:identity-trust-issuers-configuration", version.ref = "edc" }
 

--- a/samples/multi-tenancy/build.gradle.kts
+++ b/samples/multi-tenancy/build.gradle.kts
@@ -28,8 +28,6 @@ dependencies {
     implementation(libs.edc.boot)
     implementation(libs.edc.iam.mock)
     implementation(project(":edc-controlplane:edc-controlplane-base")) {
-        exclude(module = "ssi-miw-credential-client")
-        exclude(module = "ssi-identity-core")
         exclude(module = "auth-tokenbased")
         // the token refresh extension is not needed
         exclude(module = "tx-iatp-sts-dim")

--- a/spi/bdrs-client-spi/build.gradle.kts
+++ b/spi/bdrs-client-spi/build.gradle.kts
@@ -23,5 +23,5 @@ plugins {
 }
 
 dependencies {
-    implementation(libs.edc.spi.core)
+    implementation(libs.edc.runtime.metamodel)
 }

--- a/spi/core-spi/src/main/java/org/eclipse/tractusx/edc/TxIatpConstants.java
+++ b/spi/core-spi/src/main/java/org/eclipse/tractusx/edc/TxIatpConstants.java
@@ -1,5 +1,5 @@
-/********************************************************************************
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,9 +15,9 @@
  * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- ********************************************************************************/
+ */
 
-package org.eclipse.tractusx.edc.iam.iatp;
+package org.eclipse.tractusx.edc;
 
 import java.util.Set;
 


### PR DESCRIPTION
## WHAT

adds a VerifiablePresentation containing the `MembershipCredential` to the `Authorization` header of a BDRS request.
Specifically, assuming we're using JWT-VPs, this will add a header:
```
"Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6I...."
```

In order to do that, the `BdrsClient` requires access to the `SecureTokenService` to create a self-issued ID token.
That SI token is then used to execute a `PresentationQuery` request to `CredentialService`, we "IATP ourselves".

The CredentialService's URL is resolved via a config parameter, and as a fallback, is resolved from the DID document.

## WHY

Securing the directory API of the BDRS server.

## FURTHER NOTES

A similar PR will come for the BDRS Server, to verify the auth header.

Closes # <-- _insert Issue number if one exists_
