### PR TITLE
feat: adds transfer tests with suspend/resume and terminate scenario

### DIFF
--- a/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisioner.java
+++ b/edc-extensions/provision-additional-headers/src/main/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisioner.java
@@ -41,7 +41,7 @@ public class AdditionalHeadersProvisioner implements Provisioner<AdditionalHeade
 
     @Override
     public boolean canDeprovision(ProvisionedResource provisionedResource) {
-        return false; // nothing to deprovision
+        return provisionedResource instanceof AdditionalHeadersProvisionedResource;
     }
 
     @Override
@@ -70,7 +70,7 @@ public class AdditionalHeadersProvisioner implements Provisioner<AdditionalHeade
 
     @Override
     public CompletableFuture<StatusResult<DeprovisionedResource>> deprovision(
-            AdditionalHeadersProvisionedResource additionalHeadersProvisionedResource, Policy policy) {
-        return null; // nothing to deprovision
+            AdditionalHeadersProvisionedResource resource, Policy policy) {
+        return CompletableFuture.completedFuture(StatusResult.success(DeprovisionedResource.Builder.newInstance().provisionedResourceId(resource.getId()).build())); // nothing to deprovision
     }
 }

--- a/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisionerTest.java
+++ b/edc-extensions/provision-additional-headers/src/test/java/org/eclipse/tractusx/edc/provision/additionalheaders/AdditionalHeadersProvisionerTest.java
@@ -49,7 +49,7 @@ class AdditionalHeadersProvisionerTest {
 
     @Test
     void cannotDeprovisionAdditionalHeadersResourceDefinition() {
-        assertThat(provisioner.canDeprovision(mock(AdditionalHeadersProvisionedResource.class))).isFalse();
+        assertThat(provisioner.canDeprovision(mock(AdditionalHeadersProvisionedResource.class))).isTrue();
         assertThat(provisioner.canDeprovision(mock(ProvisionedResource.class))).isFalse();
     }
 
@@ -78,5 +78,21 @@ class AdditionalHeadersProvisionerTest {
                 .asInstanceOf(map(String.class, String.class))
                 .containsEntry("Edc-Contract-Agreement-Id", "contractId")
                 .containsEntry("Edc-Bpn", "bpn");
+    }
+
+    @Test
+    void shouldDeprovision() {
+        var address = HttpDataAddress.Builder.newInstance().baseUrl("http://any").build();
+        var resource = AdditionalHeadersProvisionedResource.Builder.newInstance()
+                .dataAddress(address).id("id")
+                .transferProcessId("transferProcessId")
+                .resourceDefinitionId("definitionId")
+                .resourceName("name")
+                .build();
+        
+        var result = provisioner.deprovision(resource, Policy.Builder.newInstance().build());
+        assertThat(result)
+                .succeedsWithin(5, SECONDS)
+                .matches(StatusResult::succeeded);
     }
 }

--- a/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/ParticipantDataApi.java
+++ b/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/ParticipantDataApi.java
@@ -19,13 +19,16 @@
 
 package org.eclipse.tractusx.edc.tests;
 
+import io.restassured.response.ValidatableResponse;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
 
 
 /**
@@ -41,17 +44,28 @@ public class ParticipantDataApi {
      * @return the data
      */
     public String pullData(JsonObject edr, Map<String, String> queryParams) {
+        return pullDataRequest(edr, queryParams)
+                .statusCode(allOf(greaterThanOrEqualTo(200), lessThan(300)))
+                .extract().body().asString();
+    }
 
+
+    /**
+     * Pull the data with an {@link DataAddress}
+     *
+     * @param edr         The edr
+     * @param queryParams additional params
+     * @return the {@link ValidatableResponse}
+     */
+    public ValidatableResponse pullDataRequest(JsonObject edr, Map<String, String> queryParams) {
         var endpoint = edr.getString("endpoint");
         var token = edr.getString("authorization");
-        var response = given()
+        return given()
                 .baseUri(endpoint)
                 .header("Authorization", token)
                 .queryParams(queryParams)
-                .when()
-                .get();
-        assertThat(response.statusCode()).isBetween(200, 300);
-        return response.body().asString();
+                .get()
+                .then();
     }
 
 }

--- a/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/ParticipantEdrApi.java
+++ b/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/ParticipantEdrApi.java
@@ -27,9 +27,13 @@ import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
 import org.eclipse.tractusx.edc.tests.participant.TransferParticipant;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import static io.restassured.http.ContentType.JSON;
 import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.pollinterval.FibonacciPollInterval.fibonacci;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
@@ -190,6 +194,24 @@ public class ParticipantEdrApi {
                 .extract()
                 .body()
                 .as(JsonArray.class);
+    }
+
+    /**
+     * Waits for the EDR associated with the transfer process to be available
+     *
+     * @param transferProcessId The transfer process id
+     * @return The {@link JsonObject} representation of the EDR
+     */
+    public JsonObject waitForEdr(String transferProcessId) {
+        var edr = new AtomicReference<JsonObject>();
+        await().pollInterval(fibonacci())
+                .atMost(participant.getTimeout())
+                .untilAsserted(() -> {
+                    edr.set(getEdr(transferProcessId));
+                    assertThat(edr).isNotNull();
+                });
+
+        return edr.get();
     }
 
     /**

--- a/edc-tests/edc-controlplane/transfer-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/TransferPullEndToEndTest.java
+++ b/edc-tests/edc-controlplane/transfer-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/TransferPullEndToEndTest.java
@@ -19,6 +19,9 @@
 
 package org.eclipse.tractusx.edc.tests.transfer;
 
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
 import org.eclipse.tractusx.edc.tests.participant.TractusxParticipantBase;
@@ -26,14 +29,23 @@ import org.eclipse.tractusx.edc.tests.participant.TransferParticipant;
 import org.eclipse.tractusx.edc.tests.runtimes.ParticipantRuntime;
 import org.eclipse.tractusx.edc.tests.runtimes.PgParticipantRuntime;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockserver.verify.VerificationTimes;
 
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.inForceDatePolicy;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PLATO_BPN;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PLATO_NAME;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.SOKRATES_BPN;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.SOKRATES_NAME;
+import static org.eclipse.tractusx.edc.tests.helpers.TransferProcessHelperFunctions.createProxyRequest;
 import static org.eclipse.tractusx.edc.tests.runtimes.Runtimes.memoryRuntime;
 import static org.eclipse.tractusx.edc.tests.runtimes.Runtimes.pgRuntime;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
 
 public class TransferPullEndToEndTest {
 
@@ -56,6 +68,107 @@ public class TransferPullEndToEndTest {
         @Override
         public TractusxParticipantBase sokrates() {
             return SOKRATES;
+        }
+
+
+        @Test
+        void transferData_withSuspendResume() {
+            var assetId = "api-asset-1";
+
+            var requestDefinition = request().withMethod("GET").withPath(MOCK_BACKEND_PATH);
+
+            Map<String, Object> dataAddress = Map.of(
+                    "baseUrl", privateBackendUrl,
+                    "type", "HttpData",
+                    "contentType", "application/json"
+            );
+
+            PLATO.createAsset(assetId, Map.of(), dataAddress);
+
+            var accessPolicyId = PLATO.createPolicyDefinition(createAccessPolicy(SOKRATES.getBpn()));
+            var contractPolicyId = PLATO.createPolicyDefinition(createContractPolicy(SOKRATES.getBpn()));
+            PLATO.createContractDefinition(assetId, "def-1", accessPolicyId, contractPolicyId);
+            var transferProcessId = SOKRATES.requestAsset(PLATO, assetId, Json.createObjectBuilder().build(), createProxyRequest(), "HttpData-PULL");
+
+            SOKRATES.waitForTransferProcess(transferProcessId, TransferProcessStates.STARTED);
+
+            // wait until EDC is available on the consumer side
+            server.when(requestDefinition).respond(response().withStatusCode(200).withBody("test response"));
+
+            var edr = SOKRATES.edrs().waitForEdr(transferProcessId);
+
+            // consumer can fetch data with a valid token
+            var data = SOKRATES.data().pullData(edr, Map.of());
+            assertThat(data).isNotNull().isEqualTo("test response");
+
+            server.verify(requestDefinition, VerificationTimes.exactly(1));
+
+            SOKRATES.suspendTransfer(transferProcessId, "reason");
+            SOKRATES.waitForTransferProcess(transferProcessId, TransferProcessStates.SUSPENDED);
+
+            // consumer cannot fetch data with the prev token (suspended)
+            SOKRATES.data().pullDataRequest(edr, Map.of()).statusCode(403);
+            server.verify(requestDefinition, VerificationTimes.exactly(1));
+
+            SOKRATES.resumeTransfer(transferProcessId);
+            SOKRATES.waitForTransferProcess(transferProcessId, TransferProcessStates.STARTED);
+
+            var newEdr = SOKRATES.edrs().waitForEdr(transferProcessId);
+
+            // consumer can now re-fetch data with a new EDR token
+            data = SOKRATES.data().pullData(newEdr, Map.of());
+            assertThat(data).isNotNull().isEqualTo("test response");
+
+            server.verify(requestDefinition, VerificationTimes.exactly(2));
+
+            // consumer cannot fetch data with the prev token (suspended) after the transfer process has been resumed
+            SOKRATES.data().pullDataRequest(edr, Map.of()).statusCode(403);
+            server.verify(requestDefinition, VerificationTimes.exactly(2));
+
+        }
+
+        @Test
+        void transferData_withTerminate() {
+            var assetId = "api-asset-1";
+
+            var requestDefinition = request().withMethod("GET").withPath(MOCK_BACKEND_PATH);
+
+            Map<String, Object> dataAddress = Map.of(
+                    "baseUrl", privateBackendUrl,
+                    "type", "HttpData",
+                    "contentType", "application/json"
+            );
+
+            PLATO.createAsset(assetId, Map.of(), dataAddress);
+
+            var accessPolicyId = PLATO.createPolicyDefinition(createAccessPolicy(SOKRATES.getBpn()));
+            var contractPolicyId = PLATO.createPolicyDefinition(inForcePolicy());
+            PLATO.createContractDefinition(assetId, "def-1", accessPolicyId, contractPolicyId);
+            var transferProcessId = SOKRATES.requestAsset(PLATO, assetId, Json.createObjectBuilder().build(), createProxyRequest(), "HttpData-PULL");
+
+            SOKRATES.waitForTransferProcess(transferProcessId, TransferProcessStates.STARTED);
+
+            // wait until EDC is available on the consumer side
+            server.when(requestDefinition).respond(response().withStatusCode(200).withBody("test response"));
+
+            var edr = SOKRATES.edrs().waitForEdr(transferProcessId);
+
+            // consumer can fetch data with a valid token
+            var data = SOKRATES.data().pullData(edr, Map.of());
+            assertThat(data).isNotNull().isEqualTo("test response");
+
+            server.verify(requestDefinition, VerificationTimes.exactly(1));
+
+            SOKRATES.waitForTransferProcess(transferProcessId, TransferProcessStates.TERMINATED);
+
+            // consumer cannot fetch data with the prev token (suspended)
+            var body = SOKRATES.data().pullDataRequest(edr, Map.of()).statusCode(403).extract().body().asString();
+            server.verify(requestDefinition, VerificationTimes.exactly(1));
+
+        }
+        
+        protected JsonObject inForcePolicy() {
+            return inForceDatePolicy("gteq", "contractAgreement+0s", "lteq", "contractAgreement+10s");
         }
 
     }


### PR DESCRIPTION
## WHAT

Adds two tests for transfer in the following transfer process states:

- STARTED -> SUSPENDED -> STARTED (suspension)
- STARTED  -> TERMINATED ->  (contract expires)

Additionally fixed the `AdditionalHeadersProvisioner` which had some issue with the deprovision phase

## WHY

testing is good.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
