### PR TITLE
feat: add additional tx JSON-LD contexts

### DIFF
--- a/core/json-ld-core/src/main/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtension.java
+++ b/core/json-ld-core/src/main/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtension.java
@@ -51,6 +51,7 @@ public class JsonLdExtension implements ServiceExtension {
     public static final String SECURITY_ED25519_V1 = "https://w3id.org/security/suites/ed25519-2020/v1";
 
     public static final String CX_POLICY_CONTEXT = "https://w3id.org/tractusx/policy/v1.0.0";
+    public static final String TX_AUTH_CONTEXT = "https://w3id.org/tractusx/auth/v1.0.0";
 
     private static final String PREFIX = "document" + File.separator;
     private static final Map<String, String> FILES = Map.of(
@@ -59,6 +60,7 @@ public class JsonLdExtension implements ServiceExtension {
             SECURITY_ED25519_V1, PREFIX + "security-ed25519-2020.jsonld",
             TX_CONTEXT, PREFIX + "tx-v1.jsonld",
             CX_POLICY_CONTEXT, PREFIX + "cx-policy-v1.jsonld",
+            TX_AUTH_CONTEXT, PREFIX + "tx-auth-v1.jsonld",
             EDC_CONTEXT, PREFIX + "edc-v1.jsonld");
     @Inject
     private JsonLd jsonLdService;

--- a/core/json-ld-core/src/main/resources/document/tx-auth-v1.jsonld
+++ b/core/json-ld-core/src/main/resources/document/tx-auth-v1.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "tx-auth": "https://w3id.org/tractusx/auth/",
+    "refreshToken": "tx-auth:refreshToken",
+    "refreshEndpoint": "tx-auth:refreshEndpoint",
+    "refreshAudience": "tx-auth:refreshAudience",
+    "audience": "tx-auth:audience",
+    "expiresIn": "tx-auth:expiresIn"
+  }
+}

--- a/core/json-ld-core/src/main/resources/document/tx-v1.jsonld
+++ b/core/json-ld-core/src/main/resources/document/tx-v1.jsonld
@@ -4,18 +4,6 @@
     "@protected": true,
     "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
     "BusinessPartnerNumber": "tx:BusinessPartnerNumber",
-    "NegotiationInitiateRequestDto": "tx:NegotiationInitiateRequestDto",
-    "BusinessPartnerGroup": "tx:BusinessPartnerGroup",
-    "EndpointDataReferenceEntry": "tx:EndpointDataReferenceEntry",
-    "Membership": "tx:Membership",
-    "Dismantler": "tx:Dismantler",
-    "FrameworkAgreement.pcf": "tx:FrameworkAgreement.pcf",
-    "FrameworkAgreement.sustainability": "tx:FrameworkAgreement.sustainability",
-    "FrameworkAgreement.quality": "tx:FrameworkAgreement.quality",
-    "FrameworkAgreement.traceability": "tx:FrameworkAgreement.traceability",
-    "FrameworkAgreement.behavioraltwin": "tx:FrameworkAgreement.behavioraltwin",
-    "BPN": "tx:BPN",
-    "expirationDate": "tx:expirationDate",
-    "edrState": "tx:edrState"
+    "BusinessPartnerGroup": "tx:BusinessPartnerGroup"
   }
 }


### PR DESCRIPTION
## WHAT

create additional JSON-LD context for the `tx` and `tx-auth` namespace

> The tx one already existed but it was clean up from the old policy term definitions with now are in the `cx-policy` namespace

## WHY

policy definition usability

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #1233 
