### PR TITLE
fix: add notice file to Mock Connector

### DIFF
--- a/edc-tests/runtime/mock-connector/notice.md
+++ b/edc-tests/runtime/mock-connector/notice.md
@@ -1,0 +1,28 @@
+# Notice for Docker image
+
+A mocked EDC Management API providing an instrumentation API for configuration.
+
+DockerHub: <https://hub.docker.com/r/tractusx/mock-connector>
+
+Eclipse Tractus-X product(s) installed within the image:
+
+## Tractus-X EDC Control Plane
+
+- GitHub: <https://github.com/eclipse-tractusx/tractusx-edc>
+- Project home: <https://projects.eclipse.org/projects/automotive.tractusx>
+- Dockerfile: <https://github.com/eclipse-tractusx/tractusx-edc/blob/main/edc-tests/runtime/mock-connector/src/main/docker/Dockerfile>
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/main/LICENSE)
+
+## Used base image
+
+- [eclipse-temurin:22_36-jre-alpine](https://github.com/adoptium/containers)
+- Official Eclipse Temurin DockerHub page: <https://hub.docker.com/_/eclipse-temurin>
+- Eclipse Temurin Project: <https://projects.eclipse.org/projects/adoptium.temurin>
+- Additional information about the Eclipse Temurin
+  images: <https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin>
+
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
+from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
+with any relevant licenses for all software contained within.


### PR DESCRIPTION

## WHAT

Adds the `notice.md` file to the docker build of the Mock Connector

## WHY

It was missing, causing the build to fail.
## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
