### PR TITLE
feat: make auto_refresh default to true

### DIFF
--- a/edc-extensions/edr/edr-api-v2/src/main/java/org/eclipse/tractusx/edc/api/edr/v2/EdrCacheApi.java
+++ b/edc-extensions/edr/edr-api-v2/src/main/java/org/eclipse/tractusx/edc/api/edr/v2/EdrCacheApi.java
@@ -67,7 +67,7 @@ public interface EdrCacheApi {
 
     @Operation(description = "Gets the EDR data address with the given transfer process ID",
             parameters = { @Parameter(name = "transferProcessId", description = "The ID of the transferprocess for which the EDR should be fetched", required = true),
-                    @Parameter(name = "auto_refresh", description = "Whether the access token that is stored on the EDR should be checked for expiry, and renewed if necessary. Default is true")
+                    @Parameter(name = "auto_refresh", description = "Whether the access token that is stored on the EDR should be checked for expiry, and renewed if necessary. Default is true.")
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "The data address",

--- a/edc-extensions/edr/edr-api-v2/src/main/java/org/eclipse/tractusx/edc/api/edr/v2/EdrCacheApiController.java
+++ b/edc-extensions/edr/edr-api-v2/src/main/java/org/eclipse/tractusx/edc/api/edr/v2/EdrCacheApiController.java
@@ -23,6 +23,7 @@ import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -139,7 +140,7 @@ public class EdrCacheApiController implements EdrCacheApi {
     @GET
     @Path("{transferProcessId}/dataaddress")
     @Override
-    public JsonObject getEdrEntryDataAddress(@PathParam("transferProcessId") String transferProcessId, @QueryParam("auto_refresh") boolean autoRefresh) {
+    public JsonObject getEdrEntryDataAddress(@PathParam("transferProcessId") String transferProcessId, @DefaultValue("true") @QueryParam("auto_refresh") boolean autoRefresh) {
         var mode = autoRefresh ? AUTO_REFRESH : NO_REFRESH;
         var dataAddress = edrService.resolveByTransferProcess(transferProcessId, mode)
                 .orElseThrow(exceptionMapper(EndpointDataReferenceEntry.class, transferProcessId));

--- a/edc-extensions/edr/edr-api-v2/src/test/java/org/eclipse/tractusx/edc/api/edr/v2/EdrCacheApiControllerTest.java
+++ b/edc-extensions/edr/edr-api-v2/src/test/java/org/eclipse/tractusx/edc/api/edr/v2/EdrCacheApiControllerTest.java
@@ -161,7 +161,7 @@ public class EdrCacheApiControllerTest extends RestControllerTestBase {
 
         var dataAddressType = "type";
         var dataAddress = DataAddress.Builder.newInstance().type(dataAddressType).build();
-        when(edrService.resolveByTransferProcess("transferProcessId", NO_REFRESH))
+        when(edrService.resolveByTransferProcess("transferProcessId", AUTO_REFRESH))
                 .thenReturn(ServiceResult.success(dataAddress));
 
         when(transformerRegistry.transform(isA(DataAddress.class), eq(JsonObject.class)))
@@ -176,13 +176,13 @@ public class EdrCacheApiControllerTest extends RestControllerTestBase {
                 .contentType(JSON)
                 .body("'%s'".formatted(DataAddress.EDC_DATA_ADDRESS_TYPE_PROPERTY), equalTo(dataAddressType));
 
-        verify(edrService).resolveByTransferProcess("transferProcessId", NO_REFRESH);
+        verify(edrService).resolveByTransferProcess("transferProcessId", AUTO_REFRESH);
         verify(transformerRegistry).transform(isA(DataAddress.class), eq(JsonObject.class));
         verifyNoMoreInteractions(transformerRegistry);
     }
 
     @Test
-    void getEdrEntryDataAddress_withAutorefresh() {
+    void getEdrEntryDataAddress_withExplicitAutoRefreshTrue() {
 
         var dataAddressType = "type";
         var dataAddress = DataAddress.Builder.newInstance().type(dataAddressType).build();
@@ -206,11 +206,36 @@ public class EdrCacheApiControllerTest extends RestControllerTestBase {
         verifyNoMoreInteractions(transformerRegistry);
     }
 
+    @Test
+    void getEdrEntryDataAddress_withExplicitAutoRefreshFalse() {
+
+        var dataAddressType = "type";
+        var dataAddress = DataAddress.Builder.newInstance().type(dataAddressType).build();
+        when(edrService.resolveByTransferProcess("transferProcessId", NO_REFRESH))
+                .thenReturn(ServiceResult.success(dataAddress));
+
+        when(transformerRegistry.transform(isA(DataAddress.class), eq(JsonObject.class)))
+                .thenReturn(Result.success(createDataAddress(dataAddressType).build()));
+
+        baseRequest()
+                .contentType(JSON)
+                .get("/v2/edrs/transferProcessId/dataaddress?auto_refresh=false")
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("'%s'".formatted(DataAddress.EDC_DATA_ADDRESS_TYPE_PROPERTY), equalTo(dataAddressType));
+
+        verify(edrService).resolveByTransferProcess("transferProcessId", NO_REFRESH);
+        verify(transformerRegistry).transform(isA(DataAddress.class), eq(JsonObject.class));
+        verifyNoMoreInteractions(transformerRegistry);
+    }
+
 
     @Test
     void getEdrEntryDataAddress_whenNotFound() {
 
-        when(edrService.resolveByTransferProcess("transferProcessId", NO_REFRESH))
+        when(edrService.resolveByTransferProcess("transferProcessId", AUTO_REFRESH))
                 .thenReturn(ServiceResult.notFound("notFound"));
 
 
@@ -222,7 +247,7 @@ public class EdrCacheApiControllerTest extends RestControllerTestBase {
                 .statusCode(404)
                 .contentType(JSON);
 
-        verify(edrService).resolveByTransferProcess("transferProcessId", NO_REFRESH);
+        verify(edrService).resolveByTransferProcess("transferProcessId", AUTO_REFRESH);
         verifyNoMoreInteractions(transformerRegistry);
     }
 


### PR DESCRIPTION
## WHAT

makes the `auto_refresh` query param of the EDR API `true` by default.

## WHY

not refreshing should be intended behaviour, not the default.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
