### PR TITLE
fix: make azure vault related variables in deployment chart optional #1304

### DIFF
--- a/charts/tractusx-connector-azure-vault/README.md
+++ b/charts/tractusx-connector-azure-vault/README.md
@@ -280,10 +280,10 @@ helm install my-release tractusx-edc/tractusx-connector-azure-vault --version 0.
 | tests | object | `{"hookDeletePolicy":"before-hook-creation,hook-succeeded"}` | Configurations for Helm tests |
 | tests.hookDeletePolicy | string | `"before-hook-creation,hook-succeeded"` | Configure the hook-delete-policy for Helm tests |
 | vault.azure.certificate | string | `nil` |  |
-| vault.azure.client | string | `"<AZURE_CLIENT_ID>"` |  |
+| vault.azure.client | string | `nil` |  |
 | vault.azure.name | string | `"<AZURE_NAME>"` |  |
 | vault.azure.secret | string | `nil` |  |
-| vault.azure.tenant | string | `"<AZURE_TENANT_ID>"` |  |
+| vault.azure.tenant | string | `nil` |  |
 | vault.secretNames.transferProxyTokenEncryptionAesKey | string | `"transfer-proxy-token-encryption-aes-key"` |  |
 | vault.secretNames.transferProxyTokenSignerPrivateKey | string | `nil` |  |
 | vault.secretNames.transferProxyTokenSignerPublicKey | string | `nil` |  |

--- a/charts/tractusx-connector-azure-vault/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/deployment-controlplane.yaml
@@ -321,18 +321,21 @@ spec:
             ## VAULT ##
             ###########
 
-            - name: "AZURE_CLIENT_ID"
-              value: {{ .Values.vault.azure.client | required ".Values.vault.azure.client is required" | quote  }}
-            - name: "AZURE_TENANT_ID"
-              value: {{ .Values.vault.azure.tenant | required ".Values.vault.azure.tenant is required" | quote }}
             - name: "EDC_VAULT_NAME"
               value: {{ .Values.vault.azure.name | required ".Values.vault.azure.name is required" | quote }}
-            # only set the env var if config value not null
+            # only set the env vars if config value not null
+            {{- if .Values.vault.azure.client }}
+            - name: "AZURE_CLIENT_ID"
+              value: {{ .Values.vault.azure.client | quote  }}
+            {{- end }}
+            {{- if .Values.vault.azure.tenant }}
+            - name: "AZURE_TENANT_ID"
+              value: {{ .Values.vault.azure.tenant | quote }}
+            {{- end }}
             {{- if .Values.vault.azure.secret }}
             - name: "AZURE_CLIENT_SECRET"
               value: {{ .Values.vault.azure.secret | quote }}
-             {{- end }}
-            # only set the env var if config value not null
+            {{- end }}
             {{- if .Values.vault.azure.certificate }}
             - name: "AZURE_CLIENT_CERTIFICATE_PATH"
               value: {{ .Values.vault.azure.certificate | quote }}

--- a/charts/tractusx-connector-azure-vault/templates/deployment-dataplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/deployment-dataplane.yaml
@@ -188,18 +188,21 @@ spec:
             ## VAULT ##
             ###########
 
+            - name: "EDC_VAULT_NAME"
+              value: {{ .Values.vault.azure.name | required ".Values.vault.azure.name is required" | quote }}
+            # only set the env vars if config value not null
+            {{- if .Values.vault.azure.client }}
             - name: "AZURE_CLIENT_ID"
               value: {{ .Values.vault.azure.client | quote  }}
+            {{- end }}
+            {{- if .Values.vault.azure.tenant }}
             - name: "AZURE_TENANT_ID"
               value: {{ .Values.vault.azure.tenant | quote }}
-            - name: "EDC_VAULT_NAME"
-              value: {{ .Values.vault.azure.name | quote }}
-            # only set the env var if config value not null
+            {{- end }}
             {{- if .Values.vault.azure.secret }}
             - name: "AZURE_CLIENT_SECRET"
               value: {{ .Values.vault.azure.secret | quote }}
             {{- end }}
-            # only set the env var if config value not null
             {{- if .Values.vault.azure.certificate }}
             - name: "AZURE_CLIENT_CERTIFICATE_PATH"
               value: {{ .Values.vault.azure.certificate | quote }}

--- a/charts/tractusx-connector-azure-vault/values.yaml
+++ b/charts/tractusx-connector-azure-vault/values.yaml
@@ -530,8 +530,8 @@ postgresql:
 vault:
   azure:
     name: "<AZURE_NAME>"
-    client: "<AZURE_CLIENT_ID>"
-    tenant: "<AZURE_TENANT_ID>"
+    client:
+    tenant:
     secret:
     certificate:
 


### PR DESCRIPTION
## WHAT

Make Azure Vault related variables optional in deployment chart.

## WHY

While deploying EDC using "tractusx-connector-azure-vault" on Azure utilizing workload identity, charts are overriding the values that are attached automatically by Azure webhook.

## FURTHER NOTES

n/a

Closes #1304
