### PR TITLE
fix: adds checks on accessTokenData not found

### DIFF
--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/rules/AuthTokenAudienceRule.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/rules/AuthTokenAudienceRule.java
@@ -54,6 +54,9 @@ public class AuthTokenAudienceRule implements TokenValidationRule {
         var tokenId = getTokenId(accessToken);
 
         var accessTokenData = store.getById(tokenId);
+        if (accessTokenData == null) {
+            return Result.failure("Token with id '%s' not found".formatted(tokenId));
+        }
         var expectedAudience = accessTokenData.additionalProperties().getOrDefault(AUDIENCE_PROPERTY, null);
         if (expectedAudience instanceof String expectedAud) {
             return expectedAud.equals(issuer) ? Result.success() : Result.failure("Principal '%s' is not authorized to refresh this token.".formatted(issuer));

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/rules/AuthTokenAudienceRuleTest.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/rules/AuthTokenAudienceRuleTest.java
@@ -78,4 +78,14 @@ class AuthTokenAudienceRuleTest {
                 .detail()
                 .isEqualTo("Property '%s' was expected to be java.lang.String but was null.".formatted(AUDIENCE_PROPERTY));
     }
+
+    @Test
+    void checkRule_accessTokenDataNotFound() {
+        when(store.getById(TEST_TOKEN_ID)).thenReturn(null);
+
+        assertThat(rule.checkRule(createAuthenticationToken(TEST_TOKEN_ID), Map.of()))
+                .isFailed()
+                .detail()
+                .isEqualTo("Token with id '%s' not found".formatted(TEST_TOKEN_ID));
+    }
 }


### PR DESCRIPTION
## WHAT

adds checks on `accessTokenData` not found in `AuthTokenAudienceRule`

## WHY

NPE fix

Closes #1303 
