### PR TITLE
build(deps): align eclipse-temurin versions to 22.0.1_8-jre-alpine

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.
@@ -21,7 +21,8 @@
 ---
 version: 2
 updates:
-  # Maven
+
+  # Gradle
   -
     package-ecosystem: "gradle"
     target-branch: main
@@ -44,6 +45,14 @@ updates:
       interval: "weekly"
 
   # Docker
+  - package-ecosystem: "docker"
+    target-branch: main
+    directory: ./edc-controlplane/edc-controlplane-postgresql-azure-vault/src/main/docker/
+    labels:
+      - "dependabot"
+      - "docker"
+    schedule:
+      interval: "weekly"
   -
     package-ecosystem: "docker"
     target-branch: main
@@ -56,16 +65,7 @@ updates:
   -
     package-ecosystem: "docker"
     target-branch: main
-    directory: ./edc-controlplane/edc-controlplane-postgresql-azure-vault/src/main/docker/
-    labels:
-      - "dependabot"
-      - "docker"
-    schedule:
-      interval: "weekly"
-  -
-    package-ecosystem: "docker"
-    target-branch: main
-    directory: ./edc-controlplane/edc-controlplane-memory/src/main/docker/
+    directory: ./edc-controlplane/edc-runtime-memory/src/main/docker/
     labels:
       - "dependabot"
       - "docker"
@@ -84,6 +84,24 @@ updates:
     package-ecosystem: "docker"
     target-branch: main
     directory: ./edc-dataplane/edc-dataplane-hashicorp-vault/src/main/docker/
+    labels:
+      - "dependabot"
+      - "docker"
+    schedule:
+      interval: "weekly"
+  -
+    package-ecosystem: "docker"
+    target-branch: main
+    directory: ./edc-tests/runtime/mock-connector/src/main/docker/
+    labels:
+      - "dependabot"
+      - "docker"
+    schedule:
+      interval: "weekly"
+  -
+    package-ecosystem: "docker"
+    target-branch: main
+    directory: ./samples/edc-dast/edc-dast-runtime/src/main/docker/
     labels:
       - "dependabot"
       - "docker"

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -8,11 +8,11 @@ maven/mavencentral/com.apicatalog/titanium-json-ld/1.4.0, Apache-2.0, approved, 
 maven/mavencentral/com.azure/azure-core-http-netty/1.13.11, MIT AND Apache-2.0, approved, #7948
 maven/mavencentral/com.azure/azure-core-http-netty/1.14.0, MIT AND Apache-2.0, approved, #13238
 maven/mavencentral/com.azure/azure-core-http-netty/1.14.2, MIT AND Apache-2.0, approved, #13238
-maven/mavencentral/com.azure/azure-core-http-netty/1.15.0, , restricted, clearlydefined
+maven/mavencentral/com.azure/azure-core-http-netty/1.15.0, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-core/1.45.1, MIT AND Apache-2.0, approved, #11845
 maven/mavencentral/com.azure/azure-core/1.46.0, MIT AND Apache-2.0, approved, #13234
 maven/mavencentral/com.azure/azure-core/1.48.0, MIT AND Apache-2.0, approved, #14409
-maven/mavencentral/com.azure/azure-core/1.49.0, , restricted, clearlydefined
+maven/mavencentral/com.azure/azure-core/1.49.0, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-identity/1.11.2, MIT AND Apache-2.0, approved, #13237
 maven/mavencentral/com.azure/azure-identity/1.12.1, MIT AND Apache-2.0, approved, #14412
 maven/mavencentral/com.azure/azure-json/1.1.0, MIT AND Apache-2.0, approved, #10547

--- a/edc-controlplane/edc-runtime-memory/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-runtime-memory/src/main/docker/Dockerfile
@@ -21,7 +21,7 @@
 #################################################################################
 
 
-FROM eclipse-temurin:21.0.2_13-jre-alpine
+FROM eclipse-temurin:22.0.1_8-jre-alpine
 ARG JAR
 
 ARG APP_USER=docker

--- a/edc-tests/runtime/mock-connector/src/main/docker/Dockerfile
+++ b/edc-tests/runtime/mock-connector/src/main/docker/Dockerfile
@@ -18,7 +18,7 @@
 #################################################################################
 
 
-FROM eclipse-temurin:22_36-jre-alpine
+FROM eclipse-temurin:22.0.1_8-jre-alpine
 ARG JAR
 ARG OTEL_JAR
 ARG ADDITIONAL_FILES

--- a/samples/edc-dast/edc-dast-runtime/src/main/docker/Dockerfile
+++ b/samples/edc-dast/edc-dast-runtime/src/main/docker/Dockerfile
@@ -17,7 +17,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #################################################################################
 
-FROM eclipse-temurin:22_36-jre-alpine
+FROM eclipse-temurin:22.0.1_8-jre-alpine
 ARG JAR
 ARG OTEL_JAR
 ARG ADDITIONAL_FILES


### PR DESCRIPTION
## WHAT

Align eclipse-temurin versions to `22.0.1_8-jre-alpine` on all the dockerfiles.
Updated dependabot.yml to make it take care of keeping them aligned.

## WHY

version updates

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
