### PR TITLE
feat(ci): add multi-k8s versions test

### DIFF
--- a/.github/actions/run-deployment-test/action.yml
+++ b/.github/actions/run-deployment-test/action.yml
@@ -40,16 +40,16 @@ inputs:
     required: true
     description: "The directory that contains the docker file, e.g. edc-controlplane/edc-runtime-memory"
 
+  k8sversion:
+    required: false
+    description: "Version of Kubernetes to use"
+    default: "v1.30.0"
+
 runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v3.3.0
     - uses: ./.github/actions/setup-java
-
-    - name: Build docker images
-      shell: bash
-      run: |-
-        ./gradlew -p ${{ inputs.rootDir }} dockerize
 
     - name: Setup Helm
       uses: azure/setup-helm@v3.5
@@ -62,7 +62,14 @@ runs:
         version: 'v1.28.2'
 
     - name: Create k8s Kind Cluster
-      uses: helm/kind-action@v1.5.0
+      uses: helm/kind-action@v1.10.0
+      with:
+        node_image: kindest/node:${{ inputs.k8sversion }}
+
+    - name: Build docker images
+      shell: bash
+      run: |-
+        ./gradlew -p ${{ inputs.rootDir }} dockerize
 
     - name: Load images into KinD
       shell: bash

--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -77,6 +77,13 @@ jobs:
   test-hashicorp-postgres:
     runs-on: ubuntu-latest
     needs: test-prepare
+    strategy:
+      fail-fast: false
+      # this will verify that the official distribution of the Tractus-X EDC Helm chart runs on the last 3 Kubernetes versions
+      matrix:
+        k8s-version: ["v1.30.0",
+                      "v1.29.4",
+                      "v1.28.9"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -85,6 +92,7 @@ jobs:
         with:
           imagename: "edc-controlplane-postgresql-hashicorp-vault edc-dataplane-hashicorp-vault"
           rootDir: "."
+          k8sversion: ${{ matrix.k8s-version }}
           helm_command: |-
             helm install tx-prod charts/tractusx-connector \
             -f edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml \


### PR DESCRIPTION
## WHAT

Converts the deployment test to a matrix test running against the last three kubernetes versions

## WHY

TRG 5.10

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #1313
