### PR TITLE
chore: removes  transferProxyTokenEncryptionAesKey setting

### DIFF
--- a/charts/tractusx-connector-azure-vault/README.md
+++ b/charts/tractusx-connector-azure-vault/README.md
@@ -286,7 +286,6 @@ helm install my-release tractusx-edc/tractusx-connector-azure-vault --version 0.
 | vault.azure.name | string | `"<AZURE_NAME>"` |  |
 | vault.azure.secret | string | `nil` |  |
 | vault.azure.tenant | string | `nil` |  |
-| vault.secretNames.transferProxyTokenEncryptionAesKey | string | `"transfer-proxy-token-encryption-aes-key"` |  |
 | vault.secretNames.transferProxyTokenSignerPrivateKey | string | `nil` |  |
 | vault.secretNames.transferProxyTokenSignerPublicKey | string | `nil` |  |
 

--- a/charts/tractusx-connector-azure-vault/values.yaml
+++ b/charts/tractusx-connector-azure-vault/values.yaml
@@ -541,7 +541,6 @@ vault:
   secretNames:
     transferProxyTokenSignerPrivateKey:
     transferProxyTokenSignerPublicKey:
-    transferProxyTokenEncryptionAesKey: transfer-proxy-token-encryption-aes-key
 
 networkPolicy:
   # -- If `true` network policy will be created to restrict access to control- and dataplane

--- a/charts/tractusx-connector-memory/README.md
+++ b/charts/tractusx-connector-memory/README.md
@@ -175,7 +175,7 @@ helm install my-release tractusx-edc/tractusx-connector-memory --version 0.7.2 \
 | serviceAccount.name | string | `""` |  |
 | tests | object | `{"hookDeletePolicy":"before-hook-creation,hook-succeeded"}` | Configurations for Helm tests |
 | tests.hookDeletePolicy | string | `"before-hook-creation,hook-succeeded"` | Configure the hook-delete-policy for Helm tests |
-| vault.secretNames.transferProxyTokenEncryptionAesKey | string | `"transfer-proxy-token-encryption-aes-key"` |  |
+| vault.secretNames | string | `nil` |  |
 | vault.secrets | string | `""` |  |
 | vault.server.postStart | string | `""` |  |
 

--- a/charts/tractusx-connector-memory/values.yaml
+++ b/charts/tractusx-connector-memory/values.yaml
@@ -313,7 +313,6 @@ vault:
   # secrets can be seeded by supplying them in a semicolon separated list key1:secret2;key2:secret2
   secrets: ""
   secretNames:
-    transferProxyTokenEncryptionAesKey: transfer-proxy-token-encryption-aes-key
   server:
     postStart: |-
 backendService:

--- a/charts/tractusx-connector/README.md
+++ b/charts/tractusx-connector/README.md
@@ -287,7 +287,6 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.7.2 \
 | vault.hashicorp.token | string | `"root"` |  |
 | vault.hashicorp.url | string | `"http://{{ .Release.Name }}-vault:8200"` |  |
 | vault.injector.enabled | bool | `false` |  |
-| vault.secretNames.transferProxyTokenEncryptionAesKey | string | `"transfer-proxy-token-encryption-aes-key"` |  |
 | vault.secretNames.transferProxyTokenSignerPrivateKey | string | `nil` |  |
 | vault.secretNames.transferProxyTokenSignerPublicKey | string | `nil` |  |
 | vault.server.dev.devRootToken | string | `"root"` |  |

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -547,8 +547,6 @@ vault:
   secretNames:
     transferProxyTokenSignerPrivateKey:
     transferProxyTokenSignerPublicKey:
-    transferProxyTokenEncryptionAesKey: transfer-proxy-token-encryption-aes-key
-
 networkPolicy:
   # -- If `true` network policy will be created to restrict access to control- and dataplane
   enabled: false

--- a/edc-tests/deployment/src/main/resources/helm/tractusx-connector-azure-vault-test.yaml
+++ b/edc-tests/deployment/src/main/resources/helm/tractusx-connector-azure-vault-test.yaml
@@ -85,7 +85,6 @@ vault:
     secret:
     certificate:
   secretNames:
-    transferProxyTokenEncryptionAesKey: aes-keys
   # this must be set through CLI args: --set vault.secrets=$YOUR_VAULT_SECRETS where YOUR_VAULT_SECRETS should
   # be a string in the format "key1:secret1;key2:secret2;..."
   secrets:

--- a/edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml
+++ b/edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml
@@ -94,7 +94,6 @@ vault:
     url: http://{{ .Release.Name }}-vault:8200
     token: root
   secretNames:
-    transferProxyTokenEncryptionAesKey: aes-keys
     # this must be set through CLI args: --set vault.secrets=$YOUR_VAULT_SECRETS where YOUR_VAULT_SECRETS should
     # be a string in the format "key1:secret1;key2:secret2;..."
     secrets:


### PR DESCRIPTION
## WHAT

removes  `transferProxyTokenEncryptionAesKey` setting

## WHY

cleanup, not used in 0.7.x


Closes #1270 
