### PR TITLE
refactor(test): cleanup unneeded dependencies

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -156,7 +156,7 @@ jobs:
       - name: Run Postgresql E2E tests
         run: ./gradlew test -DincludeTags="PostgresqlIntegrationTest" --refresh-dependencies
 
-  dataplane-tests:
+  cloud-transfer-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -166,4 +166,4 @@ jobs:
       - name: Run Azure/S3 dataplane tests
         run: |
           ./gradlew compileJava compileTestJava
-          ./gradlew -p edc-tests/edc-dataplane test -DincludeTags="AzureCosmosDbIntegrationTest,AwsS3IntegrationTest"
+          ./gradlew -p edc-tests/edc-dataplane test -DincludeTags="CloudTransferTest"

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -67,7 +67,7 @@ maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.6, A
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.6, Apache-2.0, approved, #7942
 maven/mavencentral/com.github.java-json-tools/btf/1.3, Apache-2.0 AND GPL-1.0-or-later AND LGPL-3.0-only AND Apache-2.0 AND LGPL-3.0-only, restricted, #15201
 maven/mavencentral/com.github.java-json-tools/jackson-coreutils-equivalence/1.0, LGPL-3.0 OR Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.github.java-json-tools/jackson-coreutils/2.0, Apache-2.0 AND LGPL-2.1-or-later AND LGPL-3.0-only AND (Apache-2.0 AND GPL-1.0-or-later AND LGPL-3.0-only) AND Apache-2.0 AND LGPL-3.0-only, restricted, #15186
+maven/mavencentral/com.github.java-json-tools/jackson-coreutils/2.0, Apache-2.0 OR LGPL-3.0-or-later, approved, #15186
 maven/mavencentral/com.github.java-json-tools/json-patch/1.13, Apache-2.0 OR LGPL-3.0-or-later, approved, CQ23929
 maven/mavencentral/com.github.java-json-tools/json-schema-core/1.2.14, Apache-2.0 AND LGPL-2.1-or-later AND LGPL-3.0-only AND (Apache-2.0 AND GPL-1.0-or-later AND LGPL-3.0-only) AND Apache-2.0 AND LGPL-3.0-only, restricted, #15282
 maven/mavencentral/com.github.java-json-tools/json-schema-validator/2.2.14, Apache-2.0 OR LGPL-3.0-or-later, approved, CQ20779
@@ -340,10 +340,8 @@ maven/mavencentral/org.codehaus.plexus/plexus-utils/3.3.0, , approved, CQ21066
 maven/mavencentral/org.codehaus.woodstox/stax2-api/4.2.2, BSD-2-Clause, approved, #2670
 maven/mavencentral/org.eclipse.angus/angus-activation/1.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
 maven/mavencentral/org.eclipse.edc.aws/aws-s3-core/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc.aws/aws-s3-test/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc.aws/data-plane-aws-s3/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc.azure/azure-blob-core/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc.azure/azure-test/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc.azure/data-plane-azure-storage/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc.azure/vault-azure/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/accesstoken-lib/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -439,7 +437,6 @@ maven/mavencentral/org.eclipse.edc/edr-store-core/0.7.1-20240618-SNAPSHOT, Apach
 maven/mavencentral/org.eclipse.edc/edr-store-receiver/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/edr-store-spi/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/http-lib/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/http-lib/0.7.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/http-spi/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/http/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/iam-mock/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -475,7 +472,6 @@ maven/mavencentral/org.eclipse.edc/json-ld/0.7.1-20240618-SNAPSHOT, Apache-2.0, 
 maven/mavencentral/org.eclipse.edc/json-lib/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/junit-base/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/junit/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/junit/0.7.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jws2020-lib/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jwt-spi/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jwt-verifiable-credentials/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -504,14 +500,12 @@ maven/mavencentral/org.eclipse.edc/policy-monitor-core/0.7.1-20240618-SNAPSHOT, 
 maven/mavencentral/org.eclipse.edc/policy-monitor-spi/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-monitor-store-sql/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-spi/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/policy-spi/0.7.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/presentation-api/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/query-lib/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.7.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/secrets-spi/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/sql-core/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/sql-core/0.7.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/sql-lease/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/sql-pool-apache-commons/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/state-machine-lib/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -519,10 +513,8 @@ maven/mavencentral/org.eclipse.edc/store-lib/0.7.1-20240618-SNAPSHOT, Apache-2.0
 maven/mavencentral/org.eclipse.edc/token-core/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/token-spi/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transaction-datasource-spi/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transaction-datasource-spi/0.7.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transaction-local/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transaction-spi/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/transaction-spi/0.7.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transfer-data-plane-signaling/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transfer-data-plane-spi/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transfer-process-api/0.7.1-20240618-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -568,7 +560,7 @@ maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.21, EPL-2.0 OR Apache-2.0
 maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.21, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.parsson/parsson/1.1.6, EPL-2.0, approved, ee4j.parsson
 maven/mavencentral/org.flywaydb/flyway-core/10.15.0, , restricted, clearlydefined
-maven/mavencentral/org.flywaydb/flyway-database-postgresql/10.15.0, , restricted, clearlydefined
+maven/mavencentral/org.flywaydb/flyway-database-postgresql/10.15.0, NOASSERTION, restricted, clearlydefined
 maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-locator/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
@@ -633,7 +625,6 @@ maven/mavencentral/org.ow2.asm/asm/9.1, BSD-3-Clause, approved, CQ23029
 maven/mavencentral/org.ow2.asm/asm/9.5, BSD-3-Clause, approved, #7554
 maven/mavencentral/org.ow2.asm/asm/9.6, BSD-3-Clause, approved, #10776
 maven/mavencentral/org.ow2.asm/asm/9.7, BSD-3-Clause, approved, #14076
-maven/mavencentral/org.postgresql/postgresql/42.7.2, BSD-2-Clause AND Apache-2.0, approved, #11681
 maven/mavencentral/org.postgresql/postgresql/42.7.3, BSD-2-Clause AND Apache-2.0, approved, #11681
 maven/mavencentral/org.reactivestreams/reactive-streams/1.0.4, CC0-1.0, approved, CQ16332
 maven/mavencentral/org.reflections/reflections/0.10.2, Apache-2.0 AND WTFPL, approved, clearlydefined
@@ -661,13 +652,13 @@ maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-C
 maven/mavencentral/software.amazon.awssdk/annotations/2.25.66, Apache-2.0, approved, #13691
 maven/mavencentral/software.amazon.awssdk/annotations/2.26.3, , restricted, clearlydefined
 maven/mavencentral/software.amazon.awssdk/apache-client/2.25.66, Apache-2.0, approved, #13687
-maven/mavencentral/software.amazon.awssdk/apache-client/2.26.3, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/apache-client/2.26.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/arns/2.25.66, Apache-2.0, approved, #13695
 maven/mavencentral/software.amazon.awssdk/arns/2.26.3, , restricted, clearlydefined
 maven/mavencentral/software.amazon.awssdk/auth/2.25.66, Apache-2.0, approved, #13692
-maven/mavencentral/software.amazon.awssdk/auth/2.26.3, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/auth/2.26.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/aws-core/2.25.66, Apache-2.0, approved, #13702
-maven/mavencentral/software.amazon.awssdk/aws-core/2.26.3, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/aws-core/2.26.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.25.66, Apache-2.0, approved, #13701
 maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.26.3, , restricted, clearlydefined
 maven/mavencentral/software.amazon.awssdk/aws-xml-protocol/2.25.66, Apache-2.0, approved, #13684
@@ -702,7 +693,7 @@ maven/mavencentral/software.amazon.awssdk/profiles/2.26.3, , restricted, clearly
 maven/mavencentral/software.amazon.awssdk/protocol-core/2.25.66, Apache-2.0, approved, #13679
 maven/mavencentral/software.amazon.awssdk/protocol-core/2.26.3, , restricted, clearlydefined
 maven/mavencentral/software.amazon.awssdk/regions/2.25.66, Apache-2.0, approved, #13694
-maven/mavencentral/software.amazon.awssdk/regions/2.26.3, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/regions/2.26.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/retries-spi/2.26.3, , restricted, clearlydefined
 maven/mavencentral/software.amazon.awssdk/retries/2.26.3, , restricted, clearlydefined
 maven/mavencentral/software.amazon.awssdk/s3-transfer-manager/2.26.3, , restricted, clearlydefined

--- a/edc-tests/edc-dataplane/cloud-transfer-tests/build.gradle.kts
+++ b/edc-tests/edc-dataplane/cloud-transfer-tests/build.gradle.kts
@@ -34,11 +34,10 @@ dependencies {
     testImplementation(libs.edc.auth.tokenbased)
     testImplementation(libs.edc.dpf.selector.spi)
     testImplementation(libs.testcontainers.junit)
-    testImplementation(testFixtures(libs.edc.azure.test))
     testImplementation(libs.edc.aws.s3.core)
-    testImplementation(testFixtures(libs.edc.aws.s3.test))
     testImplementation(libs.aws.s3)
     testImplementation(libs.aws.s3transfer)
+    testImplementation(libs.azure.storage.blob)
 }
 
 

--- a/edc-tests/edc-dataplane/cloud-transfer-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/transfer/test/AzureBlobHelper.java
+++ b/edc-tests/edc-dataplane/cloud-transfer-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/transfer/test/AzureBlobHelper.java
@@ -22,15 +22,16 @@ package org.eclipse.tractusx.edc.dataplane.transfer.test;
 import com.azure.core.util.BinaryData;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.sas.BlobContainerSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import com.azure.storage.common.StorageSharedKeyCredential;
 
 import java.io.InputStream;
 import java.time.OffsetDateTime;
 import java.util.List;
 
-import static org.eclipse.edc.azure.testfixtures.TestFunctions.getBlobServiceClient;
 
 /**
  * Helper class that internally uses Azure SDK classes to create containers, upload blobs, generate SAS tokens, etc.
@@ -56,7 +57,10 @@ public class AzureBlobHelper {
     private BlobServiceClient blobClient() {
         if (blobServiceClient == null) {
             var endpoint = "http://%s:%s/%s".formatted(host, port, accountName);
-            blobServiceClient = getBlobServiceClient(accountName, key, endpoint);
+            blobServiceClient = new BlobServiceClientBuilder()
+                    .credential(new StorageSharedKeyCredential(accountName, key))
+                    .endpoint(endpoint)
+                    .buildClient();
         }
         return blobServiceClient;
     }
@@ -88,4 +92,3 @@ public class AzureBlobHelper {
         return blobClient().getBlobContainerClient(containerName).generateSas(vals);
     }
 }
- 

--- a/edc-tests/edc-dataplane/cloud-transfer-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/transfer/test/AzureToAzureTest.java
+++ b/edc-tests/edc-dataplane/cloud-transfer-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/transfer/test/AzureToAzureTest.java
@@ -21,7 +21,6 @@ package org.eclipse.tractusx.edc.dataplane.transfer.test;
 
 import com.azure.core.util.BinaryData;
 import io.restassured.http.ContentType;
-import org.eclipse.edc.azure.testfixtures.annotations.AzureStorageIntegrationTest;
 import org.eclipse.edc.junit.testfixtures.TestUtils;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -70,7 +69,7 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
  */
 @SuppressWarnings("resource")
 @Testcontainers
-@AzureStorageIntegrationTest
+@CloudTransferTest
 public class AzureToAzureTest {
     private static final int PROVIDER_CONTROL_PORT = getFreePort();
     private static final int AZURITE_HOST_PORT = getFreePort();

--- a/edc-tests/edc-dataplane/cloud-transfer-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/transfer/test/CloudTransferTest.java
+++ b/edc-tests/edc-dataplane/cloud-transfer-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/transfer/test/CloudTransferTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.dataplane.transfer.test;
+
+import org.eclipse.edc.junit.annotations.IntegrationTest;
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@IntegrationTest
+@Tag("CloudTransferTest")
+public @interface CloudTransferTest {
+}

--- a/edc-tests/edc-dataplane/cloud-transfer-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/transfer/test/MultiCloudTest.java
+++ b/edc-tests/edc-dataplane/cloud-transfer-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/transfer/test/MultiCloudTest.java
@@ -25,8 +25,6 @@ import org.eclipse.edc.aws.s3.AwsClientProviderConfiguration;
 import org.eclipse.edc.aws.s3.AwsClientProviderImpl;
 import org.eclipse.edc.aws.s3.S3BucketSchema;
 import org.eclipse.edc.aws.s3.S3ClientRequest;
-import org.eclipse.edc.aws.s3.testfixtures.annotations.AwsS3IntegrationTest;
-import org.eclipse.edc.azure.testfixtures.annotations.AzureStorageIntegrationTest;
 import org.eclipse.edc.junit.testfixtures.TestUtils;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
@@ -68,8 +66,7 @@ import static org.eclipse.tractusx.edc.dataplane.transfer.test.TestFunctions.lis
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 @Testcontainers
-@AzureStorageIntegrationTest
-@AwsS3IntegrationTest
+@CloudTransferTest
 public class MultiCloudTest {
     // S3 test constants
     public static final String REGION = Region.US_WEST_2.id();

--- a/edc-tests/edc-dataplane/cloud-transfer-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/transfer/test/S3ToS3Test.java
+++ b/edc-tests/edc-dataplane/cloud-transfer-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/transfer/test/S3ToS3Test.java
@@ -24,7 +24,6 @@ import org.eclipse.edc.aws.s3.AwsClientProviderConfiguration;
 import org.eclipse.edc.aws.s3.AwsClientProviderImpl;
 import org.eclipse.edc.aws.s3.S3BucketSchema;
 import org.eclipse.edc.aws.s3.S3ClientRequest;
-import org.eclipse.edc.aws.s3.testfixtures.annotations.AwsS3IntegrationTest;
 import org.eclipse.edc.junit.testfixtures.TestUtils;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -79,7 +78,7 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
  * It spins up a fully-fledged dataplane and issues the DataFlowStartMessage via the data plane's Control API
  */
 @Testcontainers
-@AwsS3IntegrationTest
+@CloudTransferTest
 public class S3ToS3Test {
     private static final String SECRET_ACCESS_KEY = UUID.randomUUID().toString(); // password
     private static final int PROVIDER_CONTROL_PORT = getFreePort(); // port of the control api

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ assertj = "3.26.0"
 awaitility = "4.2.1"
 aws = "2.26.3"
 azure-identity = "1.12.2"
+azure-storage-blob = "12.26.0"
 bouncyCastle-jdk18on = "1.78.1"
 flyway = "10.15.0"
 jackson = "2.17.1"
@@ -84,7 +85,6 @@ edc-auth-oauth2-client = { module = "org.eclipse.edc:oauth2-client", version.ref
 edc-transaction-local = { module = "org.eclipse.edc:transaction-local", version.ref = "edc" }
 edc-ext-http = { module = "org.eclipse.edc:http", version.ref = "edc" }
 edc-ext-azure-cosmos-core = { module = "org.eclipse.edc:azure-cosmos-core", version.ref = "edc" }
-edc-ext-azure-test = { module = "org.eclipse.edc:azure-test", version.ref = "edc" }
 edc-ext-jsonld = { module = "org.eclipse.edc:json-ld", version.ref = "edc" }
 edc-validator-data-address-http-data = { module = "org.eclipse.edc:validator-data-address-http-data", version.ref = "edc" }
 edc-runtime-metamodel = { module = "org.eclipse.edc:runtime-metamodel", version.ref = "edc" }
@@ -121,13 +121,12 @@ edc-sql-dataplane = { module = "org.eclipse.edc:data-plane-store-sql", version.r
 
 # azure stuff
 edc-azure-vault = { module = "org.eclipse.edc.azure:vault-azure", version.ref = "edc" }
+azure-storage-blob = { module = "com.azure:azure-storage-blob", version.ref = "azure-storage-blob" }
 edc-azure-identity = { module = "com.azure:azure-identity", version.ref = "azure-identity" }
-edc-azure-test = { module = "org.eclipse.edc.azure:azure-test", version.ref = "edc" }
 edc-dpf-azblob = { module = "org.eclipse.edc.azure:data-plane-azure-storage", version.ref = "edc" }
 
 # EDC aws s3 stuff
 edc-aws-s3-core = { module = "org.eclipse.edc.aws:aws-s3-core", version.ref = "edc" }
-edc-aws-s3-test = { module = "org.eclipse.edc.aws:aws-s3-test", version.ref = "edc" }
 edc-dpf-awss3 = { module = "org.eclipse.edc.aws:data-plane-aws-s3", version.ref = "edc" }
 
 # Control Plane implementations


### PR DESCRIPTION
## WHAT

Removes `aws-s3-test` and `azure-test` dependencies

## WHY

not really necessary: 
- the annotations have been replaced by a single, more understandable `CloudTransferTest`
- the call to a test fixture methods has been inlined

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #1368 
