### PR TITLE
docs: add openapi spec link to metadata file

### DIFF
--- a/.github/workflows/draft-new-release.yaml
+++ b/.github/workflows/draft-new-release.yaml
@@ -50,6 +50,8 @@ jobs:
         run: |-
           # replace the project's (default) version, could be overwritten later with the -Pversion=... flag
           sed -i  's/version=.*/version=${{ github.event.inputs.version }}/g' gradle.properties
+          # replace the openapi version with the upcoming one
+          sed -i 's#tractusx-edc/.*/swagger.yaml#tractusx-edc/${{ github.event.inputs.version }}/swagger.yaml#g' .tractusx
         env:
           GITHUB_PACKAGE_USERNAME: ${{ github.actor }}
           GITHUB_PACKAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.tractusx
+++ b/.tractusx
@@ -1,3 +1,5 @@
 product: "Tractus-X EDC"
 leadingRepository: "https://github.com/eclipse-tractusx/tractusx-edc"
 repositories: []
+openApiSpecs:
+- "https://api.swaggerhub.com/apis/eclipse-tractusx-bot/tractusx-edc/0.7.3/swagger.yaml"


### PR DESCRIPTION
## WHAT

Adds `openApiSpecs` link in `.tractusx` metadata fiile

## WHY

documentation

## FURTHER NOTES

- ensured that on every version release the version number will be bumped

Closes #1384 
