### PR TITLE
feat(api): align management api to v3

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -109,7 +109,7 @@ maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #1
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.40, Apache-2.0, approved, #15156
 maven/mavencentral/com.nimbusds/oauth2-oidc-sdk/11.9.1, Apache-2.0, approved, #12667
 maven/mavencentral/com.puppycrawl.tools/checkstyle/10.17.0, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #15077
-maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
+maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause AND BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #15227
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.9.3, Apache-2.0 AND MPL-2.0, approved, #3225
@@ -311,7 +311,7 @@ maven/mavencentral/org.apache.maven.doxia/doxia-module-xdoc/1.12.0, Apache-2.0, 
 maven/mavencentral/org.apache.maven.doxia/doxia-sink-api/1.12.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.velocity.tools/velocity-tools-generic/3.1, Apache-2.0, approved, #9331
 maven/mavencentral/org.apache.velocity/velocity-engine-core/2.3, Apache-2.0, approved, #2478
-maven/mavencentral/org.apache.velocity/velocity-engine-scripting/2.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.velocity/velocity-engine-scripting/2.3, Apache-2.0, restricted, clearlydefined
 maven/mavencentral/org.apache.xbean/xbean-reflect/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.26.0, Apache-2.0, approved, #14886

--- a/charts/tractusx-connector-azure-vault/templates/tests/test-controlplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/tests/test-controlplane.yaml
@@ -45,7 +45,7 @@ spec:
                     "@id": "tx:BPN000001234",
                     "tx:groups": ["group1", "group2", "group3"]
                 }' ]
-      args: [ '{{- printf "http://%s-controlplane:%v%s/business-partner-groups" (include "txdc.fullname" $ ) $.Values.controlplane.endpoints.management.port $.Values.controlplane.endpoints.management.path -}}' ]
+      args: [ '{{- printf "http://%s-controlplane:%v%s/v3/business-partner-groups" (include "txdc.fullname" $ ) $.Values.controlplane.endpoints.management.port $.Values.controlplane.endpoints.management.path -}}' ]
   restartPolicy: Never
   securityContext:
     fsGroup: 101 # curl_group

--- a/charts/tractusx-connector-memory/templates/tests/test-runtime.yaml
+++ b/charts/tractusx-connector-memory/templates/tests/test-runtime.yaml
@@ -46,7 +46,7 @@ spec:
                     "@id": "tx:BPN000001234",
                     "tx:groups": ["group1", "group2", "group3"]
                 }' ]
-      args: [ '{{- printf "http://%s-runtime:%v%s/business-partner-groups" (include "txdc.fullname" $ ) $.Values.runtime.endpoints.management.port $.Values.runtime.endpoints.management.path -}}' ]
+      args: [ '{{- printf "http://%s-runtime:%v%s/v3/business-partner-groups" (include "txdc.fullname" $ ) $.Values.runtime.endpoints.management.port $.Values.runtime.endpoints.management.path -}}' ]
   restartPolicy: Never
   securityContext:
     fsGroup: 101 # curl_group

--- a/charts/tractusx-connector/templates/tests/test-controlplane.yaml
+++ b/charts/tractusx-connector/templates/tests/test-controlplane.yaml
@@ -45,7 +45,7 @@ spec:
                     "@id": "tx:BPN000001234",
                     "tx:groups": ["group1", "group2", "group3"]
                 }' ]
-      args: [ '{{- printf "http://%s-controlplane:%v%s/business-partner-groups" (include "txdc.fullname" $ ) $.Values.controlplane.endpoints.management.port $.Values.controlplane.endpoints.management.path -}}' ]
+      args: [ '{{- printf "http://%s-controlplane:%v%s/v3/business-partner-groups" (include "txdc.fullname" $ ) $.Values.controlplane.endpoints.management.port $.Values.controlplane.endpoints.management.path -}}' ]
   restartPolicy: Never
   securityContext:
     fsGroup: 101 # curl_group

--- a/docs/usage/management-api-walkthrough/02_policies.md
+++ b/docs/usage/management-api-walkthrough/02_policies.md
@@ -28,7 +28,7 @@ impacting policy definitions.
 Policies can be created in the EDC as follows:
 
 ```http request
-POST /v2/policydefinitions HTTP/1.1
+POST /v3/policydefinitions HTTP/1.1
 Host: https://provider-control.plane/api/management
 X-Api-Key: password
 Content-Type: application/json

--- a/docs/usage/management-api-walkthrough/03_contractdefinitions.md
+++ b/docs/usage/management-api-walkthrough/03_contractdefinitions.md
@@ -5,7 +5,7 @@ Policy. The two policies are both policies as explained [previously](02_policies
 stages of communication between Data Provider and Data Consumer. The creation request looks like this:
 
 ```http request
-POST /v2/contractdefinitions HTTP/1.1
+POST /v3/contractdefinitions HTTP/1.1
 Host: https://provider-control.plane/api/management
 X-Api-Key: password
 Content-Type: application/json
@@ -85,8 +85,8 @@ The `edc:Criterion` mechanism is used as well in the provider-internal request-e
 part of the `edc:QuerySpec` objects that also allow pagination:
 
 - `POST /v3/assets/request`
-- `POST /v2/policydefinitions/request`
-- `POST /v2/contractdefinitions/request`
+- `POST /v3/policydefinitions/request`
+- `POST /v3/contractdefinitions/request`
 
 ## Side-Effects
 

--- a/docs/usage/management-api-walkthrough/04_catalog.md
+++ b/docs/usage/management-api-walkthrough/04_catalog.md
@@ -5,7 +5,7 @@ Consumer against their own Control Plane and triggers the retrieval of a catalog
 looks like this:
 
 ```http request
-POST /v2/catalog/request HTTP/1.1
+POST /v3/catalog/request HTTP/1.1
 Host: https://consumer-control.plane/api/management
 X-Api-Key: password
 Content-Type: application/json
@@ -173,7 +173,7 @@ policies included.
 - `dcat:hasPolicy` holds the Data Offer that is relevant for the Consumer.
     - `@id` is the identifier for the Data Offer. The EDC composes this id by concatenating three identifiers in base64-encoding.
       separated with `:` (colons). The format is `base64(contractDefinitionId):base64(assetId):base64(newUuidV4)`. The last
-      of three UUIDs changes with every request as every /v2/catalog/request call yields a new catalog with new Data Offers.
+      of three UUIDs changes with every request as every /v3/catalog/request call yields a new catalog with new Data Offers.
     - The `odrl:permission`, `odrl:prohibition` and `odrl:obligation` will hold the content of the contractPolicy configured
       in the [Contract Definition](03_contractdefinitions.md) the Contract Offer was derived from.
 

--- a/docs/usage/management-api-walkthrough/05_contractnegotiations.md
+++ b/docs/usage/management-api-walkthrough/05_contractnegotiations.md
@@ -11,7 +11,7 @@ It includes
 To trigger the process, the Data Consumer POSTs against their own Control Plane.
 
 ```http request
-POST /v2/contractnegotiations HTTP/1.1
+POST /v3/contractnegotiations HTTP/1.1
 Host: https://consumer-control.plane/api/management
 X-Api-Key: password
 Content-Type: application/json
@@ -92,7 +92,7 @@ the `@id` property.
 ### Polling
 
 ```http request
-GET /v2/contractnegotiation/773b8795-45f2-4c57-a020-dc04e639baf3 HTTP/1.1
+GET /v3/contractnegotiation/773b8795-45f2-4c57-a020-dc04e639baf3 HTTP/1.1
 Host: https://consumer-control.plane/api/management
 X-Api-Key: password
 Content-Type: application/json

--- a/docs/usage/management-api-walkthrough/06_transferprocesses.md
+++ b/docs/usage/management-api-walkthrough/06_transferprocesses.md
@@ -30,7 +30,7 @@ terminated/suspended or terminated by the policy monitor depending on the config
 
 To trigger this process, the Consumer app makes a request to its EDC's Control Plane:
 ```http request
-POST /v2/transferprocesses HTTP/1.1
+POST /v3/transferprocesses HTTP/1.1
 Host: https://consumer-control.plane/api/management
 X-Api-Key: password
 Content-Type: application/json
@@ -110,7 +110,7 @@ the Consumer Control Plane. How to handle EDRs consumption check [here](07_edrs.
 The state of a given Transfer Process can be requested like this:
 
 ```http request
-GET /v2/transferprocesses/177aba51-52d7-44dc-beab-fd6151147024 HTTP/1.1
+GET /v3/transferprocesses/177aba51-52d7-44dc-beab-fd6151147024 HTTP/1.1
 Host: https://consumer-control.plane/api/management
 X-Api-Key: password
 Content-Type: application/json

--- a/docs/usage/management-api-walkthrough/07_edrs.md
+++ b/docs/usage/management-api-walkthrough/07_edrs.md
@@ -31,7 +31,7 @@ Alternatively TractusX-EDC provides a single API to collapse those two processes
 Example of negotiating a contract for an asset with a framework agreement policy:
 
 ```http request
-POST /v2/edrs HTTP/1.1
+POST /v3/edrs HTTP/1.1
 Host: https://consumer-control.plane/management
 X-Api-Key: password
 Content-Type: application/json
@@ -123,7 +123,7 @@ The Consumer Control Plane can be queried for EDRs by the
 Here's an example of querying with `assetId`:
 
 ```http request
-POST /v2/edrs/request HTTP/1.1
+POST /v3/edrs/request HTTP/1.1
 Host: https://consumer-control.plane/management
 X-Api-Key: password
 Content-Type: application/json
@@ -148,7 +148,7 @@ Content-Type: application/json
 
 It returns a set of EDR entries holding meta-data including:
 - `transferProcessId`: The ID of the [Transfer Process](06_transferprocesses.md) that was implicitly initiated
-  by the POST `/v2/edrs` request.
+  by the POST `/v3/edrs` request.
 - `agreementId`: The ID of the agreement that the two EDCs have made in the [Contract Negotiation](05_contractnegotiations.md)
   phase of their EDR-interaction.
 - `providerId`: The ID of the provider.
@@ -161,7 +161,7 @@ Finally, after first obtaining them from the Provider Control Plane and
 then locating in the Consumer Control Plane's cache, they can be retrieved using the `transferProcessId`.
 
 ```http request
-GET /v2/edrs/myTransferProcessId/dataaddress HTTP/1.1
+GET /v3/edrs/myTransferProcessId/dataaddress HTTP/1.1
 Host: https://consumer-control.plane/management
 X-Api-Key: password
 Content-Type: application/json
@@ -208,7 +208,7 @@ By using the same API described above and passing a query parameter `auto_refres
 will be done automatically if necessary transparently.
 
 ```http request
-GET /v2/edrs/myTransferProcessId/dataaddress?auto_refresh=true HTTP/1.1
+GET /v3/edrs/myTransferProcessId/dataaddress?auto_refresh=true HTTP/1.1
 Host: https://consumer-control.plane/management
 X-Api-Key: password
 Content-Type: application/json
@@ -221,7 +221,7 @@ In this way, always a valid token is returned.
 A explicit refresh API is available for users; 
 
 ```http
-POST /v2/edrs/myTransferProcessId/refresh HTTP/1.1
+POST /v3/edrs/myTransferProcessId/refresh HTTP/1.1
 Host: https://consumer-control.plane/management
 X-Api-Key: password
 Content-Type: application/json
@@ -240,7 +240,7 @@ However, if needed this endpoint will delete the EDR entry associated with the `
 from the vault.
 
 ```http request
-DELETE /v2/edrs/myTransferProcessId HTTP/1.1
+DELETE /v3/edrs/myTransferProcessId HTTP/1.1
 Host: https://consumer-control.plane/management
 X-Api-Key: password
 Content-Type: application/json

--- a/docs/usage/management-api-walkthrough/08_contractagreements.md
+++ b/docs/usage/management-api-walkthrough/08_contractagreements.md
@@ -5,7 +5,7 @@ endpoint (to be used with the previously explained `QuerySpec` object) but allow
 like this:
 
 ```http request
-GET /v2/contractagreements/{{AGREEMENT_ID}} HTTP/1.1
+GET /v3/contractagreements/{{AGREEMENT_ID}} HTTP/1.1
 Host: https://consumer-control.plane/api/management
 X-Api-Key: password
 Content-Type: application/json

--- a/docs/usage/management-api-walkthrough/README.md
+++ b/docs/usage/management-api-walkthrough/README.md
@@ -20,13 +20,13 @@ endpoints are currently versioned independently of each other.
 | Resource                                           | Endpoint                                   | Involved Actors                           |
 |----------------------------------------------------|--------------------------------------------|-------------------------------------------|
 | [Asset](01_assets.md)                              | `<MANAGEMENT_URL>/v3/assets`               | Provider Admin & Provider EDC             |
-| [Policy Definition](02_policies.md)                | `<MANAGEMENT_URL>/v2/policydefinitions`    | Provider Admin & Provider EDC             |
-| [Contract Definition](03_contractdefinitions.md)   | `<MANAGEMENT_URL>/v2/contractdefinitions`  | Provider Admin & Provider EDC             |
-| [Catalog](04_catalog.md)                           | `<MANAGEMENT_URL>/v2/catalog`              | Consumer App, Consumer EDC & Provider EDC |
-| [Contract Negotiation](05_contractnegotiations.md) | `<MANAGEMENT_URL>/v2/contractnegotiations` | Consumer App, Consumer EDC & Provider EDC |
-| [Contract Agreement](08_contractagreements.md)     | `<MANAGEMENT_URL>/v2/contractagreements`   | Provider Admin & Provider EDC             |
-| [Transfer Process](06_transferprocesses.md)        | `<MANAGEMENT_URL>/v2/transferprocesses`    | Consumer App, Consumer EDC & Provider EDC |
-| [EDR](07_edrs.md)                                  | `<MANAGEMENT_URL>/edrs`                    | Consumer App, Consumer EDC & Provider EDC |
+| [Policy Definition](02_policies.md)                | `<MANAGEMENT_URL>/v3/policydefinitions`    | Provider Admin & Provider EDC             |
+| [Contract Definition](03_contractdefinitions.md)   | `<MANAGEMENT_URL>/v3/contractdefinitions`  | Provider Admin & Provider EDC             |
+| [Catalog](04_catalog.md)                           | `<MANAGEMENT_URL>/v3/catalog`              | Consumer App, Consumer EDC & Provider EDC |
+| [Contract Negotiation](05_contractnegotiations.md) | `<MANAGEMENT_URL>/v3/contractnegotiations` | Consumer App, Consumer EDC & Provider EDC |
+| [Contract Agreement](08_contractagreements.md)     | `<MANAGEMENT_URL>/v3/contractagreements`   | Provider Admin & Provider EDC             |
+| [Transfer Process](06_transferprocesses.md)        | `<MANAGEMENT_URL>/v3/transferprocesses`    | Consumer App, Consumer EDC & Provider EDC |
+| [EDR](07_edrs.md)                                  | `<MANAGEMENT_URL>/v3/edrs`                 | Consumer App, Consumer EDC & Provider EDC |
 | Data Plane                                         | `<DATAPLANE_URL>`                          | Consumer App & Provider EDC               |
 
 ## OpenAPI

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/BaseBusinessPartnerGroupApiController.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/BaseBusinessPartnerGroupApiController.java
@@ -1,5 +1,5 @@
-/********************************************************************************
- * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,7 +15,7 @@
  * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- ********************************************************************************/
+ */
 
 package org.eclipse.tractusx.edc.api.bpn;
 
@@ -23,15 +23,7 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.PUT;
-import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.ObjectConflictException;
 import org.eclipse.edc.web.spi.exception.ObjectNotFoundException;
@@ -45,22 +37,15 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
 
 
-@Consumes({MediaType.APPLICATION_JSON})
-@Produces({MediaType.APPLICATION_JSON})
-@Path("/business-partner-groups")
-public class BusinessPartnerGroupApiController implements BusinessPartnerGroupApi {
+public abstract class BaseBusinessPartnerGroupApiController {
 
     private final BusinessPartnerStore businessPartnerService;
 
-
-    public BusinessPartnerGroupApiController(BusinessPartnerStore businessPartnerService) {
+    public BaseBusinessPartnerGroupApiController(BusinessPartnerStore businessPartnerService) {
         this.businessPartnerService = businessPartnerService;
     }
 
-    @GET
-    @Path("/{bpn}")
-    @Override
-    public JsonObject resolve(@PathParam("bpn") String bpn) {
+    public JsonObject resolve(String bpn) {
 
         // StoreResult does not support the .map() operator, because it does not override newInstance()
         var result = businessPartnerService.resolveForBpn(bpn);
@@ -71,16 +56,11 @@ public class BusinessPartnerGroupApiController implements BusinessPartnerGroupAp
         throw new ObjectNotFoundException(List.class, result.getFailureDetail());
     }
 
-    @DELETE
-    @Path("/{bpn}")
-    @Override
     public void deleteEntry(@PathParam("bpn") String bpn) {
         businessPartnerService.delete(bpn)
                 .orElseThrow(f -> new ObjectNotFoundException(List.class, f.getFailureDetail()));
     }
 
-    @PUT
-    @Override
     public void updateEntry(@RequestBody JsonObject object) {
         var bpn = getBpn(object);
         var groups = getGroups(object);
@@ -88,8 +68,6 @@ public class BusinessPartnerGroupApiController implements BusinessPartnerGroupAp
                 .orElseThrow(f -> new ObjectNotFoundException(List.class, f.getFailureDetail()));
     }
 
-    @POST
-    @Override
     public void createEntry(@RequestBody JsonObject object) {
         var bpn = getBpn(object);
         var groups = getGroups(object);
@@ -103,7 +81,6 @@ public class BusinessPartnerGroupApiController implements BusinessPartnerGroupAp
                 .add(TX_NAMESPACE + "groups", Json.createArrayBuilder(list))
                 .build();
     }
-
 
     private String getBpn(JsonObject object) {
         try {

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/BusinessPartnerGroupApiExtension.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/BusinessPartnerGroupApiExtension.java
@@ -26,6 +26,8 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
+import org.eclipse.tractusx.edc.api.bpn.v1.BusinessPartnerGroupApiV1Controller;
+import org.eclipse.tractusx.edc.api.bpn.v3.BusinessPartnerGroupApiV3Controller;
 import org.eclipse.tractusx.edc.validation.businesspartner.spi.BusinessPartnerStore;
 
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
@@ -45,7 +47,8 @@ public class BusinessPartnerGroupApiExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         jsonLdService.registerNamespace(TX_PREFIX, TX_NAMESPACE);
 
-        webService.registerResource(ApiContext.MANAGEMENT, new BusinessPartnerGroupApiController(businessPartnerStore));
+        webService.registerResource(ApiContext.MANAGEMENT, new BusinessPartnerGroupApiV1Controller(businessPartnerStore, context.getMonitor()));
+        webService.registerResource(ApiContext.MANAGEMENT, new BusinessPartnerGroupApiV3Controller(businessPartnerStore));
 
     }
 }

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v1/BusinessPartnerGroupApiV1.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v1/BusinessPartnerGroupApiV1.java
@@ -1,5 +1,5 @@
-/********************************************************************************
- * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,9 +15,9 @@
  * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- ********************************************************************************/
+ */
 
-package org.eclipse.tractusx.edc.api.bpn;
+package org.eclipse.tractusx.edc.api.bpn.v1;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,51 +38,54 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 
 @OpenAPIDefinition(info = @Info(description = "With this API clients can create, read, update and delete BusinessPartnerNumber groups. It allows the assigning of BPNs to groups.", title = "Business Partner Group API"))
 @Tag(name = "Business Partner Group")
-public interface BusinessPartnerGroupApi {
+@Deprecated(since = "0.8.0")
+public interface BusinessPartnerGroupApiV1 {
 
 
     @Operation(description = "Resolves all groups for a particular BPN",
+            deprecated = true,
             responses = {
                     @ApiResponse(responseCode = "200", description = "An object containing an array with the assigned groups"),
                     @ApiResponse(responseCode = "404", description = "No entry for the given BPN was found"),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
             })
-    JsonObject resolve(@Parameter(name = "bpn", description = "The business partner number") String bpn);
+    JsonObject resolveV1(@Parameter(name = "bpn", description = "The business partner number") String bpn);
 
     @Operation(description = "Deletes the entry for a particular BPN",
+            deprecated = true,
             responses = {
                     @ApiResponse(responseCode = "204", description = "The object was successfully deleted"),
                     @ApiResponse(responseCode = "404", description = "No entry for the given BPN was found"),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
             })
-    void deleteEntry(@Parameter(name = "bpn", description = "The business partner number") String bpn);
+    void deleteEntryV1(@Parameter(name = "bpn", description = "The business partner number") String bpn);
 
     @Operation(description = "Updates the entry for a particular BPN",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ListSchema.class))),
-
+            deprecated = true,
             responses = {
                     @ApiResponse(responseCode = "204", description = "The object was successfully updated"),
                     @ApiResponse(responseCode = "404", description = "No entry for the given BPN was found"),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
             })
-    void updateEntry(JsonObject object);
+    void updateEntryV1(JsonObject object);
 
     @Operation(description = "Creates an entry for a particular BPN",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ListSchema.class))),
-
+            deprecated = true,
             responses = {
                     @ApiResponse(responseCode = "204", description = "The object was successfully created"),
                     @ApiResponse(responseCode = "409", description = "An entry already exists for that BPN"),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
             })
-    void createEntry(JsonObject entry);
+    void createEntryV1(JsonObject entry);
 
 
-    @Schema(name = "List", example = ListSchema.EXAMPLE)
+    @Schema(name = "List", example = ListSchema.EXAMPLE, deprecated = true)
     record ListSchema(
             @Schema(name = ID) String id,
             Set<String> groups

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v1/BusinessPartnerGroupApiV1Controller.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v1/BusinessPartnerGroupApiV1Controller.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.api.bpn.v1;
+
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.tractusx.edc.api.bpn.BaseBusinessPartnerGroupApiController;
+import org.eclipse.tractusx.edc.validation.businesspartner.spi.BusinessPartnerStore;
+
+import static org.eclipse.edc.api.ApiWarnings.deprecationWarning;
+
+
+@Consumes({MediaType.APPLICATION_JSON})
+@Produces({MediaType.APPLICATION_JSON})
+@Path("/business-partner-groups")
+@Deprecated(since = "0.8.0")
+public class BusinessPartnerGroupApiV1Controller extends BaseBusinessPartnerGroupApiController implements BusinessPartnerGroupApiV1 {
+
+    private final Monitor monitor;
+
+    public BusinessPartnerGroupApiV1Controller(BusinessPartnerStore businessPartnerService, Monitor monitor) {
+        super(businessPartnerService);
+        this.monitor = monitor;
+    }
+
+    @GET
+    @Path("/{bpn}")
+    @Override
+    public JsonObject resolveV1(@PathParam("bpn") String bpn) {
+        monitor.warning(deprecationWarning("/v1", "/v3"));
+        return super.resolve(bpn);
+    }
+
+    @DELETE
+    @Path("/{bpn}")
+    @Override
+    public void deleteEntryV1(@PathParam("bpn") String bpn) {
+        monitor.warning(deprecationWarning("/v1", "/v3"));
+        super.deleteEntry(bpn);
+    }
+
+    @PUT
+    @Override
+    public void updateEntryV1(@RequestBody JsonObject object) {
+        monitor.warning(deprecationWarning("/v1", "/v3"));
+        super.updateEntry(object);
+    }
+
+    @POST
+    @Override
+    public void createEntryV1(@RequestBody JsonObject object) {
+        monitor.warning(deprecationWarning("/v1", "/v3"));
+        super.createEntry(object);
+    }
+
+}

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.api.bpn.v3;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.web.spi.ApiErrorDetail;
+
+import java.util.Set;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+
+@OpenAPIDefinition(info = @Info(description = "With this API clients can create, read, update and delete BusinessPartnerNumber groups. It allows the assigning of BPNs to groups.", title = "Business Partner Group API"))
+@Tag(name = "Business Partner Group")
+public interface BusinessPartnerGroupApiV3 {
+
+
+    @Operation(description = "Resolves all groups for a particular BPN",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "An object containing an array with the assigned groups"),
+                    @ApiResponse(responseCode = "404", description = "No entry for the given BPN was found"),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    JsonObject resolveV3(@Parameter(name = "bpn", description = "The business partner number") String bpn);
+
+    @Operation(description = "Deletes the entry for a particular BPN",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "The object was successfully deleted"),
+                    @ApiResponse(responseCode = "404", description = "No entry for the given BPN was found"),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    void deleteEntryV3(@Parameter(name = "bpn", description = "The business partner number") String bpn);
+
+    @Operation(description = "Updates the entry for a particular BPN",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ListSchema.class))),
+
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "The object was successfully updated"),
+                    @ApiResponse(responseCode = "404", description = "No entry for the given BPN was found"),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    void updateEntryV3(JsonObject object);
+
+    @Operation(description = "Creates an entry for a particular BPN",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ListSchema.class))),
+
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "The object was successfully created"),
+                    @ApiResponse(responseCode = "409", description = "An entry already exists for that BPN"),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    void createEntryV3(JsonObject entry);
+
+
+    @Schema(name = "List", example = ListSchema.EXAMPLE)
+    record ListSchema(
+            @Schema(name = ID) String id,
+            Set<String> groups
+    ) {
+        public static final String EXAMPLE = """
+                {
+                    "@context": {
+                        "tx": "https://w3id.org/tractusx/v0.0.1/ns/"
+                    },
+                    "@id": "tx:BPN000001234",
+                    "tx:groups": ["group1", "group2", "group3"]
+                }
+                """;
+    }
+}

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3Controller.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3Controller.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.api.bpn.v3;
+
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.tractusx.edc.api.bpn.BaseBusinessPartnerGroupApiController;
+import org.eclipse.tractusx.edc.validation.businesspartner.spi.BusinessPartnerStore;
+
+
+@Consumes({MediaType.APPLICATION_JSON})
+@Produces({MediaType.APPLICATION_JSON})
+@Path("/v3/business-partner-groups")
+public class BusinessPartnerGroupApiV3Controller extends BaseBusinessPartnerGroupApiController implements BusinessPartnerGroupApiV3 {
+
+    public BusinessPartnerGroupApiV3Controller(BusinessPartnerStore businessPartnerService) {
+        super(businessPartnerService);
+    }
+
+    @GET
+    @Path("/{bpn}")
+    @Override
+    public JsonObject resolveV3(@PathParam("bpn") String bpn) {
+        return super.resolve(bpn);
+    }
+
+    @DELETE
+    @Path("/{bpn}")
+    @Override
+    public void deleteEntryV3(@PathParam("bpn") String bpn) {
+        super.deleteEntry(bpn);
+    }
+
+    @PUT
+    @Override
+    public void updateEntryV3(@RequestBody JsonObject object) {
+        super.updateEntry(object);
+    }
+
+    @POST
+    @Override
+    public void createEntryV3(@RequestBody JsonObject object) {
+        super.createEntry(object);
+    }
+
+}

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/test/java/org/eclipse/tractusx/edc/api/bpn/BaseBusinessPartnerGroupApiControllerTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/test/java/org/eclipse/tractusx/edc/api/bpn/BaseBusinessPartnerGroupApiControllerTest.java
@@ -1,5 +1,5 @@
-/********************************************************************************
- * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,7 +15,7 @@
  * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- ********************************************************************************/
+ */
 
 package org.eclipse.tractusx.edc.api.bpn;
 
@@ -24,7 +24,6 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.jsonld.TitaniumJsonLd;
 import org.eclipse.edc.jsonld.spi.JsonLd;
-import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
 import org.eclipse.tractusx.edc.validation.businesspartner.spi.BusinessPartnerStore;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
@@ -46,11 +44,10 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ApiTest
-class BusinessPartnerGroupApiControllerTest extends RestControllerTestBase {
+public abstract class BaseBusinessPartnerGroupApiControllerTest extends RestControllerTestBase {
 
     private final JsonLd jsonLdService = new TitaniumJsonLd(mock());
-    private final BusinessPartnerStore businessPartnerStore = mock();
+    protected final BusinessPartnerStore businessPartnerStore = mock();
 
     @BeforeEach
     void setUp() {
@@ -169,17 +166,7 @@ class BusinessPartnerGroupApiControllerTest extends RestControllerTestBase {
                 .statusCode(400);
     }
 
-    @Override
-    protected Object controller() {
-        return new BusinessPartnerGroupApiController(businessPartnerStore);
-    }
-
-    private RequestSpecification baseRequest() {
-        return given()
-                .baseUri("http://localhost:" + port)
-                .basePath("/business-partner-groups")
-                .when();
-    }
+    protected abstract RequestSpecification baseRequest();
 
     private JsonObject createJsonObject() {
         return jsonLdService.expand(Json.createObjectBuilder()

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/test/java/org/eclipse/tractusx/edc/api/bpn/v1/BusinessPartnerGroupApiV1ControllerTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/test/java/org/eclipse/tractusx/edc/api/bpn/v1/BusinessPartnerGroupApiV1ControllerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.api.bpn.v1;
+
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.tractusx.edc.api.bpn.BaseBusinessPartnerGroupApiControllerTest;
+
+import static io.restassured.RestAssured.given;
+import static org.mockito.Mockito.mock;
+
+@ApiTest
+class BusinessPartnerGroupApiV1ControllerTest extends BaseBusinessPartnerGroupApiControllerTest {
+
+    @Override
+    protected Object controller() {
+        return new BusinessPartnerGroupApiV1Controller(businessPartnerStore, mock());
+    }
+
+    @Override
+    protected RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port)
+                .basePath("/business-partner-groups")
+                .when();
+    }
+
+}

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/test/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3ControllerTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/test/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3ControllerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.api.bpn.v3;
+
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.tractusx.edc.api.bpn.BaseBusinessPartnerGroupApiControllerTest;
+
+import static io.restassured.RestAssured.given;
+
+@ApiTest
+class BusinessPartnerGroupApiV3ControllerTest extends BaseBusinessPartnerGroupApiControllerTest {
+
+    @Override
+    protected Object controller() {
+        return new BusinessPartnerGroupApiV3Controller(businessPartnerStore);
+    }
+
+    @Override
+    protected RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port)
+                .basePath("/v3/business-partner-groups")
+                .when();
+    }
+
+}

--- a/edc-extensions/edr/edr-api-v2/src/main/java/org/eclipse/tractusx/edc/api/edr/EdrCacheApiExtension.java
+++ b/edc-extensions/edr/edr-api-v2/src/main/java/org/eclipse/tractusx/edc/api/edr/EdrCacheApiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.eclipse.tractusx.edc.api.edr.v2;
+package org.eclipse.tractusx.edc.api.edr;
 
 import jakarta.json.Json;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
@@ -31,7 +31,9 @@ import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
-import org.eclipse.tractusx.edc.api.edr.v2.transform.JsonObjectFromEndpointDataReferenceEntryTransformer;
+import org.eclipse.tractusx.edc.api.edr.transform.JsonObjectFromEndpointDataReferenceEntryTransformer;
+import org.eclipse.tractusx.edc.api.edr.v2.EdrCacheApiV2Controller;
+import org.eclipse.tractusx.edc.api.edr.v3.EdrCacheApiV3Controller;
 import org.eclipse.tractusx.edc.edr.spi.service.EdrService;
 
 import java.util.Map;
@@ -69,6 +71,7 @@ public class EdrCacheApiExtension implements ServiceExtension {
         jsonLdService.registerNamespace(TX_PREFIX, TX_NAMESPACE);
         var mgmtApiTransformerRegistry = transformerRegistry.forContext("management-api");
         mgmtApiTransformerRegistry.register(new JsonObjectFromEndpointDataReferenceEntryTransformer(Json.createBuilderFactory(Map.of())));
-        webService.registerResource(ApiContext.MANAGEMENT, new EdrCacheApiController(edrStore, mgmtApiTransformerRegistry, validatorRegistry, monitor, edrService, contractNegotiationService));
+        webService.registerResource(ApiContext.MANAGEMENT, new EdrCacheApiV2Controller(edrStore, mgmtApiTransformerRegistry, validatorRegistry, monitor, edrService, contractNegotiationService));
+        webService.registerResource(ApiContext.MANAGEMENT, new EdrCacheApiV3Controller(edrStore, mgmtApiTransformerRegistry, validatorRegistry, monitor, edrService, contractNegotiationService));
     }
 }

--- a/edc-extensions/edr/edr-api-v2/src/main/java/org/eclipse/tractusx/edc/api/edr/transform/JsonObjectFromEndpointDataReferenceEntryTransformer.java
+++ b/edc-extensions/edr/edr-api-v2/src/main/java/org/eclipse/tractusx/edc/api/edr/transform/JsonObjectFromEndpointDataReferenceEntryTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.eclipse.tractusx.edc.api.edr.v2.transform;
+package org.eclipse.tractusx.edc.api.edr.transform;
 
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;

--- a/edc-extensions/edr/edr-api-v2/src/main/java/org/eclipse/tractusx/edc/api/edr/v2/EdrCacheApiV2.java
+++ b/edc-extensions/edr/edr-api-v2/src/main/java/org/eclipse/tractusx/edc/api/edr/v2/EdrCacheApiV2.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.api.edr.v2;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.model.ApiCoreSchema;
+import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.v3.ContractNegotiationApiV3;
+import org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry;
+import org.eclipse.edc.web.spi.ApiErrorDetail;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+
+@OpenAPIDefinition
+@Tag(name = "Control Plane EDR Api")
+@Deprecated(since = "0.8.0")
+public interface EdrCacheApiV2 {
+
+    @Operation(description = "Initiates an EDR negotiation by handling a contract negotiation first and then a transfer process for a given offer and with the given counter part. Please note that successfully invoking this endpoint " +
+            "only means that the negotiation was initiated.",
+            deprecated = true,
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The negotiation was successfully initiated.",
+                            content = @Content(schema = @Schema(implementation = ApiCoreSchema.IdResponseSchema.class))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
+            })
+    JsonObject initiateEdrNegotiationV2(@Schema(implementation = ContractNegotiationApiV3.ContractRequestSchema.class) JsonObject dto);
+
+    @Operation(description = "Request all Edr entries according to a particular query",
+            deprecated = true,
+            requestBody = @RequestBody(
+                    content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The edr entries matching the query",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = EndpointDataReferenceEntrySchema.class)))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            })
+    JsonArray requestEdrEntriesV2(JsonObject querySpecJson);
+
+    @Operation(description = "Gets the EDR data address with the given transfer process ID",
+            deprecated = true,
+            parameters = { @Parameter(name = "transferProcessId", description = "The ID of the transferprocess for which the EDR should be fetched", required = true),
+                    @Parameter(name = "auto_refresh", description = "Whether the access token that is stored on the EDR should be checked for expiry, and renewed if necessary. Default is true.")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The data address",
+                            content = @Content(schema = @Schema(implementation = ApiCoreSchema.DataAddressSchema.class))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "An EDR data address with the given transfer process ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    JsonObject getEdrEntryDataAddressV2(String transferProcessId, boolean autoRefresh);
+
+    @Operation(description = "Removes an EDR entry given the transfer process ID",
+            deprecated = true,
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "EDR entry was deleted successfully"),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "An EDR entry with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            })
+    void removeEdrEntryV2(String transferProcessId);
+
+    @Operation(description = "Refreshes and returns the EDR data address with the given transfer process ID",
+            deprecated = true,
+            parameters = { @Parameter(name = "transferProcessId", description = "The ID of the transferprocess for which the EDR should be fetched", required = true),
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The data address",
+                            content = @Content(schema = @Schema(implementation = ApiCoreSchema.DataAddressSchema.class))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "An EDR data address with the given transfer process ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    JsonObject refreshEdrV2(String transferProcessId);
+
+    @ArraySchema()
+    @Schema(name = "EndpointDataReferenceEntry", example = EndpointDataReferenceEntrySchema.EDR_ENTRY_OUTPUT_EXAMPLE, deprecated = true)
+    record EndpointDataReferenceEntrySchema(
+            @Schema(name = ID)
+            String id,
+            @Schema(name = TYPE, example = EndpointDataReferenceEntry.EDR_ENTRY_TYPE)
+            String type
+    ) {
+        public static final String EDR_ENTRY_OUTPUT_EXAMPLE = """
+                {
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@id": "transfer-process-id",
+                    "transferProcessId": "transfer-process-id",
+                    "agreementId": "agreement-id",
+                    "contractNegotiationId": "contract-negotiation-id",
+                    "assetId": "asset-id",
+                    "providerId": "provider-id",
+                    "createdAt": 1688465655
+                }
+                """;
+    }
+}

--- a/edc-extensions/edr/edr-api-v2/src/main/java/org/eclipse/tractusx/edc/api/edr/v2/EdrCacheApiV2Controller.java
+++ b/edc-extensions/edr/edr-api-v2/src/main/java/org/eclipse/tractusx/edc/api/edr/v2/EdrCacheApiV2Controller.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.api.edr.v2;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceStore;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.tractusx.edc.api.edr.BaseEdrCacheApiController;
+import org.eclipse.tractusx.edc.edr.spi.service.EdrService;
+
+import static org.eclipse.edc.api.ApiWarnings.deprecationWarning;
+
+@Consumes({ MediaType.APPLICATION_JSON })
+@Produces({ MediaType.APPLICATION_JSON })
+@Path("/v2/edrs")
+@Deprecated(since = "0.8.0")
+public class EdrCacheApiV2Controller extends BaseEdrCacheApiController implements EdrCacheApiV2 {
+
+    public EdrCacheApiV2Controller(EndpointDataReferenceStore edrStore,
+                                   TypeTransformerRegistry transformerRegistry,
+                                   JsonObjectValidatorRegistry validator,
+                                   Monitor monitor,
+                                   EdrService edrService, ContractNegotiationService contractNegotiationService) {
+        super(edrStore, transformerRegistry, validator, monitor, edrService, contractNegotiationService);
+    }
+
+    @POST
+    @Override
+    public JsonObject initiateEdrNegotiationV2(JsonObject requestObject) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return super.initiateEdrNegotiation(requestObject);
+    }
+
+    @POST
+    @Path("/request")
+    @Override
+    public JsonArray requestEdrEntriesV2(JsonObject querySpecJson) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return requestEdrEntries(querySpecJson);
+    }
+
+    @GET
+    @Path("{transferProcessId}/dataaddress")
+    @Override
+    public JsonObject getEdrEntryDataAddressV2(@PathParam("transferProcessId") String transferProcessId, @DefaultValue("true") @QueryParam("auto_refresh") boolean autoRefresh) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return super.getEdrEntryDataAddress(transferProcessId, autoRefresh);
+    }
+
+    @DELETE
+    @Path("{transferProcessId}")
+    @Override
+    public void removeEdrEntryV2(@PathParam("transferProcessId") String transferProcessId) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        super.removeEdrEntry(transferProcessId);
+    }
+
+    @POST
+    @Path("{transferProcessId}/refresh")
+    @Override
+    public JsonObject refreshEdrV2(@PathParam("transferProcessId") String transferProcessId) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return super.refreshEdr(transferProcessId);
+    }
+
+}

--- a/edc-extensions/edr/edr-api-v2/src/main/java/org/eclipse/tractusx/edc/api/edr/v3/EdrCacheApiV3.java
+++ b/edc-extensions/edr/edr-api-v2/src/main/java/org/eclipse/tractusx/edc/api/edr/v3/EdrCacheApiV3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.eclipse.tractusx.edc.api.edr.v2;
+package org.eclipse.tractusx.edc.api.edr.v3;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,7 +40,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
 @OpenAPIDefinition
 @Tag(name = "Control Plane EDR Api")
-public interface EdrCacheApi {
+public interface EdrCacheApiV3 {
 
     @Operation(description = "Initiates an EDR negotiation by handling a contract negotiation first and then a transfer process for a given offer and with the given counter part. Please note that successfully invoking this endpoint " +
             "only means that the negotiation was initiated.",
@@ -50,7 +50,7 @@ public interface EdrCacheApi {
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
             })
-    JsonObject initiateEdrNegotiation(@Schema(implementation = ContractNegotiationApiV3.ContractRequestSchema.class) JsonObject dto);
+    JsonObject initiateEdrNegotiationV3(@Schema(implementation = ContractNegotiationApiV3.ContractRequestSchema.class) JsonObject dto);
 
     @Operation(description = "Request all Edr entries according to a particular query",
             requestBody = @RequestBody(
@@ -62,7 +62,7 @@ public interface EdrCacheApi {
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
-    JsonArray requestEdrEntries(JsonObject querySpecJson);
+    JsonArray requestEdrEntriesV3(JsonObject querySpecJson);
 
     @Operation(description = "Gets the EDR data address with the given transfer process ID",
             parameters = { @Parameter(name = "transferProcessId", description = "The ID of the transferprocess for which the EDR should be fetched", required = true),
@@ -77,7 +77,7 @@ public interface EdrCacheApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonObject getEdrEntryDataAddress(String transferProcessId, boolean autoRefresh);
+    JsonObject getEdrEntryDataAddressV3(String transferProcessId, boolean autoRefresh);
 
     @Operation(description = "Removes an EDR entry given the transfer process ID",
             responses = {
@@ -87,7 +87,7 @@ public interface EdrCacheApi {
                     @ApiResponse(responseCode = "404", description = "An EDR entry with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
-    void removeEdrEntry(String transferProcessId);
+    void removeEdrEntryV3(String transferProcessId);
 
     @Operation(description = "Refreshes and returns the EDR data address with the given transfer process ID",
             parameters = { @Parameter(name = "transferProcessId", description = "The ID of the transferprocess for which the EDR should be fetched", required = true),
@@ -101,7 +101,7 @@ public interface EdrCacheApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonObject refreshEdr(String transferProcessId);
+    JsonObject refreshEdrV3(String transferProcessId);
 
 
     @ArraySchema()

--- a/edc-extensions/edr/edr-api-v2/src/main/java/org/eclipse/tractusx/edc/api/edr/v3/EdrCacheApiV3Controller.java
+++ b/edc-extensions/edr/edr-api-v2/src/main/java/org/eclipse/tractusx/edc/api/edr/v3/EdrCacheApiV3Controller.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.api.edr.v3;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceStore;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.tractusx.edc.api.edr.BaseEdrCacheApiController;
+import org.eclipse.tractusx.edc.edr.spi.service.EdrService;
+
+@Consumes({ MediaType.APPLICATION_JSON })
+@Produces({ MediaType.APPLICATION_JSON })
+@Path("/v3/edrs")
+public class EdrCacheApiV3Controller extends BaseEdrCacheApiController implements EdrCacheApiV3 {
+
+    public EdrCacheApiV3Controller(EndpointDataReferenceStore edrStore,
+                                   TypeTransformerRegistry transformerRegistry,
+                                   JsonObjectValidatorRegistry validator,
+                                   Monitor monitor,
+                                   EdrService edrService, ContractNegotiationService contractNegotiationService) {
+        super(edrStore, transformerRegistry, validator, monitor, edrService, contractNegotiationService);
+    }
+
+    @POST
+    @Override
+    public JsonObject initiateEdrNegotiationV3(JsonObject requestObject) {
+        return super.initiateEdrNegotiation(requestObject);
+    }
+
+    @POST
+    @Path("/request")
+    @Override
+    public JsonArray requestEdrEntriesV3(JsonObject querySpecJson) {
+        return requestEdrEntries(querySpecJson);
+    }
+
+    @GET
+    @Path("{transferProcessId}/dataaddress")
+    @Override
+    public JsonObject getEdrEntryDataAddressV3(@PathParam("transferProcessId") String transferProcessId, @DefaultValue("true") @QueryParam("auto_refresh") boolean autoRefresh) {
+        return super.getEdrEntryDataAddress(transferProcessId, autoRefresh);
+    }
+
+    @DELETE
+    @Path("{transferProcessId}")
+    @Override
+    public void removeEdrEntryV3(@PathParam("transferProcessId") String transferProcessId) {
+        super.removeEdrEntry(transferProcessId);
+    }
+
+    @POST
+    @Path("{transferProcessId}/refresh")
+    @Override
+    public JsonObject refreshEdrV3(@PathParam("transferProcessId") String transferProcessId) {
+        return super.refreshEdr(transferProcessId);
+    }
+
+}

--- a/edc-extensions/edr/edr-api-v2/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/edc-extensions/edr/edr-api-v2/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -17,4 +17,4 @@
 #  SPDX-License-Identifier: Apache-2.0
 #################################################################################
 
-org.eclipse.tractusx.edc.api.edr.v2.EdrCacheApiExtension
+org.eclipse.tractusx.edc.api.edr.EdrCacheApiExtension

--- a/edc-extensions/edr/edr-api-v2/src/test/java/org/eclipse/tractusx/edc/api/edr/EdrCacheApiExtensionTest.java
+++ b/edc-extensions/edr/edr-api-v2/src/test/java/org/eclipse/tractusx/edc/api/edr/EdrCacheApiExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,14 +17,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.eclipse.tractusx.edc.api.edr.v2;
+package org.eclipse.tractusx.edc.api.edr;
 
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.eclipse.edc.web.spi.WebService;
-import org.eclipse.tractusx.edc.api.edr.v2.transform.JsonObjectFromEndpointDataReferenceEntryTransformer;
+import org.eclipse.tractusx.edc.api.edr.transform.JsonObjectFromEndpointDataReferenceEntryTransformer;
+import org.eclipse.tractusx.edc.api.edr.v2.EdrCacheApiV2Controller;
+import org.eclipse.tractusx.edc.api.edr.v3.EdrCacheApiV3Controller;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -56,7 +58,8 @@ class EdrCacheApiExtensionTest {
     void initialize_shouldRegisterControllers(EdrCacheApiExtension extension, ServiceExtensionContext context) {
         extension.initialize(context);
 
-        verify(webService).registerResource(any(), isA(EdrCacheApiController.class));
+        verify(webService).registerResource(any(), isA(EdrCacheApiV2Controller.class));
+        verify(webService).registerResource(any(), isA(EdrCacheApiV3Controller.class));
     }
 
     @Test

--- a/edc-extensions/edr/edr-api-v2/src/test/java/org/eclipse/tractusx/edc/api/edr/EdrCacheApiTest.java
+++ b/edc-extensions/edr/edr-api-v2/src/test/java/org/eclipse/tractusx/edc/api/edr/EdrCacheApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.eclipse.tractusx.edc.api.edr.v2;
+package org.eclipse.tractusx.edc.api.edr;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -36,7 +36,7 @@ import static org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry.EDR_ENTRY
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
-import static org.eclipse.tractusx.edc.api.edr.v2.EdrCacheApi.EndpointDataReferenceEntrySchema.EDR_ENTRY_OUTPUT_EXAMPLE;
+import static org.eclipse.tractusx.edc.api.edr.v2.EdrCacheApiV2.EndpointDataReferenceEntrySchema.EDR_ENTRY_OUTPUT_EXAMPLE;
 import static org.mockito.Mockito.mock;
 
 public class EdrCacheApiTest {

--- a/edc-extensions/edr/edr-api-v2/src/test/java/org/eclipse/tractusx/edc/api/edr/TestFunctions.java
+++ b/edc-extensions/edr/edr-api-v2/src/test/java/org/eclipse/tractusx/edc/api/edr/TestFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.eclipse.tractusx.edc.api.edr.v2;
+package org.eclipse.tractusx.edc.api.edr;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;

--- a/edc-extensions/edr/edr-api-v2/src/test/java/org/eclipse/tractusx/edc/api/edr/transform/JsonObjectFromEndpointDataReferenceEntryTransformerTest.java
+++ b/edc-extensions/edr/edr-api-v2/src/test/java/org/eclipse/tractusx/edc/api/edr/transform/JsonObjectFromEndpointDataReferenceEntryTransformerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.eclipse.tractusx.edc.api.edr.v2.transform;
+package org.eclipse.tractusx.edc.api.edr.transform;
 
 import jakarta.json.Json;
 import org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry;

--- a/edc-extensions/edr/edr-api-v2/src/test/java/org/eclipse/tractusx/edc/api/edr/v2/EdrCacheApiV2ControllerTest.java
+++ b/edc-extensions/edr/edr-api-v2/src/test/java/org/eclipse/tractusx/edc/api/edr/v2/EdrCacheApiV2ControllerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.api.edr.v2;
+
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.tractusx.edc.api.edr.BaseEdrCacheApiControllerTest;
+
+import static io.restassured.RestAssured.given;
+import static org.mockito.Mockito.mock;
+
+@ApiTest
+public class EdrCacheApiV2ControllerTest extends BaseEdrCacheApiControllerTest {
+
+    @Override
+    protected Object controller() {
+        return new EdrCacheApiV2Controller(edrStore, transformerRegistry, validator, mock(), edrService, contractNegotiationService);
+    }
+
+    protected RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port + "/v2")
+                .when();
+    }
+
+}

--- a/edc-extensions/edr/edr-api-v2/src/test/java/org/eclipse/tractusx/edc/api/edr/v3/EdrCacheApiV3ControllerTest.java
+++ b/edc-extensions/edr/edr-api-v2/src/test/java/org/eclipse/tractusx/edc/api/edr/v3/EdrCacheApiV3ControllerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.api.edr.v3;
+
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.tractusx.edc.api.edr.BaseEdrCacheApiControllerTest;
+
+import static io.restassured.RestAssured.given;
+import static org.mockito.Mockito.mock;
+
+@ApiTest
+public class EdrCacheApiV3ControllerTest extends BaseEdrCacheApiControllerTest {
+
+    @Override
+    protected Object controller() {
+        return new EdrCacheApiV3Controller(edrStore, transformerRegistry, validator, mock(), edrService, contractNegotiationService);
+    }
+
+    protected RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port + "/v3")
+                .when();
+    }
+
+}

--- a/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/ParticipantEdrApi.java
+++ b/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/ParticipantEdrApi.java
@@ -88,7 +88,7 @@ public class ParticipantEdrApi {
     public ValidatableResponse getEdrWithRefresh(String transferProcessId, boolean autoRefresh) {
         return baseEdrRequest()
                 .when()
-                .get("/v2/edrs/{id}/dataaddress?auto_refresh={auto_refresh}", transferProcessId, autoRefresh)
+                .get("/v3/edrs/{id}/dataaddress?auto_refresh={auto_refresh}", transferProcessId, autoRefresh)
                 .then()
                 .log().ifError();
 
@@ -100,7 +100,7 @@ public class ParticipantEdrApi {
     public ValidatableResponse refreshEdr(String transferProcessId) {
         return baseEdrRequest()
                 .when()
-                .post("/v2/edrs/{id}/refresh", transferProcessId)
+                .post("/v3/edrs/{id}/refresh", transferProcessId)
                 .then()
                 .log().ifError();
     }
@@ -128,7 +128,7 @@ public class ParticipantEdrApi {
         var response = baseEdrRequest()
                 .when()
                 .body(requestBody)
-                .post("/v2/edrs")
+                .post("/v3/edrs")
                 .then();
 
         var body = response.extract().body().asString();
@@ -148,7 +148,7 @@ public class ParticipantEdrApi {
         return baseEdrRequest()
                 .when()
                 .body(query)
-                .post("/v2/edrs/request")
+                .post("/v3/edrs/request")
                 .then()
                 .statusCode(200)
                 .extract()
@@ -167,7 +167,7 @@ public class ParticipantEdrApi {
         return baseEdrRequest()
                 .when()
                 .body(query)
-                .post("/v2/edrs/request")
+                .post("/v3/edrs/request")
                 .then()
                 .statusCode(200)
                 .extract()
@@ -186,7 +186,7 @@ public class ParticipantEdrApi {
         return baseEdrRequest()
                 .when()
                 .body(query)
-                .post("/v2/edrs/request")
+                .post("/v3/edrs/request")
                 .then()
                 .statusCode(200)
                 .extract()

--- a/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java
+++ b/edc-tests/edc-controlplane/fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java
@@ -156,7 +156,7 @@ public abstract class TractusxParticipantBase extends IdentityParticipant {
                 .contentType(JSON)
                 .body(body)
                 .when()
-                .post("/business-partner-groups")
+                .post("/v3/business-partner-groups")
                 .then()
                 .statusCode(204);
     }

--- a/samples/multi-tenancy/README.md
+++ b/samples/multi-tenancy/README.md
@@ -57,7 +57,7 @@ java -jar -Dedc.tenants.path=samples/multi-tenancy/tenants.properties samples/mu
 Create a PolicyDefinition on `first` tenant:
 
 ```shell
-curl -X POST http://localhost:18183/management/v2/policydefinitions \
+curl -X POST http://localhost:18183/management/v3/policydefinitions \
     --header 'Content-Type: application/json' \
     --data '{
                 "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
@@ -75,7 +75,7 @@ curl -X POST http://localhost:18183/management/v2/policydefinitions \
 Get `first` tenant policy definitions:
 
 ```shell
-curl -X POST http://localhost:18183/management/v2/policydefinitions/request
+curl -X POST http://localhost:18183/management/v3/policydefinitions/request
 ```
 
 Will get a list containing the PolicyDefinition we created:
@@ -108,13 +108,13 @@ Will get a list containing the PolicyDefinition we created:
 `second` and `third` tenants will have no policy definitions:
 
 ```shell
-curl -X POST http://localhost:28183/management/v2/policydefinitions/request
+curl -X POST http://localhost:28183/management/v3/policydefinitions/request
 ```
 
 and
 
 ```shell
-curl -X POST http://localhost:38183/management/v2/policydefinitions/request
+curl -X POST http://localhost:38183/management/v3/policydefinitions/request
 ```
 
 will return


### PR DESCRIPTION
## WHAT

Align management api version to v3 for `/edrs` and `/business-partner-groups`, deprecating the current ones

## WHY

api version

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #1410