### PR TITLE
refactor(charts): cleanup unneeded version checks

### DIFF
--- a/charts/tractusx-connector-azure-vault/templates/ingress-controlplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/ingress-controlplane.yaml
@@ -20,7 +20,6 @@
 {{- $fullName := include "txdc.fullname" . }}
 {{- $controlLabels := include "txdc.controlplane.labels" . }}
 {{- $controlEdcEndpoints := .Values.controlplane.endpoints }}
-{{- $gitVersion := .Capabilities.KubeVersion.GitVersion }}
 {{- $namespace := .Release.Namespace }}
 
 {{- range .Values.controlplane.ingresses }}
@@ -28,13 +27,7 @@
 {{- $controlIngressName := printf "%s-controlplane-%s" $fullName .hostname }}
 {{- $annotations := .annotations | default dict }}
 ---
-{{- if semverCompare ">=1.19-0" $gitVersion }}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" $gitVersion }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else }}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $controlIngressName }}
@@ -42,11 +35,6 @@ metadata:
   labels:
     {{- $controlLabels | nindent 4 }}
   annotations:
-    {{- if and .className (not (semverCompare ">=1.18-0" $gitVersion)) }}
-    {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
-    {{- $_ := set $annotations "kubernetes.io/ingress.class" .className}}
-    {{- end }}
-    {{- end }}
     {{- if .certManager }}
     {{- if .certManager.issuer }}
     {{- $_ := set $annotations "cert-manager.io/issuer" .certManager.issuer}}
@@ -59,7 +47,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .className (semverCompare ">=1.18-0" $gitVersion) }}
+  {{- if .className }}
   ingressClassName: {{ .className }}
   {{- end }}
   {{- if .hostname }}
@@ -83,13 +71,10 @@ spec:
           - path: {{ $mapping.path }}
             pathType: Prefix
             backend:
-              {{- if semverCompare ">=1.19-0" $gitVersion }}
               service:
                 name: {{ $fullName }}-controlplane
                 port:
                   number: {{ $mapping.port }}
-              {{- else }}
-              {{- end }}
         {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/tractusx-connector-azure-vault/templates/ingress-dataplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/ingress-dataplane.yaml
@@ -20,7 +20,6 @@
 {{- $fullName := include "txdc.fullname" . }}
 {{- $dataLabels := include "txdc.dataplane.labels" . }}
 {{- $dataEdcEndpoints := .Values.dataplane.endpoints }}
-{{- $gitVersion := .Capabilities.KubeVersion.GitVersion }}
 {{- $namespace := .Release.Namespace }}
 
 {{- range .Values.dataplane.ingresses }}
@@ -28,13 +27,7 @@
 {{- $dataIngressName := printf "%s-dataplane-%s" $fullName .hostname }}
 {{- $annotations := .annotations | default dict }}
 ---
-{{- if semverCompare ">=1.19-0" $gitVersion }}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" $gitVersion }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else }}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $dataIngressName }}
@@ -42,11 +35,6 @@ metadata:
   labels:
     {{- $dataLabels | nindent 4 }}
   annotations:
-    {{- if and .className (not (semverCompare ">=1.18-0" $gitVersion)) }}
-    {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
-    {{- $_ := set $annotations "kubernetes.io/ingress.class" .className}}
-    {{- end }}
-    {{- end }}
     {{- if .certManager }}
     {{- if .certManager.issuer }}
     {{- $_ := set $annotations "cert-manager.io/issuer" .certManager.issuer}}
@@ -59,7 +47,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .className (semverCompare ">=1.18-0" $gitVersion) }}
+  {{- if .className }}
   ingressClassName: {{ .className }}
   {{- end }}
   {{- if .hostname }}
@@ -83,13 +71,10 @@ spec:
           - path: {{ $mapping.path }}
             pathType: Prefix
             backend:
-              {{- if semverCompare ">=1.19-0" $gitVersion }}
               service:
                 name: {{ $fullName }}-dataplane
                 port:
                   number: {{ $mapping.port }}
-              {{- else }}
-              {{- end }}
         {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/tractusx-connector-memory/templates/ingress-runtime.yaml
+++ b/charts/tractusx-connector-memory/templates/ingress-runtime.yaml
@@ -24,7 +24,6 @@
 {{- $fullName := include "txdc.fullname" . }}
 {{- $controlLabels := include "txdc.runtime.labels" . }}
 {{- $controlEdcEndpoints := .Values.runtime.endpoints }}
-{{- $gitVersion := .Capabilities.KubeVersion.GitVersion }}
 {{- $namespace := .Release.Namespace }}
 
 {{- range .Values.runtime.ingresses }}
@@ -32,13 +31,7 @@
 {{- $controlIngressName := printf "%s-runtime-%s" $fullName .hostname }}
 {{- $annotations := .annotations | default dict }}
 ---
-{{- if semverCompare ">=1.19-0" $gitVersion }}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" $gitVersion }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else }}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $controlIngressName }}
@@ -46,11 +39,6 @@ metadata:
   labels:
     {{- $controlLabels | nindent 4 }}
   annotations:
-    {{- if and .className (not (semverCompare ">=1.18-0" $gitVersion)) }}
-    {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
-    {{- $_ := set $annotations "kubernetes.io/ingress.class" .className}}
-    {{- end }}
-    {{- end }}
     {{- if .certManager }}
     {{- if .certManager.issuer }}
     {{- $_ := set $annotations "cert-manager.io/issuer" .certManager.issuer}}
@@ -63,7 +51,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .className (semverCompare ">=1.18-0" $gitVersion) }}
+  {{- if .className }}
   ingressClassName: {{ .className }}
   {{- end }}
   {{- if .hostname }}
@@ -87,13 +75,10 @@ spec:
           - path: {{ $mapping.path }}
             pathType: Prefix
             backend:
-              {{- if semverCompare ">=1.19-0" $gitVersion }}
               service:
                 name: {{ $fullName }}-runtime
                 port:
                   number: {{ $mapping.port }}
-              {{- else }}
-              {{- end }}
         {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/tractusx-connector/templates/ingress-controlplane.yaml
+++ b/charts/tractusx-connector/templates/ingress-controlplane.yaml
@@ -24,7 +24,6 @@
 {{- $fullName := include "txdc.fullname" . }}
 {{- $controlLabels := include "txdc.controlplane.labels" . }}
 {{- $controlEdcEndpoints := .Values.controlplane.endpoints }}
-{{- $gitVersion := .Capabilities.KubeVersion.GitVersion }}
 {{- $namespace := .Release.Namespace }}
 
 {{- range .Values.controlplane.ingresses }}
@@ -32,13 +31,7 @@
 {{- $controlIngressName := printf "%s-controlplane-%s" $fullName .hostname }}
 {{- $annotations := .annotations | default dict }}
 ---
-{{- if semverCompare ">=1.19-0" $gitVersion }}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" $gitVersion }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else }}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $controlIngressName }}
@@ -46,11 +39,6 @@ metadata:
   labels:
     {{- $controlLabels | nindent 4 }}
   annotations:
-    {{- if and .className (not (semverCompare ">=1.18-0" $gitVersion)) }}
-    {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
-    {{- $_ := set $annotations "kubernetes.io/ingress.class" .className}}
-    {{- end }}
-    {{- end }}
     {{- if .certManager }}
     {{- if .certManager.issuer }}
     {{- $_ := set $annotations "cert-manager.io/issuer" .certManager.issuer}}
@@ -63,7 +51,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .className (semverCompare ">=1.18-0" $gitVersion) }}
+  {{- if .className }}
   ingressClassName: {{ .className }}
   {{- end }}
   {{- if .hostname }}
@@ -87,13 +75,10 @@ spec:
           - path: {{ $mapping.path }}
             pathType: Prefix
             backend:
-              {{- if semverCompare ">=1.19-0" $gitVersion }}
               service:
                 name: {{ $fullName }}-controlplane
                 port:
                   number: {{ $mapping.port }}
-              {{- else }}
-              {{- end }}
         {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/tractusx-connector/templates/ingress-dataplane.yaml
+++ b/charts/tractusx-connector/templates/ingress-dataplane.yaml
@@ -24,7 +24,6 @@
 {{- $fullName := include "txdc.fullname" . }}
 {{- $dataLabels := include "txdc.dataplane.labels" . }}
 {{- $dataEdcEndpoints := .Values.dataplane.endpoints }}
-{{- $gitVersion := .Capabilities.KubeVersion.GitVersion }}
 {{- $namespace := .Release.Namespace }}
 
 {{- range .Values.dataplane.ingresses }}
@@ -32,13 +31,7 @@
 {{- $dataIngressName := printf "%s-dataplane-%s" $fullName .hostname }}
 {{- $annotations := .annotations | default dict }}
 ---
-{{- if semverCompare ">=1.19-0" $gitVersion }}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" $gitVersion }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else }}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $dataIngressName }}
@@ -46,11 +39,6 @@ metadata:
   labels:
     {{- $dataLabels | nindent 4 }}
   annotations:
-    {{- if and .className (not (semverCompare ">=1.18-0" $gitVersion)) }}
-    {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
-    {{- $_ := set $annotations "kubernetes.io/ingress.class" .className}}
-    {{- end }}
-    {{- end }}
     {{- if .certManager }}
     {{- if .certManager.issuer }}
     {{- $_ := set $annotations "cert-manager.io/issuer" .certManager.issuer}}
@@ -63,7 +51,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .className (semverCompare ">=1.18-0" $gitVersion) }}
+  {{- if .className }}
   ingressClassName: {{ .className }}
   {{- end }}
   {{- if .hostname }}
@@ -87,13 +75,10 @@ spec:
           - path: {{ $mapping.path }}
             pathType: Prefix
             backend:
-              {{- if semverCompare ">=1.19-0" $gitVersion }}
               service:
                 name: {{ $fullName }}-dataplane
                 port:
                   number: {{ $mapping.port }}
-              {{- else }}
-              {{- end }}
         {{- end }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
## WHAT

Cleanup unnecessary version checks on ingresses

## WHY

oldest supported k8s version is 1.28

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #1423 
