### PR TITLE
docs: publish openapi-ui to github pages

### DIFF
--- a/.github/workflows/publish-openapi-ui.yml
+++ b/.github/workflows/publish-openapi-ui.yml
@@ -1,0 +1,88 @@
+#################################################################################
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+---
+name: "Publish OpenAPI to Swaggerhub"
+
+on:
+  push:
+    branches:
+      - main
+      - release/*
+
+  workflow_dispatch:
+    inputs:
+      version:
+        required: false
+        description: "Version of the Tractus-X EDC API to be should be published"
+        type: string
+
+jobs:
+  swagger-api:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-java
+
+      - name: Set version
+        run: |
+          if [ -z ${{ inputs.version }} ]; then
+            export VERSION=$(grep "version" gradle.properties  | awk -F= '{print $2}')
+          else
+            export VERSION=${{ inputs.version }}
+          fi
+
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Generate openapi spec
+        shell: bash
+        run: |
+          ./gradlew resolve
+
+      - name: Download upstream API specs for control-plane and data-plane
+        run: |
+          ./gradlew :edc-controlplane:edc-controlplane-base:downloadOpenapi
+          cp edc-controlplane/edc-controlplane-base/build/docs/openapi/* resources/openapi/yaml/
+
+          ./gradlew :edc-dataplane:edc-dataplane-base:downloadOpenapi
+          cp edc-dataplane/edc-dataplane-base/build/docs/openapi/* resources/openapi/yaml/
+
+      - name: Merge API specs
+        run: |
+          ./gradlew -Pversion=${{ env.VERSION }} -PapiTitle="Tractus-X EDC REST API" -PapiDescription="Tractus-X EDC API Documentation" :mergeApiSpec --input=./resources/openapi/yaml --output=./resources/openapi/yaml/tractusx-edc-api.yaml
+
+      - name: Generate Swagger UI current version
+        uses: Legion2/swagger-ui-action@v1
+        with:
+          output: openapi/${{ env.VERSION }}
+          spec-file: resources/openapi/yaml/tractusx-edc-api.yaml
+
+      - name: Generate Swagger UI stable version
+        uses: Legion2/swagger-ui-action@v1
+        if: ${{ !endsWith( env.VERSION, '-SNAPSHOT') }}
+        with:
+          output: openapi
+          spec-file: resources/openapi/yaml/tractusx-edc-api.yaml
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: openapi
+          keep_files: true


### PR DESCRIPTION
## WHAT

Add workflow that  builds and publish openapi-ui on github pages

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #1409 
