### PR TITLE
docs: split openapi spec by plane

### DIFF
--- a/.github/workflows/publish-openapi-ui.yml
+++ b/.github/workflows/publish-openapi-ui.yml
@@ -18,7 +18,7 @@
 #################################################################################
 
 ---
-name: "Publish OpenAPI to Swaggerhub"
+name: publish openapi ui
 
 on:
   push:
@@ -34,11 +34,35 @@ on:
         type: string
 
 jobs:
-  swagger-api:
+  generate-openapi-spec:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-java
+
+      - name: Generate openapi spec
+        run: ./gradlew resolve
+      - uses: actions/upload-artifact@v4
+        with:
+          name: openapi-spec
+          path: resources/openapi/yaml
+
+  generate-swagger-ui:
+    needs: generate-openapi-spec
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        apiGroup: [
+          { name: "control-plane", folder: "edc-controlplane/edc-controlplane-base" },
+          { name: "data-plane", folder: "edc-dataplane/edc-dataplane-base" }
+        ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: eclipse-edc/.github/.github/actions/setup-build@main
+      - uses: actions/download-artifact@v4
+        with:
+          name: openapi-spec
+          path: resources/openapi/yaml
 
       - name: Set version
         run: |
@@ -50,39 +74,44 @@ jobs:
 
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
-      - name: Generate openapi spec
-        shell: bash
+      - name: Download upstream API specs for ${{ matrix.apiGroup.name }}
         run: |
-          ./gradlew resolve
-
-      - name: Download upstream API specs for control-plane and data-plane
-        run: |
-          ./gradlew :edc-controlplane:edc-controlplane-base:downloadOpenapi
-          cp edc-controlplane/edc-controlplane-base/build/docs/openapi/* resources/openapi/yaml/
-
-          ./gradlew :edc-dataplane:edc-dataplane-base:downloadOpenapi
-          cp edc-dataplane/edc-dataplane-base/build/docs/openapi/* resources/openapi/yaml/
+          ./gradlew -p ${{ matrix.apiGroup.folder }} downloadOpenapi
+          cp ${{ matrix.apiGroup.folder }}/build/docs/openapi/* resources/openapi/yaml/
 
       - name: Merge API specs
         run: |
-          ./gradlew -Pversion=${{ env.VERSION }} -PapiTitle="Tractus-X EDC REST API" -PapiDescription="Tractus-X EDC API Documentation" :mergeApiSpec --input=./resources/openapi/yaml --output=./resources/openapi/yaml/tractusx-edc-api.yaml
+          ./gradlew -Pversion=${{ env.VERSION }} -PapiTitle="Tractus-X EDC ${{ matrix.apiGroup.name }} API" -PapiDescription="Tractus-X EDC ${{ matrix.apiGroup.name }} API Documentation" :mergeApiSpec --input=./resources/openapi/yaml/${{ matrix.apiGroup.name }} --output=./resources/openapi/yaml/${{ matrix.apiGroup.name }}.yaml
 
       - name: Generate Swagger UI current version
         uses: Legion2/swagger-ui-action@v1
         with:
-          output: openapi/${{ env.VERSION }}
-          spec-file: resources/openapi/yaml/tractusx-edc-api.yaml
+          output: dist/${{ matrix.apiGroup.name }}/${{ env.VERSION }}
+          spec-file: resources/openapi/yaml/${{ matrix.apiGroup.name }}/${{ matrix.apiGroup.name }}.yaml
 
       - name: Generate Swagger UI stable version
         uses: Legion2/swagger-ui-action@v1
         if: ${{ !endsWith( env.VERSION, '-SNAPSHOT') }}
         with:
-          output: openapi
-          spec-file: resources/openapi/yaml/tractusx-edc-api.yaml
+          output: dist/${{ matrix.apiGroup.name }}
+          spec-file: resources/openapi/yaml/${{ matrix.apiGroup.name }}/${{ matrix.apiGroup.name }}.yaml
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.apiGroup.name }}-api
+          path: dist
+
+  deploy-swagger-ui:
+    needs: generate-swagger-ui
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: openapi
+          pattern: "*-api"
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: openapi
+          publish_dir: .
           keep_files: true

--- a/.github/workflows/publish-swaggerhub.yaml
+++ b/.github/workflows/publish-swaggerhub.yaml
@@ -19,6 +19,7 @@
 #################################################################################
 
 
+# DEPRECATED: openapi are published on github-pages now, please look at publish-openapi-ui
 ---
 name: "Publish OpenAPI to Swaggerhub"
 

--- a/edc-extensions/bpn-validation/bpn-validation-api/build.gradle.kts
+++ b/edc-extensions/bpn-validation/bpn-validation-api/build.gradle.kts
@@ -20,7 +20,7 @@
 plugins {
     `java-library`
     `maven-publish`
-    id("io.swagger.core.v3.swagger-gradle-plugin")
+    id(libs.plugins.swagger.get().pluginId)
 }
 
 dependencies {
@@ -32,4 +32,10 @@ dependencies {
     testImplementation(testFixtures(libs.edc.core.jersey))
     testImplementation(libs.restAssured)
     testImplementation(libs.edc.junit)
+}
+
+edcBuild {
+    swagger {
+        apiGroup.set("control-plane")
+    }
 }

--- a/edc-extensions/dataplane/dataplane-proxy/edc-dataplane-proxy-consumer-api/build.gradle.kts
+++ b/edc-extensions/dataplane/dataplane-proxy/edc-dataplane-proxy-consumer-api/build.gradle.kts
@@ -19,7 +19,7 @@
 
 plugins {
     `java-library`
-    id("io.swagger.core.v3.swagger-gradle-plugin")
+    id(libs.plugins.swagger.get().pluginId)
 }
 
 dependencies {
@@ -42,4 +42,11 @@ dependencies {
     testImplementation(testFixtures(libs.edc.core.jersey))
     testImplementation(libs.restAssured)
 }
+
+edcBuild {
+    swagger {
+        apiGroup.set("data-plane")
+    }
+}
+
 

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/build.gradle.kts
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/build.gradle.kts
@@ -20,7 +20,7 @@
 plugins {
     `java-library`
     `maven-publish`
-    id("io.swagger.core.v3.swagger-gradle-plugin")
+    id(libs.plugins.swagger.get().pluginId)
 }
 
 dependencies {
@@ -36,3 +36,8 @@ dependencies {
     testImplementation(testFixtures(libs.edc.core.jersey))
 }
 
+edcBuild {
+    swagger {
+        apiGroup.set("data-plane")
+    }
+}

--- a/edc-extensions/edr/edr-api-v2/build.gradle.kts
+++ b/edc-extensions/edr/edr-api-v2/build.gradle.kts
@@ -20,7 +20,7 @@
 plugins {
     `java-library`
     `maven-publish`
-    id("io.swagger.core.v3.swagger-gradle-plugin")
+    id(libs.plugins.swagger.get().pluginId)
 }
 
 dependencies {
@@ -42,3 +42,10 @@ dependencies {
     testImplementation(libs.edc.lib.transform)
     testImplementation(libs.edc.spi.contract)
 }
+
+edcBuild {
+    swagger {
+        apiGroup.set("control-plane")
+    }
+}
+

--- a/edc-tests/runtime/mock-connector/build.gradle.kts
+++ b/edc-tests/runtime/mock-connector/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     `java-library`
     id("application")
     id("com.github.johnrengelman.shadow") version "8.1.1"
-    id("io.swagger.core.v3.swagger-gradle-plugin")
+    id(libs.plugins.swagger.get().pluginId)
 }
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -234,3 +234,6 @@ edc-dpf = ["edc.dpf-transfer-signaling", "edc.dpf-selector-core", "edc.spi-datap
 edc-sqlstores = ["edc.sql-assetindex", "edc.sql-contract-definition", "edc.sql-contract-negotiation", "edc.sql-transferprocess", "edc.sql-policydef", "edc.sql-policy-monitor", "edc.sql-edrindex", "edc-transaction-local"]
 edc-monitoring = ["edc.micrometer-core", "edc.micrometer-jersey", "edc.micrometer-jetty"]
 edc-sts = ["edc-identity-trust-sts-core", "edc-identity-trust-sts-api", "edc-identity-trust-sts-client-configuration"]
+
+[plugins]
+swagger = { id = "io.swagger.core.v3.swagger-gradle-plugin", version = "2.2.22" }


### PR DESCRIPTION
## WHAT

Split openapi documentation in `control-plane` and `data-plane` 

## WHY

documentation

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Part of  #1409
