### PR TITLE
fix(charts): make DIM URL optional

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -5,13 +5,17 @@ maven/mavencentral/com.apicatalog/iron-ed25519-cryptosuite-2020/0.14.0, Apache-2
 maven/mavencentral/com.apicatalog/iron-verifiable-credentials/0.14.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.4.0, Apache-2.0, approved, #15200
+maven/mavencentral/com.apicatalog/titanium-json-ld/1.4.1, Apache-2.0, approved, #15200
 maven/mavencentral/com.azure/azure-core-http-netty/1.13.11, MIT AND Apache-2.0, approved, #7948
 maven/mavencentral/com.azure/azure-core-http-netty/1.15.0, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-core-http-netty/1.15.1, MIT, approved, clearlydefined
+maven/mavencentral/com.azure/azure-core-http-netty/1.15.2, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-core/1.45.1, MIT AND Apache-2.0, approved, #11845
 maven/mavencentral/com.azure/azure-core/1.49.0, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-core/1.49.1, MIT, approved, clearlydefined
+maven/mavencentral/com.azure/azure-core/1.50.0, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-identity/1.13.0, MIT, approved, clearlydefined
+maven/mavencentral/com.azure/azure-identity/1.13.1, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-json/1.1.0, MIT AND Apache-2.0, approved, #10547
 maven/mavencentral/com.azure/azure-security-keyvault-secrets/4.7.3, MIT, approved, #10868
 maven/mavencentral/com.azure/azure-security-keyvault-secrets/4.8.4, MIT, approved, #13690
@@ -65,8 +69,11 @@ maven/mavencentral/com.fasterxml.uuid/java-uuid-generator/4.1.0, Apache-2.0, app
 maven/mavencentral/com.fasterxml.woodstox/woodstox-core/6.7.0, Apache-2.0, approved, #15476
 maven/mavencentral/com.github.cliftonlabs/json-simple/3.0.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.6, Apache-2.0, approved, #10346
+maven/mavencentral/com.github.docker-java/docker-java-api/3.4.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.6, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #15251
+maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.4.0, Apache-2.0, restricted, clearlydefined
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.6, Apache-2.0, approved, #7942
+maven/mavencentral/com.github.docker-java/docker-java-transport/3.4.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.java-json-tools/btf/1.3, Apache-2.0 OR LGPL-3.0-only, approved, #15201
 maven/mavencentral/com.github.java-json-tools/jackson-coreutils-equivalence/1.0, LGPL-3.0 OR Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.java-json-tools/jackson-coreutils/2.0, Apache-2.0 OR LGPL-3.0-or-later, approved, #15186
@@ -100,6 +107,7 @@ maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefine
 maven/mavencentral/com.microsoft.azure/msal4j-persistence-extension/1.3.0, MIT, approved, #14411
 maven/mavencentral/com.microsoft.azure/msal4j/1.15.0, MIT, approved, clearlydefined
 maven/mavencentral/com.microsoft.azure/msal4j/1.15.1, MIT, approved, clearlydefined
+maven/mavencentral/com.microsoft.azure/msal4j/1.16.1, MIT, approved, clearlydefined
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/content-type/2.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/lang-tag/1.7, Apache-2.0, approved, clearlydefined
@@ -348,12 +356,14 @@ maven/mavencentral/org.eclipse.edc/asset-api/0.8.0, Apache-2.0, approved, techno
 maven/mavencentral/org.eclipse.edc/asset-index-sql/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/asset-spi/0.7.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/asset-spi/0.8.0, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/asset-spi/0.8.1-20240719-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/auth-spi/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/auth-tokenbased/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/autodoc-processor/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot-lib/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot-spi/0.7.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot-spi/0.8.0, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/boot-spi/0.8.1-20240719-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/callback-event-dispatcher/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/callback-http-dispatcher/0.8.0, Apache-2.0, approved, technology.edc
@@ -361,6 +371,7 @@ maven/mavencentral/org.eclipse.edc/callback-static-endpoint/0.8.0, Apache-2.0, a
 maven/mavencentral/org.eclipse.edc/catalog-api/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/catalog-spi/0.7.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/catalog-spi/0.8.0, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/catalog-spi/0.8.1-20240719-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/catalog-util-lib/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/configuration-filesystem/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/connector-core/0.8.0, Apache-2.0, approved, technology.edc
@@ -386,8 +397,10 @@ maven/mavencentral/org.eclipse.edc/control-plane-transfer/0.8.0, Apache-2.0, app
 maven/mavencentral/org.eclipse.edc/control-plane-transform/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/core-spi/0.7.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/core-spi/0.8.0, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/core-spi/0.8.1-20240719-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/crawler-core/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/crawler-spi/0.8.0, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/crawler-spi/0.8.1-20240719-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/credential-query-lib/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/crypto-common-lib/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-address-http-data-spi/0.8.0, Apache-2.0, approved, technology.edc
@@ -436,8 +449,10 @@ maven/mavencentral/org.eclipse.edc/edr-store-core/0.8.0, Apache-2.0, approved, t
 maven/mavencentral/org.eclipse.edc/edr-store-receiver/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/edr-store-spi/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/federated-catalog-api/0.8.0, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/federated-catalog-cache-sql/0.8.1-20240719-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/federated-catalog-core/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/federated-catalog-spi/0.8.0, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/federated-catalog-spi/0.8.1-20240719-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/http-lib/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/http-spi/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/http/0.8.0, Apache-2.0, approved, technology.edc
@@ -498,6 +513,7 @@ maven/mavencentral/org.eclipse.edc/policy-engine-spi/0.8.0, Apache-2.0, approved
 maven/mavencentral/org.eclipse.edc/policy-evaluator-lib/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-model/0.7.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-model/0.8.0, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/policy-model/0.8.1-20240719-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-monitor-core/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-monitor-spi/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-monitor-store-sql/0.8.0, Apache-2.0, approved, technology.edc
@@ -506,8 +522,10 @@ maven/mavencentral/org.eclipse.edc/presentation-api/0.8.0, Apache-2.0, approved,
 maven/mavencentral/org.eclipse.edc/query-lib/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.7.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.8.0, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.8.1-20240719-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/secrets-spi/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/sql-core/0.8.0, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/sql-core/0.8.1-20240719-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/sql-lease/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/sql-pool-apache-commons/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/state-machine-lib/0.8.0, Apache-2.0, approved, technology.edc
@@ -515,8 +533,10 @@ maven/mavencentral/org.eclipse.edc/store-lib/0.8.0, Apache-2.0, approved, techno
 maven/mavencentral/org.eclipse.edc/token-core/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/token-spi/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transaction-datasource-spi/0.8.0, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transaction-datasource-spi/0.8.1-20240719-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transaction-local/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transaction-spi/0.8.0, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/transaction-spi/0.8.1-20240719-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transfer-data-plane-signaling/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transfer-data-plane-spi/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/transfer-process-api/0.8.0, Apache-2.0, approved, technology.edc
@@ -528,6 +548,7 @@ maven/mavencentral/org.eclipse.edc/transform-lib/0.8.0, Apache-2.0, approved, te
 maven/mavencentral/org.eclipse.edc/transform-spi/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/util-lib/0.7.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/util-lib/0.8.0, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/util-lib/0.8.1-20240719-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/validator-data-address-http-data/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/validator-lib/0.8.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/validator-spi/0.7.2-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -561,8 +582,8 @@ maven/mavencentral/org.eclipse.jetty/jetty-util/11.0.22, EPL-2.0 OR Apache-2.0, 
 maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.22, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.22, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.parsson/parsson/1.1.6, EPL-2.0, approved, ee4j.parsson
-maven/mavencentral/org.flywaydb/flyway-core/10.15.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.flywaydb/flyway-database-postgresql/10.15.2, Apache-2.0, approved, #15694
+maven/mavencentral/org.flywaydb/flyway-core/10.16.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.flywaydb/flyway-database-postgresql/10.16.0, NOASSERTION, restricted, clearlydefined
 maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-locator/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
@@ -639,70 +660,76 @@ maven/mavencentral/org.slf4j/slf4j-api/2.0.13, MIT, approved, #5915
 maven/mavencentral/org.slf4j/slf4j-api/2.0.6, MIT, approved, #5915
 maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
 maven/mavencentral/org.testcontainers/database-commons/1.19.8, Apache-2.0, approved, #10345
+maven/mavencentral/org.testcontainers/database-commons/1.20.0, MIT, approved, clearlydefined
 maven/mavencentral/org.testcontainers/jdbc/1.19.8, Apache-2.0, approved, #10348
+maven/mavencentral/org.testcontainers/jdbc/1.20.0, MIT, approved, clearlydefined
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.8, MIT, approved, #10344
+maven/mavencentral/org.testcontainers/junit-jupiter/1.20.0, MIT, approved, clearlydefined
 maven/mavencentral/org.testcontainers/postgresql/1.19.8, MIT, approved, #10350
+maven/mavencentral/org.testcontainers/postgresql/1.20.0, MIT, approved, clearlydefined
 maven/mavencentral/org.testcontainers/testcontainers/1.19.8, MIT, approved, #15203
+maven/mavencentral/org.testcontainers/testcontainers/1.20.0, MIT, restricted, clearlydefined
 maven/mavencentral/org.xmlresolver/xmlresolver/5.2.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.xmlunit/xmlunit-placeholders/2.9.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/1.33, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #10232
 maven/mavencentral/software.amazon.awssdk/annotations/2.25.66, Apache-2.0, approved, #13691
-maven/mavencentral/software.amazon.awssdk/annotations/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/annotations/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/apache-client/2.25.66, Apache-2.0, approved, #13687
-maven/mavencentral/software.amazon.awssdk/apache-client/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/apache-client/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/arns/2.25.66, Apache-2.0, approved, #13695
-maven/mavencentral/software.amazon.awssdk/arns/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/arns/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/auth/2.25.66, Apache-2.0, approved, #13692
-maven/mavencentral/software.amazon.awssdk/auth/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/auth/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/aws-core/2.25.66, Apache-2.0, approved, #13702
-maven/mavencentral/software.amazon.awssdk/aws-core/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/aws-core/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.25.66, Apache-2.0, approved, #13701
-maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/aws-xml-protocol/2.25.66, Apache-2.0, approved, #13684
-maven/mavencentral/software.amazon.awssdk/aws-xml-protocol/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/aws-xml-protocol/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/checksums-spi/2.25.66, Apache-2.0, approved, #13686
-maven/mavencentral/software.amazon.awssdk/checksums-spi/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/checksums-spi/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/checksums/2.25.66, Apache-2.0, approved, #13677
-maven/mavencentral/software.amazon.awssdk/checksums/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/checksums/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/crt-core/2.25.66, Apache-2.0, approved, #13705
-maven/mavencentral/software.amazon.awssdk/crt-core/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/crt-core/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/endpoints-spi/2.25.66, Apache-2.0, approved, #13681
-maven/mavencentral/software.amazon.awssdk/endpoints-spi/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/endpoints-spi/2.26.21, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/http-auth-aws-eventstream/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/http-auth-aws/2.25.66, Apache-2.0, approved, #13696
-maven/mavencentral/software.amazon.awssdk/http-auth-aws/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/http-auth-aws/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/http-auth-spi/2.25.66, Apache-2.0, approved, #13704
-maven/mavencentral/software.amazon.awssdk/http-auth-spi/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/http-auth-spi/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/http-auth/2.25.66, Apache-2.0, approved, #13682
-maven/mavencentral/software.amazon.awssdk/http-auth/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/http-auth/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/http-client-spi/2.25.66, Apache-2.0, approved, #13706
-maven/mavencentral/software.amazon.awssdk/http-client-spi/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/http-client-spi/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/iam/2.25.66, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/identity-spi/2.25.66, Apache-2.0, approved, #13685
-maven/mavencentral/software.amazon.awssdk/identity-spi/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/identity-spi/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/json-utils/2.25.66, Apache-2.0, approved, #13698
-maven/mavencentral/software.amazon.awssdk/json-utils/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/json-utils/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/metrics-spi/2.25.66, Apache-2.0, approved, #13680
-maven/mavencentral/software.amazon.awssdk/metrics-spi/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/metrics-spi/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/netty-nio-client/2.25.66, Apache-2.0, approved, #13693
-maven/mavencentral/software.amazon.awssdk/netty-nio-client/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/netty-nio-client/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/profiles/2.25.66, Apache-2.0, approved, #13697
-maven/mavencentral/software.amazon.awssdk/profiles/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/profiles/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/protocol-core/2.25.66, Apache-2.0, approved, #13679
-maven/mavencentral/software.amazon.awssdk/protocol-core/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/protocol-core/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/regions/2.25.66, Apache-2.0, approved, #13694
-maven/mavencentral/software.amazon.awssdk/regions/2.26.20, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/retries-spi/2.26.20, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/retries/2.26.20, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/s3-transfer-manager/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/regions/2.26.21, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/retries-spi/2.26.21, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/retries/2.26.21, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/s3-transfer-manager/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/s3/2.25.66, Apache-2.0, approved, #13688
-maven/mavencentral/software.amazon.awssdk/s3/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/s3/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/sdk-core/2.25.66, Apache-2.0, approved, #13700
-maven/mavencentral/software.amazon.awssdk/sdk-core/2.26.20, Apache-2.0, approved, #15695
+maven/mavencentral/software.amazon.awssdk/sdk-core/2.26.21, Apache-2.0, approved, #15695
 maven/mavencentral/software.amazon.awssdk/sts/2.25.66, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.25.66, Apache-2.0, approved, #13703
-maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.26.20, Apache-2.0, approved, #15693
+maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.26.21, Apache-2.0, approved, #15693
 maven/mavencentral/software.amazon.awssdk/utils/2.25.66, Apache-2.0, approved, #13689
-maven/mavencentral/software.amazon.awssdk/utils/2.26.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/utils/2.26.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.eventstream/eventstream/1.0.1, Apache-2.0, approved, clearlydefined

--- a/charts/tractusx-connector-azure-vault/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/deployment-controlplane.yaml
@@ -282,8 +282,10 @@ spec:
               value: {{ .Values.iatp.sts.oauth.client.id | required ".Values.iatp.sts.oauth.client.id is required" | quote}}
             - name: "EDC_IAM_STS_OAUTH_CLIENT_SECRET_ALIAS"
               value: {{ .Values.iatp.sts.oauth.client.secret_alias | required ".Values.iatp.sts.oauth.client.secret_alias is required" | quote}}
+            {{- if .Values.iatp.sts.dim.url }}
             - name: "TX_EDC_IAM_STS_DIM_URL"
-              value: {{ .Values.iatp.sts.dim.url | required ".Values.iatp.sts.dim.url is required" | quote}}
+              value: {{ .Values.iatp.sts.dim.url | quote}}
+            {{- end}}
 
             {{- range $index, $issuer := .Values.iatp.trustedIssuers }}
             - name: "EDC_IAM_TRUSTED-ISSUER_{{$index}}-ISSUER_ID"

--- a/charts/tractusx-connector-azure-vault/templates/deployment-dataplane.yaml
+++ b/charts/tractusx-connector-azure-vault/templates/deployment-dataplane.yaml
@@ -219,8 +219,11 @@ spec:
               value: {{ .Values.iatp.sts.oauth.client.id | required ".Values.iatp.sts.oauth.client.id is required" | quote}}
             - name: "EDC_IAM_STS_OAUTH_CLIENT_SECRET_ALIAS"
               value: {{ .Values.iatp.sts.oauth.client.secret_alias | required ".Values.iatp.sts.oauth.client.secret_alias is required" | quote}}
+
+            {{- if .Values.iatp.sts.dim.url }}
             - name: "TX_EDC_IAM_STS_DIM_URL"
-              value: {{ .Values.iatp.sts.dim.url | required ".Values.iatp.sts.dim.url is required" | quote}}
+              value: {{ .Values.iatp.sts.dim.url | quote}}
+            {{- end}}
 
             ################
             ## POSTGRESQL ##

--- a/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
+++ b/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
@@ -212,8 +212,11 @@ spec:
               value: {{ .Values.iatp.sts.oauth.client.id | required ".Values.iatp.sts.oauth.client.id is required" | quote}}
             - name: "EDC_IAM_STS_OAUTH_CLIENT_SECRET_ALIAS"
               value: {{ .Values.iatp.sts.oauth.client.secret_alias | required ".Values.iatp.sts.oauth.client.secret_alias is required" | quote}}
+
+            {{- if .Values.iatp.sts.dim.url }}
             - name: "TX_EDC_IAM_STS_DIM_URL"
-              value: {{ .Values.iatp.sts.dim.url | required ".Values.iatp.sts.dim.url is required" | quote}}
+              value: {{ .Values.iatp.sts.dim.url | quote}}
+            {{- end}}
 
             {{- range $index, $issuer := .Values.iatp.trustedIssuers }}
             - name: "EDC_IAM_TRUSTED-ISSUER_{{$index}}-ISSUER_ID"

--- a/charts/tractusx-connector/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-controlplane.yaml
@@ -282,8 +282,10 @@ spec:
               value: {{ .Values.iatp.sts.oauth.client.id | required ".Values.iatp.sts.oauth.client.id is required" | quote}}
             - name: "EDC_IAM_STS_OAUTH_CLIENT_SECRET_ALIAS"
               value: {{ .Values.iatp.sts.oauth.client.secret_alias | required ".Values.iatp.sts.oauth.client.secret_alias is required" | quote}}
+            {{- if .Values.iatp.sts.dim.url }}
             - name: "TX_EDC_IAM_STS_DIM_URL"
-              value: {{ .Values.iatp.sts.dim.url | required ".Values.iatp.sts.dim.url is required" | quote}}
+              value: {{ .Values.iatp.sts.dim.url | quote}}
+            {{- end }}
 
             {{- range $index, $issuer := .Values.iatp.trustedIssuers }}
             - name: "EDC_IAM_TRUSTED-ISSUER_{{$index}}-ISSUER_ID"

--- a/charts/tractusx-connector/templates/deployment-dataplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-dataplane.yaml
@@ -215,8 +215,10 @@ spec:
               value: {{ .Values.iatp.sts.oauth.client.id | required ".Values.iatp.sts.oauth.client.id is required" | quote}}
             - name: "EDC_IAM_STS_OAUTH_CLIENT_SECRET_ALIAS"
               value: {{ .Values.iatp.sts.oauth.client.secret_alias | required ".Values.iatp.sts.oauth.client.secret_alias is required" | quote}}
+            {{- if .Values.iatp.sts.dim.url }}
             - name: "TX_EDC_IAM_STS_DIM_URL"
-              value: {{ .Values.iatp.sts.dim.url | required ".Values.iatp.sts.dim.url is required" | quote}}
+              value: {{ .Values.iatp.sts.dim.url | quote}}
+            {{- end }}
 
             ################
             ## POSTGRESQL ##


### PR DESCRIPTION
## WHAT

Makes the DIM url Helm value optional to enable the switch to the regular STS client

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #1443
