### PR TITLE
feat(ci): publish workflows call reusable trigger workflows

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -60,66 +60,26 @@ jobs:
   maven-release:
     name: Publish extension's release version to maven repository
     needs: [ release-version ]
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     if: github.event.pull_request.merged == true && needs.release-version.outputs.RELEASE_VERSION
-    steps:
-      - name: Export RELEASE_VERSION env
-        run: |
-          echo "RELEASE_VERSION=${{ needs.release-version.outputs.RELEASE_VERSION }}" >> $GITHUB_ENV
-
-      # Set-Up
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-java
-
-      # Import GPG Key
-      - uses: ./.github/actions/import-gpg-key
-        name: "Import GPG Key"
-        with:
-          gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
-
-      # publish releases
-      - name: Publish version
-        env:
-          OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
-          OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
-        run: |-
-          echo "Publishing Version $RELEASE_VERSION to Sonatype/MavenCentral"
-          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Pversion=$RELEASE_VERSION -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ secrets.ORG_GPG_PASSPHRASE }}"
+    uses: ./.github/workflows/trigger-maven-publish.yaml
+    secrets: inherit
+    with:
+      version: $RELEASE_VERSION
 
   docker-release:
     name: Publish Docker images
-    runs-on: ubuntu-latest
     needs: [ release-version ]
     permissions:
       contents: write
     if: github.event.pull_request.merged == true && needs.release-version.outputs.RELEASE_VERSION
 
-    strategy:
-      fail-fast: false
-      matrix:
-        variant: [ { dir: edc-controlplane, img: edc-runtime-memory },
-                   { dir: edc-controlplane, img: edc-controlplane-postgresql-hashicorp-vault },
-                   { dir: edc-controlplane, img: edc-controlplane-postgresql-azure-vault },
-                   { dir: edc-dataplane,    img: edc-dataplane-azure-vault },
-                   { dir: edc-dataplane,    img: edc-dataplane-hashicorp-vault },
-                   { dir: edc-tests/runtime, img: mock-connector }]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Export RELEASE_VERSION env
-        run: |
-          echo "RELEASE_VERSION=${{ needs.release-version.outputs.RELEASE_VERSION }}" >> $GITHUB_ENV
-      - uses: ./.github/actions/publish-docker-image
-        name: Publish ${{ matrix.variant.img }}
-        with:
-          docker_tag: ${{ env.RELEASE_VERSION }}
-          rootDir: ${{ matrix.variant.dir }}/${{ matrix.variant.img }}
-          imagename: ${{ matrix.variant.img }}
-          docker_user: ${{ secrets.DOCKER_HUB_USER }}
-          docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}
-          do_push: 'true'
+    uses: ./.github/workflows/trigger-docker-publish.yaml
+    secrets: inherit
+    with:
+      docker_tag: ${{ env.RELEASE_VERSION }}
 
   # Release: Helm Charts
   helm-release:

--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -22,7 +22,7 @@
 
 
 ---
-name: "Publish Artefacts"
+name: "Publish new snapshot"
 
 on:
   workflow_run:
@@ -65,38 +65,19 @@ jobs:
           [ ! -z "${{ secrets.SWAGGERHUB_USER }}" ]  && echo "HAS_SWAGGER=true" >> $GITHUB_OUTPUT
           exit 0
 
-  build-docker-images:
+  publish-docker-images:
     name: "Create Docker Images"
-    runs-on: ubuntu-latest
     needs: [ secret-presence ]
     if: |
       needs.secret-presence.outputs.DOCKER_HUB_TOKEN
-    strategy:
-      fail-fast: false
-      matrix:
-        variant: [ { dir: edc-controlplane, img: edc-runtime-memory },
-                   { dir: edc-controlplane, img: edc-controlplane-postgresql-hashicorp-vault },
-                   { dir: edc-controlplane, img: edc-controlplane-postgresql-azure-vault },
-                   { dir: edc-dataplane,    img: edc-dataplane-azure-vault },
-                   { dir: edc-dataplane,    img: edc-dataplane-hashicorp-vault },
-                   { dir: edc-tests/runtime, img: mock-connector }]
     permissions:
       contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/publish-docker-image
-        name: Publish ${{ matrix.variant.img }}
-        with:
-          docker_tag: ${{ needs.release-version.outputs.RELEASE_VERSION }}
-          rootDir: ${{ matrix.variant.dir }}/${{ matrix.variant.img }}
-          imagename: ${{ matrix.variant.img }}
-          docker_user: ${{ secrets.DOCKER_HUB_USER }}
-          docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}
-          do_push: ${{ github.event_name != 'pull_request' }}
+    uses: ./.github/workflows/trigger-docker-publish.yaml
+    secrets: inherit
 
-  publish-to-sonatype:
+
+  publish-maven-artifacts:
     name: "Publish artefacts to OSSRH Snapshots / MavenCentral"
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -105,31 +86,8 @@ jobs:
     # do not run on PR branches, do not run on releases
     if: |
       needs.secret-presence.outputs.HAS_OSSRH && github.event_name != 'pull_request' && github.ref != 'refs/heads/releases'
-    steps:
-      # Set-Up
-      - uses: actions/checkout@v4
-
-      # Import GPG Key
-      - uses: ./.github/actions/import-gpg-key
-        name: "Import GPG Key"
-        with:
-          gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
-
-      - uses: ./.github/actions/setup-java
-      # publish snapshots or releases
-      - name: Publish version
-        env:
-          OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
-          OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
-        run: |-
-          VERSION=$(./gradlew properties -q | grep "version:" | awk '{print $2}')
-          cmd=""
-          if [[ $VERSION != *-SNAPSHOT ]]
-          then
-            cmd="closeAndReleaseSonatypeStagingRepository";
-          fi
-          echo "Publishing Version $VERSION to Sonatype"
-          ./gradlew publishToSonatype ${cmd} --no-parallel -Pversion=$VERSION -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ secrets.ORG_GPG_PASSPHRASE }}"
+    uses: ./.github/workflows/trigger-maven-publish.yaml
+    secrets: inherit
 
   publish-to-swaggerhub:
     name: "Publish OpenAPI spec to Swaggerhub"

--- a/.github/workflows/trigger-maven-publish.yaml
+++ b/.github/workflows/trigger-maven-publish.yaml
@@ -47,7 +47,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       # Set-Up
       - uses: actions/checkout@v4


### PR DESCRIPTION
## WHAT

`publish-new-release.yaml` and `publish-new-snapshot.yaml` invoke the `trigger-[maven|docker]-publish.yaml` workflow to increase code re-use.

## WHY

_Briefly state why the change was necessary._
avoid duplication

## FURTHER NOTES

- `publish.yaml` was renamed `publish-new-snapshot.yaml`
- successful(-ish) workflow run in my [fork](https://github.com/paullatzelsperger/tractusx-edc/actions/runs/10059604679)

Closes #1447
