### PR TITLE
Fix: Adjusted BPN validations on different operators

### DIFF
--- a/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunction.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunction.java
@@ -137,7 +137,7 @@ public class BusinessPartnerGroupFunction implements AtomicConstraintFunction<Pe
 
         // right-operand is anything other than String or Collection
         var rightOperand = parseRightOperand(rightValue, policyContext);
-        if (rightOperand.isEmpty()) {
+        if (rightOperand == null) {
             return false;
         }
 
@@ -145,8 +145,7 @@ public class BusinessPartnerGroupFunction implements AtomicConstraintFunction<Pe
         return OPERATOR_EVALUATOR_MAP.get(operator).apply(new BpnGroupHolder(assignedGroups, rightOperand));
     }
 
-    private boolean evaluateEmptyGroupsResponse(final Operator operator, final PolicyContext policyContext,
-                                                final String problemMessage) {
+    private boolean evaluateEmptyGroupsResponse(Operator operator, PolicyContext policyContext, String problemMessage) {
         if (NEQ.equals(operator) || IS_NONE_OF.equals(operator)) {
             return true;
         }
@@ -165,7 +164,7 @@ public class BusinessPartnerGroupFunction implements AtomicConstraintFunction<Pe
         }
 
         context.reportProblem(format("Right operand expected to be either String or a Collection, but was %s", rightValue.getClass()));
-        return Collections.emptyList();
+        return null;
     }
     
     private Boolean evaluateIn(BpnGroupHolder bpnGroupHolder) {

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunction.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunction.java
@@ -86,7 +86,7 @@ public class BusinessPartnerGroupFunction implements AtomicConstraintFunction<Pe
         OPERATOR_EVALUATOR_MAP.put(EQ, this::evaluateEquals);
         OPERATOR_EVALUATOR_MAP.put(NEQ, this::evaluateNotEquals);
         OPERATOR_EVALUATOR_MAP.put(IN, this::evaluateIn);
-        OPERATOR_EVALUATOR_MAP.put(IS_ALL_OF, this::evaluateEquals);
+        OPERATOR_EVALUATOR_MAP.put(IS_ALL_OF, this::evaluateIsAllOf);
         OPERATOR_EVALUATOR_MAP.put(IS_ANY_OF, this::evaluateIn);
         OPERATOR_EVALUATOR_MAP.put(IS_NONE_OF, this::evaluateNotEquals);
     }
@@ -175,6 +175,14 @@ public class BusinessPartnerGroupFunction implements AtomicConstraintFunction<Pe
 
     private Boolean evaluateEquals(BpnGroupHolder bpnGroupHolder) {
         return bpnGroupHolder.allowedGroups.equals(bpnGroupHolder.assignedGroups);
+    }
+
+    private boolean evaluateIsAllOf(BpnGroupHolder bpnGroupHolder) {
+        var assigned = bpnGroupHolder.assignedGroups;
+        return bpnGroupHolder.allowedGroups
+                .stream()
+                .distinct()
+                .allMatch(assigned::contains);
     }
 
     /**

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunction.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunction.java
@@ -127,13 +127,8 @@ public class BusinessPartnerGroupFunction implements AtomicConstraintFunction<Pe
 
         // BPN not found in database
         if (groups.failed()) {
-            boolean isNotFound = Reason.NOT_FOUND.equals(groups.getFailure().getReason());
-            if (!isNotFound) {
-                policyContext.reportProblem(groups.getFailureDetail());
-                return false;
-            }
-
-            assignedGroups = List.of();
+            policyContext.reportProblem(groups.getFailureDetail());
+            return false;
         }
 
         // right-operand is anything other than String or Collection

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunction.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunction.java
@@ -175,6 +175,10 @@ public class BusinessPartnerGroupFunction implements AtomicConstraintFunction<Pe
     }
 
     private Boolean evaluateNotEquals(BpnGroupHolder bpnGroupHolder) {
+        if (bpnGroupHolder.allowedGroups.isEmpty()) {
+            return true;
+        }
+
         return !evaluateEquals(bpnGroupHolder);
     }
 

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunction.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunction.java
@@ -28,6 +28,7 @@ import org.eclipse.tractusx.edc.validation.businesspartner.spi.BusinessPartnerSt
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -136,7 +137,7 @@ public class BusinessPartnerGroupFunction implements AtomicConstraintFunction<Pe
 
         // right-operand is anything other than String or Collection
         var rightOperand = parseRightOperand(rightValue, policyContext);
-        if (rightOperand == null) {
+        if (rightOperand.isEmpty()) {
             return false;
         }
 
@@ -164,7 +165,7 @@ public class BusinessPartnerGroupFunction implements AtomicConstraintFunction<Pe
         }
 
         context.reportProblem(format("Right operand expected to be either String or a Collection, but was %s", rightValue.getClass()));
-        return null;
+        return Collections.emptyList();
     }
     
     private Boolean evaluateIn(BpnGroupHolder bpnGroupHolder) {

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
@@ -167,9 +167,9 @@ class BusinessPartnerGroupFunctionTest {
 
     @ArgumentsSource(OperatorForEmptyGroupsProvider.class)
     @ParameterizedTest
-    void evaluate_groupsAssignedButNoGroupsSentToEvaluate(Operator operator, boolean expectedOutcome) {
+    void evaluate_groupsAssignedButNoGroupsSentToEvaluate(Operator operator, List<String> assignedBpnGroups,
+                                                          boolean expectedOutcome) {
         var allowedGroups = List.<String>of();
-        var assignedBpnGroups = List.of(TEST_GROUP_1, TEST_GROUP_2);
 
         when(context.getContextData(eq(ParticipantAgent.class))).thenReturn(new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, TEST_BPN)));
         when(store.resolveForBpn(TEST_BPN)).thenReturn(StoreResult.success(assignedBpnGroups));
@@ -239,13 +239,21 @@ class BusinessPartnerGroupFunctionTest {
     private static class OperatorForEmptyGroupsProvider implements ArgumentsProvider {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+            var assignedBpnGroups = List.of(TEST_GROUP_1, TEST_GROUP_2);
+
             return Stream.of(
-                    Arguments.of(EQ, false),
-                    Arguments.of(NEQ, true),
-                    Arguments.of(IN, false),
-                    Arguments.of(IS_ALL_OF, false),
-                    Arguments.of(IS_ANY_OF, false),
-                    Arguments.of(IS_NONE_OF, true)
+                    Arguments.of(EQ, assignedBpnGroups, false),
+                    Arguments.of(EQ, List.of(), false),
+                    Arguments.of(NEQ, assignedBpnGroups, true),
+                    Arguments.of(NEQ, List.of(), true),
+                    Arguments.of(IN, assignedBpnGroups, false),
+                    Arguments.of(IN, List.of(), false),
+                    Arguments.of(IS_ALL_OF, assignedBpnGroups, false),
+                    Arguments.of(IS_ALL_OF, List.of(), false),
+                    Arguments.of(IS_ANY_OF, assignedBpnGroups, false),
+                    Arguments.of(IS_ANY_OF, List.of(), false),
+                    Arguments.of(IS_NONE_OF, assignedBpnGroups, true),
+                    Arguments.of(IS_NONE_OF, List.of(), true)
             );
         }
     }

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
@@ -83,8 +83,8 @@ class BusinessPartnerGroupFunctionTest {
     @DisplayName("PolicyContext does not carry ParticipantAgent")
     void evaluate_noParticipantAgentOnContext() {
         reset(context);
-        assertThat(function.evaluate(EQ, eq("test-group"), createPermission(EQ, List.of()), context)).isFalse();
-        verify(context).reportProblem("ParticipantAgent not found on PolicyContext");
+        assertThat(function.evaluate(EQ, "test-group", createPermission(EQ, List.of()), context)).isFalse();
+        verify(context).reportProblem(eq("ParticipantAgent not found on PolicyContext"));
     }
 
     @ParameterizedTest(name = "Invalid operator {0}")

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
@@ -153,6 +153,7 @@ class BusinessPartnerGroupFunctionTest {
         when(store.resolveForBpn(TEST_BPN)).thenReturn(StoreResult.notFound("foobar"));
 
         assertFalse(function.evaluate(operator, allowedGroups, createPermission(operator, allowedGroups), context));
+        verify(context).reportProblem("foobar");
     }
 
     @EnumSource(value = Operator.class, names = {"EQ", "IS_ANY_OF", "IS_ALL_OF", "IN"})
@@ -163,6 +164,7 @@ class BusinessPartnerGroupFunctionTest {
         when(store.resolveForBpn(TEST_BPN)).thenReturn(StoreResult.success(Collections.emptyList()));
 
         assertFalse(function.evaluate(operator, allowedGroups, createPermission(operator, allowedGroups), context));
+        verify(context).reportProblem("No groups were assigned to BPN " + TEST_BPN);
     }
 
     private Permission createPermission(Operator op, List<String> rightOperand) {

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.List;
 import java.util.Map;
@@ -59,7 +58,6 @@ import static org.eclipse.tractusx.edc.validation.businesspartner.functions.Busi
 import static org.mockito.ArgumentMatchers.endsWith;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
@@ -123,27 +123,15 @@ class BusinessPartnerGroupFunctionTest {
         assertThat(function.evaluate(operator, allowedGroups, createPermission(operator, allowedGroups), context)).isEqualTo(expectedOutcome);
     }
 
-    @EnumSource(value = Operator.class, names = {"EQ", "IS_ANY_OF", "IS_ALL_OF", "IN", "IS_NONE_OF", "NEQ"})
-    @ParameterizedTest
-    void evaluate_failedResolveForBpn_shouldBeFalse(Operator operator) {
-        var allowedGroups = List.of(TEST_GROUP_1, TEST_GROUP_2);
-        when(context.getContextData(eq(ParticipantAgent.class))).thenReturn(new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, TEST_BPN)));
-        when(store.resolveForBpn(TEST_BPN)).thenReturn(StoreResult.generalError("foobar"));
-
-        assertThat(function.evaluate(operator, allowedGroups, createPermission(operator, allowedGroups), context)).isFalse();
-        verify(context).reportProblem("foobar");
-    }
-
     @Test
-    void evaluate_failedResolveForBpn_shouldEvaluateBasedOnOperator() {
-        var allowedGroups = List.<String>of();
+    void evaluate_failedResolveForBpn_shouldBeFalse() {
+        var allowedGroups = List.of(TEST_GROUP_1, TEST_GROUP_2);
         var operator = EQ;
-
         when(context.getContextData(eq(ParticipantAgent.class))).thenReturn(new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, TEST_BPN)));
         when(store.resolveForBpn(TEST_BPN)).thenReturn(StoreResult.notFound("foobar"));
 
-        assertThat(function.evaluate(operator, allowedGroups, createPermission(operator, allowedGroups), context)).isTrue();
-        verify(context, never()).reportProblem("foobar");
+        assertThat(function.evaluate(operator, allowedGroups, createPermission(operator, allowedGroups), context)).isFalse();
+        verify(context).reportProblem("foobar");
     }
 
     @ArgumentsSource(OperatorForEmptyGroupsProvider.class)

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
@@ -57,9 +57,8 @@ import static org.eclipse.edc.policy.model.Operator.LT;
 import static org.eclipse.edc.policy.model.Operator.NEQ;
 import static org.eclipse.edc.spi.agent.ParticipantAgent.PARTICIPANT_IDENTITY;
 import static org.eclipse.tractusx.edc.validation.businesspartner.functions.BusinessPartnerGroupFunction.BUSINESS_PARTNER_CONSTRAINT_KEY;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.endsWith;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -84,7 +83,7 @@ class BusinessPartnerGroupFunctionTest {
     @DisplayName("PolicyContext does not carry ParticipantAgent")
     void evaluate_noParticipantAgentOnContext() {
         reset(context);
-        assertThat(function.evaluate(EQ, "test-group", createPermission(EQ, List.of()), context)).isFalse();
+        assertThat(function.evaluate(EQ, eq("test-group"), createPermission(EQ, List.of()), context)).isFalse();
         verify(context).reportProblem("ParticipantAgent not found on PolicyContext");
     }
 
@@ -92,7 +91,7 @@ class BusinessPartnerGroupFunctionTest {
     @ArgumentsSource(InvalidOperatorProvider.class)
     @DisplayName("Invalid operators, expect report in policy context")
     void evaluate_invalidOperator(Operator invalidOperator) {
-        when(context.getContextData(ParticipantAgent.class)).thenReturn(new ParticipantAgent(Map.of(), Map.of()));
+        when(context.getContextData(eq(ParticipantAgent.class))).thenReturn(new ParticipantAgent(Map.of(), Map.of()));
         assertThat(function.evaluate(invalidOperator, "test-group", createPermission(invalidOperator, List.of()), context)).isFalse();
         verify(context).reportProblem(endsWith("but was [" + invalidOperator.name() + "]"));
     }
@@ -101,7 +100,7 @@ class BusinessPartnerGroupFunctionTest {
     @DisplayName("Right-hand operand is not String or Collection<?>")
     void evaluate_rightOperandNotStringOrCollection() {
         when(store.resolveForBpn(TEST_BPN)).thenReturn(StoreResult.success(List.of("test-group")));
-        when(context.getContextData(ParticipantAgent.class)).thenReturn(new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, TEST_BPN)));
+        when(context.getContextData(eq(ParticipantAgent.class))).thenReturn(new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, TEST_BPN)));
 
         assertThat(function.evaluate(EQ, 42, createPermission(EQ, List.of("test-group")), context)).isFalse();
         assertThat(function.evaluate(EQ, 42L, createPermission(EQ, List.of("test-group")), context)).isFalse();
@@ -120,50 +119,50 @@ class BusinessPartnerGroupFunctionTest {
     void evaluate_validOperator(String ignored, Operator operator, List<String> assignedBpn, boolean expectedOutcome) {
 
         var allowedGroups = List.of(TEST_GROUP_1, TEST_GROUP_2);
-        when(context.getContextData(ParticipantAgent.class)).thenReturn(new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, TEST_BPN)));
+        when(context.getContextData(eq(ParticipantAgent.class))).thenReturn(new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, TEST_BPN)));
         when(store.resolveForBpn(TEST_BPN)).thenReturn(StoreResult.success(assignedBpn));
         assertThat(function.evaluate(operator, allowedGroups, createPermission(operator, allowedGroups), context)).isEqualTo(expectedOutcome);
     }
 
     @EnumSource(value = Operator.class, names = {"NEQ", "IS_NONE_OF"})
     @ParameterizedTest
-    void evaluate_noEntryForBpnWithNegativeOperator_shouldBeTrue(final Operator operator) {
+    void evaluate_noEntryForBpnWithNegativeOperator_shouldBeTrue(Operator operator) {
         var allowedGroups = List.of(TEST_GROUP_1, TEST_GROUP_2);
-        when(context.getContextData(ParticipantAgent.class)).thenReturn(new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, TEST_BPN)));
+        when(context.getContextData(eq(ParticipantAgent.class))).thenReturn(new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, TEST_BPN)));
         when(store.resolveForBpn(TEST_BPN)).thenReturn(StoreResult.notFound("foobar"));
 
-        assertTrue(function.evaluate(operator, allowedGroups, createPermission(operator, allowedGroups), context));
+        assertThat(function.evaluate(operator, allowedGroups, createPermission(operator, allowedGroups), context)).isTrue();
     }
 
     @EnumSource(value = Operator.class, names = {"NEQ", "IS_NONE_OF"})
     @ParameterizedTest
-    void evaluate_noGroupsAssignedToBpnWithNegativeOperator_shouldBeTrue(final Operator operator) {
+    void evaluate_noGroupsAssignedToBpnWithNegativeOperator_shouldBeTrue(Operator operator) {
         var allowedGroups = List.of(TEST_GROUP_1, TEST_GROUP_2);
-        when(context.getContextData(ParticipantAgent.class)).thenReturn(new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, TEST_BPN)));
+        when(context.getContextData(eq(ParticipantAgent.class))).thenReturn(new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, TEST_BPN)));
         when(store.resolveForBpn(TEST_BPN)).thenReturn(StoreResult.success(Collections.emptyList()));
 
-        assertTrue(function.evaluate(operator, allowedGroups, createPermission(operator, allowedGroups), context));
+        assertThat(function.evaluate(operator, allowedGroups, createPermission(operator, allowedGroups), context)).isTrue();
     }
 
     @EnumSource(value = Operator.class, names = {"EQ", "IS_ANY_OF", "IS_ALL_OF", "IN"})
     @ParameterizedTest
-    void evaluate_noEntryForBpnWithPositiveOperator_shouldBeFalse(final Operator operator) {
+    void evaluate_noEntryForBpnWithPositiveOperator_shouldBeFalse(Operator operator) {
         var allowedGroups = List.of(TEST_GROUP_1, TEST_GROUP_2);
-        when(context.getContextData(ParticipantAgent.class)).thenReturn(new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, TEST_BPN)));
+        when(context.getContextData(eq(ParticipantAgent.class))).thenReturn(new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, TEST_BPN)));
         when(store.resolveForBpn(TEST_BPN)).thenReturn(StoreResult.notFound("foobar"));
 
-        assertFalse(function.evaluate(operator, allowedGroups, createPermission(operator, allowedGroups), context));
+        assertThat(function.evaluate(operator, allowedGroups, createPermission(operator, allowedGroups), context)).isFalse();
         verify(context).reportProblem("foobar");
     }
 
     @EnumSource(value = Operator.class, names = {"EQ", "IS_ANY_OF", "IS_ALL_OF", "IN"})
     @ParameterizedTest
-    void evaluate_noGroupsAssignedToBpnWithPositiveOperator_shouldBeFalse(final Operator operator) {
+    void evaluate_noGroupsAssignedToBpnWithPositiveOperator_shouldBeFalse(Operator operator) {
         var allowedGroups = List.of(TEST_GROUP_1, TEST_GROUP_2);
-        when(context.getContextData(ParticipantAgent.class)).thenReturn(new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, TEST_BPN)));
+        when(context.getContextData(eq(ParticipantAgent.class))).thenReturn(new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, TEST_BPN)));
         when(store.resolveForBpn(TEST_BPN)).thenReturn(StoreResult.success(Collections.emptyList()));
 
-        assertFalse(function.evaluate(operator, allowedGroups, createPermission(operator, allowedGroups), context));
+        assertThat(function.evaluate(operator, allowedGroups, createPermission(operator, allowedGroups), context)).isFalse();
         verify(context).reportProblem("No groups were assigned to BPN " + TEST_BPN);
     }
 

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
@@ -19,11 +19,6 @@
 
 package org.eclipse.tractusx.edc.validation.businesspartner.functions;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Stream;
-
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.LiteralExpression;
@@ -41,6 +36,11 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.policy.model.Operator.EQ;

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
@@ -183,7 +183,9 @@ class BusinessPartnerGroupFunctionTest {
 
                     Arguments.of("Disjoint groups", IS_ALL_OF, List.of("different-group", "another-different-group"), false),
                     Arguments.of("Matching groups", IS_ALL_OF, List.of(TEST_GROUP_1, TEST_GROUP_2), true),
-                    Arguments.of("Overlapping groups", IS_ALL_OF, List.of(TEST_GROUP_1, TEST_GROUP_2, "different-group", "another-different-group"), false),
+                    Arguments.of("Overlapping groups", IS_ALL_OF, List.of(TEST_GROUP_1, TEST_GROUP_2, "different-group", "another-different-group"), true),
+                    Arguments.of("Overlapping groups (1 overlap)", IS_ALL_OF, List.of(TEST_GROUP_1, "different-group"), false),
+                    Arguments.of("Overlapping groups (1 overlap)", IS_ALL_OF, List.of(TEST_GROUP_1), false),
 
 
                     Arguments.of("Disjoint groups", IS_ANY_OF, List.of("different-group", "another-different-group"), false),

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunctionTest.java
@@ -138,7 +138,7 @@ class BusinessPartnerGroupFunctionTest {
     @ParameterizedTest
     void evaluate_groupsAssignedButNoGroupsSentToEvaluate(Operator operator, List<String> assignedBpnGroups,
                                                           boolean expectedOutcome) {
-        var allowedGroups = List.<String>of();
+        List<String> allowedGroups = List.of();
 
         when(context.getContextData(eq(ParticipantAgent.class))).thenReturn(new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, TEST_BPN)));
         when(store.resolveForBpn(TEST_BPN)).thenReturn(StoreResult.success(assignedBpnGroups));


### PR DESCRIPTION
## WHAT
- Fixed **IS_ALL_OF** operator validation. It had the same behavior of **EQ** operator
- Fixed **IS_NONE_OF** operator validation. It had the same behavior of the **NEQ** operator
- Fixed **NEQ** operator validation. It was considering the opposite result of the IN operator, and it should be the opposite of the EQ operator
- Added a new rule when the BPN groups or assigned groups are empty, and if the operator is **NEQ** or **IS_NONE_OF**, it returns true instead of false

## WHY
In order to keep the correct behavior on BPNL validations

## FURTHER NOTES
Some minor adjusts reported by Sonar, including:
- Adjusted String format and casting

Closes #https://github.com/eclipse-tractusx/tractusx-edc/issues/1411
Closes #https://github.com/eclipse-tractusx/tractusx-edc/issues/775
