### PR TITLE
build: change copyDockerfile output path

### DIFF
--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -102,7 +102,7 @@ runs:
       uses: docker/build-push-action@v3
       with:
         context: .
-        file: ${{ inputs.rootDir }}/build/Dockerfile
+        file: ${{ inputs.rootDir }}/build/resources/docker/Dockerfile
         build-args: |
           JAR=${{ inputs.rootDir }}/build/libs/${{ inputs.imagename }}.jar
           OTEL_JAR=${{ inputs.rootDir }}/opentelemetry-javaagent.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -183,7 +183,7 @@ subprojects {
 
             val copyDockerfile = tasks.create("copyDockerfile", Copy::class) {
                 from(rootProject.projectDir.toPath().resolve("resources"))
-                into(project.layout.buildDirectory)
+                into(project.layout.buildDirectory.dir("resources").get().dir("docker"))
                 include("Dockerfile")
             }
             shadowJarTask.dependsOn(copyDockerfile)
@@ -192,7 +192,7 @@ subprojects {
             apply(plugin = "com.bmuschko.docker-remote-api")
 
             val dockerTask: DockerBuildImage = tasks.create("dockerize", DockerBuildImage::class) {
-                dockerFile.set(project.layout.buildDirectory.asFile.get().toPath().resolve("Dockerfile").toFile())
+                dockerFile.set(project.layout.buildDirectory.asFile.get().toPath().resolve("resources").resolve("docker").resolve("Dockerfile").toFile())
 
                 val dockerContextDir = project.projectDir
                 images.add("${project.name}:${project.version}")


### PR DESCRIPTION
## WHAT

copy dockerfile into `build/resources/docker`

## WHY

avoid conflicts with `jar` task

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
