### PR TITLE
feat(ci): add periodic build trigger

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -209,3 +209,13 @@ jobs:
     with:
       downstream-version: ${{ needs.release-version.outputs.RELEASE_VERSION }}
     secrets: inherit
+
+  publish-openapi-to-gh-pages:
+    name: "Publish OpenAPI UI spec GitHub Pages"
+    permissions:
+      contents: read
+    needs: [ release-version ]
+    uses: ./.github/workflows/publish-openapi-ui.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.release-version.outputs.RELEASE_VERSION }}

--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -39,6 +39,8 @@ on:
       - published
   workflow_dispatch:
 
+  # periodic build triggers are defined in run-all-tests.yml, which triggers this workflow
+
 
 concurrency:
   # cancel only running jobs on pull requests
@@ -65,34 +67,63 @@ jobs:
           [ ! -z "${{ secrets.SWAGGERHUB_USER }}" ]  && echo "HAS_SWAGGER=true" >> $GITHUB_OUTPUT
           exit 0
 
+  determine-version:
+    runs-on: ubuntu-latest
+    outputs:
+      VERSION: ${{ steps.get-version.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Get version"
+        id: get-version
+        run: |
+          if [[ ${{ github.event_name }} == "schedule" }} ]]; then
+            echo "VERSION=$(IFS=.- read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH SNAPSHOT<<<$(grep "version" gradle.properties | awk -F= '{print $2}') && echo $RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$RELEASE_VERSION_PATCH-$(date +"%Y%m%d")-SNAPSHOT)" >> "$GITHUB_OUTPUT"
+          fi
+
   publish-docker-images:
     name: "Create Docker Images"
-    needs: [ secret-presence ]
+    needs: [ secret-presence, determine-version]
     if: |
       needs.secret-presence.outputs.DOCKER_HUB_TOKEN
     permissions:
       contents: write
     uses: ./.github/workflows/trigger-docker-publish.yaml
     secrets: inherit
+    with:
+      docker_tag: ${{ needs.determine-version.outputs.VERSION }}
 
 
   publish-maven-artifacts:
     name: "Publish artefacts to OSSRH Snapshots / MavenCentral"
     permissions:
       contents: read
-    needs: [ secret-presence ]
+    needs: [ secret-presence, determine-version ]
 
     # do not run on PR branches, do not run on releases
     if: |
       needs.secret-presence.outputs.HAS_OSSRH && github.event_name != 'pull_request' && github.ref != 'refs/heads/releases'
     uses: ./.github/workflows/trigger-maven-publish.yaml
     secrets: inherit
+    with:
+      version: ${{ needs.determine-version.outputs.VERSION }}
 
   publish-to-swaggerhub:
     name: "Publish OpenAPI spec to Swaggerhub"
     permissions:
       contents: read
-    needs: [ secret-presence ]
+    needs: [ secret-presence, determine-version ]
     if: needs.secret-presence.outputs.HAS_SWAGGER
     uses: ./.github/workflows/publish-swaggerhub.yaml
     secrets: inherit
+    with:
+      downstream_version: ${{ needs.determine-version.outputs.VERSION }}
+
+  publish-openapi-to-ghpages:
+    name: "Publish OpenAPI UI spec GitHub Pages"
+    permissions:
+      contents: read
+    needs: [ secret-presence, determine-version ]
+    uses: ./.github/workflows/publish-openapi-ui.yaml
+    secrets: inherit
+    with:
+      version: ${{ needs.determine-version.outputs.VERSION }}

--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -67,6 +67,13 @@ jobs:
           [ ! -z "${{ secrets.SWAGGERHUB_USER }}" ]  && echo "HAS_SWAGGER=true" >> $GITHUB_OUTPUT
           exit 0
 
+  print-calling-workflow-event:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "log parent workflow event"
+        run: |
+          echo '${{ github.event.workflow_run.event }}'
+
   determine-version:
     runs-on: ubuntu-latest
     outputs:
@@ -77,9 +84,9 @@ jobs:
         id: get-version
         run: |
           
-          echo '${{ toJSON(context.payload.workflow_run) }}' | jq
+          # only create the version string if the run-all-tests workflow was triggered by a cron event
           
-          if [[ ${{ github.event_name }} == "workflow_run" }} ]]; then
+          if [[ ${{ github.event.workflow_run.event }} == "schedule" ]]; then
             echo "VERSION=$(IFS=.- read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH SNAPSHOT<<<$(grep "version" gradle.properties | awk -F= '{print $2}') && echo $RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$RELEASE_VERSION_PATCH-$(date +"%Y%m%d")-SNAPSHOT)" >> "$GITHUB_OUTPUT"
           fi
 
@@ -119,14 +126,14 @@ jobs:
     uses: ./.github/workflows/publish-swaggerhub.yaml
     secrets: inherit
     with:
-      downstream_version: ${{ needs.determine-version.outputs.VERSION }}
+      downstream-version: ${{ needs.determine-version.outputs.VERSION }}
 
-  publish-openapi-to-ghpages:
+  publish-openapi-to-gh-pages:
     name: "Publish OpenAPI UI spec GitHub Pages"
     permissions:
       contents: read
     needs: [ secret-presence, determine-version ]
-    uses: ./.github/workflows/publish-openapi-ui.yaml
+    uses: ./.github/workflows/publish-openapi-ui.yml
     secrets: inherit
     with:
       version: ${{ needs.determine-version.outputs.VERSION }}

--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -76,7 +76,10 @@ jobs:
       - name: "Get version"
         id: get-version
         run: |
-          if [[ ${{ github.event_name }} == "schedule" }} ]]; then
+          
+          echo '${{ toJSON(context.payload.workflow_run) }}' | jq
+          
+          if [[ ${{ github.event_name }} == "workflow_run" }} ]]; then
             echo "VERSION=$(IFS=.- read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH SNAPSHOT<<<$(grep "version" gradle.properties | awk -F= '{print $2}') && echo $RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$RELEASE_VERSION_PATCH-$(date +"%Y%m%d")-SNAPSHOT)" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -67,13 +67,6 @@ jobs:
           [ ! -z "${{ secrets.SWAGGERHUB_USER }}" ]  && echo "HAS_SWAGGER=true" >> $GITHUB_OUTPUT
           exit 0
 
-  print-calling-workflow-event:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "log parent workflow event"
-        run: |
-          echo '${{ github.event.workflow_run.event }}'
-
   determine-version:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/publish-openapi-ui.yml
+++ b/.github/workflows/publish-openapi-ui.yml
@@ -21,12 +21,15 @@
 name: publish openapi ui
 
 on:
-  push:
-    branches:
-      - main
-      - release/*
 
   workflow_dispatch:
+    inputs:
+      version:
+        required: false
+        description: "Version of the Tractus-X EDC API to be should be published"
+        type: string
+
+  workflow_call:
     inputs:
       version:
         required: false

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -37,6 +37,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+  schedule:
+    - cron: 0 3 * * MON # run on 03:00 UTC every Monday -> weekly build
+
 concurrency:
   # cancel older running jobs on the same branch
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -38,7 +38,7 @@ on:
   workflow_dispatch:
 
   schedule:
-    - cron: 0 3 * * * # run on 03:00 UTC every day
+    - cron: 0 3 * * 1 # run on 03:00 UTC every Monday
 
 concurrency:
   # cancel older running jobs on the same branch
@@ -47,13 +47,13 @@ concurrency:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-#  verify:
-#    uses: ./.github/workflows/verify.yaml
-#    secrets: inherit
-#
-#  deployment-test:
-#    uses: ./.github/workflows/deployment-test.yaml
-#    secrets: inherit
+  verify:
+    uses: ./.github/workflows/verify.yaml
+    secrets: inherit
+
+  deployment-test:
+    uses: ./.github/workflows/deployment-test.yaml
+    secrets: inherit
 
   upgradeability-test:
     uses: ./.github/workflows/upgradeability-test.yaml
@@ -63,8 +63,8 @@ jobs:
   # in future iterations, this could be used as a choke point to collect test data, etc.
   summary:
     needs:
-#      - verify
-#      - deployment-test
+      - verify
+      - deployment-test
       - upgradeability-test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -38,7 +38,7 @@ on:
   workflow_dispatch:
 
   schedule:
-    - cron: 0 3 * * MON # run on 03:00 UTC every Monday -> weekly build
+    - cron: 0 3 * * * # run on 03:00 UTC every day
 
 concurrency:
   # cancel older running jobs on the same branch
@@ -47,13 +47,13 @@ concurrency:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  verify:
-    uses: ./.github/workflows/verify.yaml
-    secrets: inherit
-
-  deployment-test:
-    uses: ./.github/workflows/deployment-test.yaml
-    secrets: inherit
+#  verify:
+#    uses: ./.github/workflows/verify.yaml
+#    secrets: inherit
+#
+#  deployment-test:
+#    uses: ./.github/workflows/deployment-test.yaml
+#    secrets: inherit
 
   upgradeability-test:
     uses: ./.github/workflows/upgradeability-test.yaml
@@ -63,8 +63,9 @@ jobs:
   # in future iterations, this could be used as a choke point to collect test data, etc.
   summary:
     needs:
-      - verify
-      - deployment-test
+#      - verify
+#      - deployment-test
+      - upgradeability-test
     runs-on: ubuntu-latest
     steps:
       - name: 'Master test job'

--- a/.github/workflows/trigger-docker-publish.yaml
+++ b/.github/workflows/trigger-docker-publish.yaml
@@ -62,6 +62,9 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+      - name: Log inputs
+        run: |
+          echo "Input Version: ${{ inputs.version }}, Input namespace: ${{ inputs.namespace}}"
       - uses: ./.github/actions/publish-docker-image
         name: Publish ${{ matrix.variant.img }}
         with:

--- a/.github/workflows/trigger-maven-publish.yaml
+++ b/.github/workflows/trigger-maven-publish.yaml
@@ -59,6 +59,8 @@ jobs:
           OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
         run: |-
           
+          echo "Input Version: ${{ inputs.version }}"
+
           # check if version input was specified, else read from gradle.properties 
           
           if [ ! -z ${{ inputs.version }} ];


### PR DESCRIPTION
## WHAT

Enables intermediate builds (weekly, on Monday at 03:00 AM UTC). More specifically, the following changes were made:

- `trigger-{maven|docker}-publish.yaml`: added log lines to print the input parameters
- `publish-new-snapshot.yaml`
  - added a job to determine the version using a date string, if the parent workflow (`run-all-tests`) was triggered by a `schedule` event
  - added a job to publish OpenAPI specs to GH Pages
  - supply that version to the publish maven, docker and openapi jobs
- `publish-new-release.yaml`: added a job to publish OpenAPI specs to GH Pages

## WHY

intermediate builds shorten dev adoption and feedback loops

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #1449 
