### PR TITLE
build: add write contents permission to deploy-swagger-ui

### DIFF
--- a/.github/workflows/publish-openapi-ui.yml
+++ b/.github/workflows/publish-openapi-ui.yml
@@ -107,6 +107,8 @@ jobs:
   deploy-swagger-ui:
     needs: generate-swagger-ui
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## WHAT

This should fix the broken deploy of swagger ui:
https://github.com/eclipse-tractusx/tractusx-edc/actions/runs/10078713965/job/27864470198

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
