### PR TITLE
build: fix dependency scope for libs.edc.junit

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -277,7 +277,6 @@ maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.1, Apache-2.0, approved, 
 maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.15, Apache-2.0, approved, #7164
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.1, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.15, Apache-2.0 AND BSD-3-Clause, approved, #7163
-maven/mavencentral/net.bytebuddy/byte-buddy/1.14.16, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.18, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.java.dev.jna/jna-platform/5.13.0, Apache-2.0 OR LGPL-2.1-or-later, approved, #6707
 maven/mavencentral/net.java.dev.jna/jna-platform/5.6.0, Apache-2.0 OR LGPL-2.1-or-later, approved, CQ22390

--- a/edc-extensions/dataplane/dataplane-selector-configuration/build.gradle.kts
+++ b/edc-extensions/dataplane/dataplane-selector-configuration/build.gradle.kts
@@ -24,8 +24,8 @@ plugins {
 
 dependencies {
     api(libs.edc.spi.core)
-    api(libs.edc.junit)
     implementation(libs.edc.spi.dataplane.selector)
     implementation(libs.edc.spi.dataplane.transfer)
     implementation(libs.bouncyCastle.bcpkixJdk18on)
+    testImplementation(libs.edc.junit)
 }

--- a/edc-extensions/migrations/control-plane-migration/build.gradle.kts
+++ b/edc-extensions/migrations/control-plane-migration/build.gradle.kts
@@ -25,7 +25,6 @@ plugins {
 dependencies {
     implementation(project(":edc-extensions:migrations:postgresql-migration-lib"))
     implementation(libs.edc.spi.core)
-    implementation(libs.edc.junit)
     implementation(libs.edc.spi.transaction.datasource)
     implementation(libs.edc.sql.assetindex)
     implementation(libs.edc.sql.core)
@@ -37,5 +36,6 @@ dependencies {
     // https://documentation.red-gate.com/flyway/release-notes-and-older-versions/release-notes-for-flyway-engine
     runtimeOnly(libs.flyway.database.postgres)
 
+    testImplementation(libs.edc.junit)
     testImplementation(testFixtures(libs.edc.sql.core))
 }

--- a/edc-extensions/migrations/data-plane-migration/build.gradle.kts
+++ b/edc-extensions/migrations/data-plane-migration/build.gradle.kts
@@ -25,7 +25,6 @@ plugins {
 dependencies {
     implementation(project(":edc-extensions:migrations:postgresql-migration-lib"))
     implementation(libs.edc.spi.core)
-    implementation(libs.edc.junit)
     implementation(libs.edc.spi.transaction.datasource)
     implementation(libs.edc.sql.assetindex)
     implementation(libs.edc.sql.core)
@@ -37,5 +36,6 @@ dependencies {
     // https://documentation.red-gate.com/flyway/release-notes-and-older-versions/release-notes-for-flyway-engine
     runtimeOnly(libs.flyway.database.postgres)
 
+    testImplementation(libs.edc.junit)
     testImplementation(testFixtures(libs.edc.sql.core))
 }

--- a/edc-extensions/migrations/postgresql-migration-lib/build.gradle.kts
+++ b/edc-extensions/migrations/postgresql-migration-lib/build.gradle.kts
@@ -25,7 +25,6 @@ plugins {
 dependencies {
     implementation(project(":core:core-utils"))
     implementation(libs.edc.spi.core)
-    implementation(libs.edc.junit)
     implementation(libs.edc.spi.transaction.datasource)
     implementation(libs.edc.sql.assetindex)
     implementation(libs.edc.sql.core)
@@ -36,4 +35,6 @@ dependencies {
     // so we need to add PG support explicitly
     // https://documentation.red-gate.com/flyway/release-notes-and-older-versions/release-notes-for-flyway-engine
     runtimeOnly(libs.flyway.database.postgres)
+
+    testImplementation(libs.edc.junit)
 }


### PR DESCRIPTION
## WHAT

Fix dependency scope for `libs.edc.junit`

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #1462
