### PR TITLE
fix(ci): remove obsolete workflow parameter `do_push`

### DIFF
--- a/.github/workflows/trigger-docker-publish.yaml
+++ b/.github/workflows/trigger-docker-publish.yaml
@@ -74,4 +74,3 @@ jobs:
           namespace: ${{ inputs.namespace }}
           docker_user: ${{ secrets.DOCKER_HUB_USER }}
           docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}
-          do_push: 'true'


### PR DESCRIPTION

## WHAT

removes obsolete `do_push` parameter, that was previously removed from the called workflow

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
