### PR TITLE
build: TRG-8-03 enable TruffleHog secrets scan

### DIFF
--- a/.github/workflows/dash-scan.yml
+++ b/.github/workflows/dash-scan.yml
@@ -1,0 +1,62 @@
+#################################################################################
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+
+name: "3rd Party dependency check (Eclipse Dash)"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  check-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-java
+
+      - name: generate dependency list
+        run: |
+          ./gradlew allDependencies | grep -Poh "(?<=\s)[\w.-]+:[\w.-]+:[^:\s\[\]]+" | sort | uniq > dependency-list
+          cat dependency-list
+
+      - name: Run dash
+        id: run-dash
+        uses: eclipse-tractusx/sig-infra/.github/actions/run-dash@main
+        with:
+          dash_input: dependency-list
+          dependencies_file: DEPENDENCIES
+          fail_on_out_of_date: true
+          fail_on_rejected: true
+          fail_on_restricted: false
+
+      - name: print generated file
+        if: failure()
+        run: |
+          echo "=== Please copy the following content back to DEPENDENCIES ==="
+          cat DEPENDENCIES
+          echo "=== end of content ==="

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,0 +1,58 @@
+#################################################################################
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+
+name: "Secrets scan (TruffleHog)"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *" # Once a day
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+  id-token: write
+  issues: write
+
+jobs:
+  ScanSecrets:
+    name: Scan secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Ensure full clone for pull request workflows
+
+      - name: TruffleHog OSS
+        id: trufflehog
+        uses: trufflesecurity/trufflehog@main
+        continue-on-error: true
+        with:
+          path: ./  # Scan the entire repository
+          base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
+          extra_args: --filter-entropy=4 --results=verified,unknown --debug
+
+      - name: Scan Results Status
+        if: steps.trufflehog.outcome == 'failure'
+        run: exit 1  # Set workflow run to failure if TruffleHog finds secrets

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -28,21 +28,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  
-  verify-license-headers:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: "Check for files without a license header"
-        run: |-
-          # checks all java, yaml, kts and sql files for an Apache 2.0 license header
-          cmd="grep -riL \"SPDX-License-Identifier: Apache-2.0\" --include=\*.{java,yaml,yml,kts,sql} --exclude-dir={.gradle,\*\openapi} ."
-          violations=$(eval $cmd | wc -l)
-          if [[ $violations -ne 0 ]] ; then
-            echo "$violations files without license headers were found:";
-            eval $cmd;
-            exit 1;
-          fi
 
   verify-helm-docs:
     runs-on: ubuntu-latest
@@ -64,9 +49,6 @@ jobs:
             exit 1
           fi
 
-  verify-dependencies:
-    uses: eclipse-edc/.github/.github/workflows/dependency-check.yml@main
-  
   verify-formatting:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## WHAT

TruffleHog is the OSS replacement for GitGuardian that will be replaced soon.
Details: https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/pull/950

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

- removed "verify license header" job because it's already done by checkstyle

Closes # <-- _insert Issue number if one exists_
