### PR TITLE
fix(ci): use RELEASE_VERSION from step output

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -67,7 +67,7 @@ jobs:
     uses: ./.github/workflows/trigger-maven-publish.yaml
     secrets: inherit
     with:
-      version: $RELEASE_VERSION
+      version: ${{ needs.release-version.outputs.RELEASE_VERSION }}
 
   docker-release:
     name: Publish Docker images
@@ -79,7 +79,7 @@ jobs:
     uses: ./.github/workflows/trigger-docker-publish.yaml
     secrets: inherit
     with:
-      docker_tag: $RELEASE_VERSION
+      docker_tag: ${{ needs.release-version.outputs.RELEASE_VERSION }}
 
   # Release: Helm Charts
   helm-release:

--- a/.github/workflows/trigger-docker-publish.yaml
+++ b/.github/workflows/trigger-docker-publish.yaml
@@ -32,6 +32,7 @@ on:
       docker_tag:
         description: 'Explicitly specify the Docker tag. Note that SHA and latest are added automatically.'
         required: false
+        type: string
 
   workflow_call:
     inputs:
@@ -64,7 +65,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Log inputs
         run: |
-          echo "Input Version: ${{ inputs.version }}, Input namespace: ${{ inputs.namespace}}"
+          echo "Input Version: ${{ inputs.docker_tag }}, Input namespace: ${{ inputs.namespace}}"
       - uses: ./.github/actions/publish-docker-image
         name: Publish ${{ matrix.variant.img }}
         with:

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -706,7 +706,7 @@ maven/mavencentral/software.amazon.awssdk/profiles/2.27.2, , restricted, clearly
 maven/mavencentral/software.amazon.awssdk/protocol-core/2.26.27, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/protocol-core/2.27.2, , restricted, clearlydefined
 maven/mavencentral/software.amazon.awssdk/regions/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/regions/2.27.2, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/regions/2.27.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/retries-spi/2.26.27, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/retries-spi/2.27.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/retries/2.26.27, Apache-2.0, approved, clearlydefined


### PR DESCRIPTION
## WHAT

changes the value of the `docker_tag` input to use the step output of the version extraction step. also fixes a log line

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
