### PR TITLE
chore(workflows): Add publish-bugfix-release workflow to main

### DIFF
--- a/.github/workflows/publish-bugfix-release.yml
+++ b/.github/workflows/publish-bugfix-release.yml
@@ -71,6 +71,8 @@ jobs:
         run: |-
           # replace the project's (default) version, could be overwritten later with the -Pversion=... flag
           sed -i  's/version=.*/version=${{ inputs.version }}/g' gradle.properties
+          # replace the openapi version with the upcoming one
+          sed -i 's#tractusx-edc/.*/swagger.yaml#tractusx-edc/${{ github.event.inputs.version }}/swagger.yaml#g' .tractusx
         env:
           GITHUB_PACKAGE_USERNAME: ${{ github.actor }}
           GITHUB_PACKAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
@@ -97,56 +99,23 @@ jobs:
   maven-release:
     name: Publish extension's release version to maven repository
     needs: [ prepare-bugfix-release, validate-release ]
-    runs-on: ubuntu-latest
     permissions:
       contents: read
-    steps:
-
-      # Set-Up
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-java
-
-      # Import GPG Key
-      - uses: ./.github/actions/import-gpg-key
-        name: "Import GPG Key"
-        with:
-          gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
-
-      # publish releases
-      - name: Publish version
-        env:
-          OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
-          OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
-        run: |-
-          echo "Publishing Version ${{ inputs.version }} to Sonatype/MavenCentral"
-          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Pversion=${{inputs.version}} -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ secrets.ORG_GPG_PASSPHRASE }}"
+    uses: ./.github/workflows/trigger-maven-publish.yaml
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}
 
   docker-release:
     name: Publish Docker images
-    runs-on: ubuntu-latest
     needs: [ prepare-bugfix-release, validate-release ]
     permissions:
       contents: write
-    strategy:
-      fail-fast: false
-      matrix:
-        variant: [ { dir: edc-controlplane, img: edc-runtime-memory },
-                   { dir: edc-controlplane, img: edc-controlplane-postgresql-hashicorp-vault },
-                   { dir: edc-controlplane, img: edc-controlplane-postgresql-azure-vault },
-                   { dir: edc-dataplane,    img: edc-dataplane-azure-vault },
-                   { dir: edc-dataplane,    img: edc-dataplane-hashicorp-vault },
-                   { dir: edc-tests/runtime, img: mock-connector }]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/publish-docker-image
-        name: Publish ${{ matrix.variant.img }}
-        with:
-          docker_tag: ${{ inputs.version }}
-          rootDir: ${{ matrix.variant.dir }}/${{ matrix.variant.img }}
-          imagename: ${{ matrix.variant.img }}
-          docker_user: ${{ secrets.DOCKER_HUB_USER }}
-          docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}
-          do_push: 'true'
+
+    uses: ./.github/workflows/trigger-docker-publish.yaml
+    secrets: inherit
+    with:
+      docker_tag: ${{ inputs.version }}
 
   # Release: Helm Charts
   helm-release:
@@ -155,7 +124,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
       pages: write
 
     steps:
@@ -231,3 +199,13 @@ jobs:
     with:
       downstream-version: ${{ inputs.version }}
     secrets: inherit
+
+  publish-openapi-to-gh-pages:
+    name: "Publish OpenAPI UI spec GitHub Pages"
+    permissions:
+      contents: write
+    needs: [ prepare-bugfix-release, validate-release ]
+    uses: ./.github/workflows/publish-openapi-ui.yml
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}

--- a/.github/workflows/publish-bugfix-release.yml
+++ b/.github/workflows/publish-bugfix-release.yml
@@ -1,0 +1,233 @@
+#################################################################################
+#  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+
+---
+name: "Publish bugfix release"
+
+# Temporary workflow to enable the release of bugfix versions.
+# Should be reworked as this file contains duplicate code from draft-new-release and publish-new-release
+# This workflow, as is, should be executed after the bugfix branch is created and all needed PRs are merged
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The bugfix version you want to release.'
+        required: true
+
+jobs:
+  # Gate: Check release version presence
+  validate-release:
+    name: Validate if bugfix version can be released
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref_name, 'bugfix/')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: check-tag
+        name: Check if tag exists
+        run: |-
+          
+          tag=$(git tag -l ${{ inputs.version }})
+          
+          if [ ! -z $tag ];
+          then
+            echo "Tag already exists! Please choose another tag."
+            exit 1
+          fi
+
+  prepare-bugfix-release:
+    name: "Prepare bugfix release"
+    runs-on: ubuntu-latest
+    needs: [validate-release]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "eclipse-tractusx-bot"
+          git config user.email "tractusx-bot@eclipse.org"
+      - uses: ./.github/actions/setup-java
+      - name: Bump version in gradle.properties
+        run: |-
+          # replace the project's (default) version, could be overwritten later with the -Pversion=... flag
+          sed -i  's/version=.*/version=${{ inputs.version }}/g' gradle.properties
+        env:
+          GITHUB_PACKAGE_USERNAME: ${{ github.actor }}
+          GITHUB_PACKAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Bump version in /charts
+        uses: mikefarah/yq@v4.44.2
+        with:
+          cmd: |-
+            find charts -name Chart.yaml -maxdepth 3 | xargs -n1 yq -i '.appVersion = "${{ inputs.version }}" | .version = "${{ inputs.version }}"'
+      - name: Update Chart READMEs
+        uses: addnab/docker-run-action@v3
+        with:
+          image: jnorwood/helm-docs:v1.10.0
+          options: -v ${{ github.workspace }}/charts:/helm-docs
+          run: |
+            helm-docs --log-level debug
+      - name: Commit manifest files
+        id: make-commit
+        run: |
+          git add gradle.properties $(find charts -name Chart.yaml) $(find charts -name README.md)
+          git commit --message "Prepare release ${{ inputs.version }}"
+
+
+  # Release: Maven Artifacts
+  maven-release:
+    name: Publish extension's release version to maven repository
+    needs: [ prepare-bugfix-release, validate-release ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+
+      # Set-Up
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-java
+
+      # Import GPG Key
+      - uses: ./.github/actions/import-gpg-key
+        name: "Import GPG Key"
+        with:
+          gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
+
+      # publish releases
+      - name: Publish version
+        env:
+          OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
+          OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
+        run: |-
+          echo "Publishing Version ${{ inputs.version }} to Sonatype/MavenCentral"
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Pversion=${{inputs.version}} -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ secrets.ORG_GPG_PASSPHRASE }}"
+
+  docker-release:
+    name: Publish Docker images
+    runs-on: ubuntu-latest
+    needs: [ prepare-bugfix-release, validate-release ]
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [ { dir: edc-controlplane, img: edc-runtime-memory },
+                   { dir: edc-controlplane, img: edc-controlplane-postgresql-hashicorp-vault },
+                   { dir: edc-controlplane, img: edc-controlplane-postgresql-azure-vault },
+                   { dir: edc-dataplane,    img: edc-dataplane-azure-vault },
+                   { dir: edc-dataplane,    img: edc-dataplane-hashicorp-vault },
+                   { dir: edc-tests/runtime, img: mock-connector }]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/publish-docker-image
+        name: Publish ${{ matrix.variant.img }}
+        with:
+          docker_tag: ${{ inputs.version }}
+          rootDir: ${{ matrix.variant.dir }}/${{ matrix.variant.img }}
+          imagename: ${{ matrix.variant.img }}
+          docker_user: ${{ secrets.DOCKER_HUB_USER }}
+          docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}
+          do_push: 'true'
+
+  # Release: Helm Charts
+  helm-release:
+    name: Publish new helm release
+    needs: [ prepare-bugfix-release, validate-release ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      pages: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.8.1
+      - name: Package helm, update index.yaml and push to gh-pages
+        run: |
+          # Prepare git env
+          git config user.name "eclipse-tractusx-bot"
+          git config user.email "tractusx-bot@eclipse.org"
+
+          # Package all charts
+          find charts -name Chart.yaml -not -path "./edc-tests/*" | xargs -n1 dirname | xargs -n1 helm package -u -d helm-charts
+
+          git checkout gh-pages || git checkout -b gh-pages
+          git pull --rebase origin gh-pages
+
+          # Generate helm repo index.yaml
+          helm repo index . --merge index.yaml --url https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY#*/}/
+
+          # Commit and push to gh-pages
+          git add index.yaml helm-charts
+          git commit -s -m "Release ${{ inputs.version }}"
+
+          git push origin gh-pages
+
+  # Release: GitHub tag & release;
+  github-release:
+    name: Publish new github release
+    needs: [ prepare-bugfix-release, validate-release, maven-release, docker-release, helm-release ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # 0 to fetch the full history due to upcoming merge of releases into main branch
+          fetch-depth: 0
+      - name: Create Release Tag
+        id: create_release_tag
+        run: |
+          # Prepare git env
+          git config user.name "eclipse-tractusx-bot"
+          git config user.email "tractusx-bot@eclipse.org"
+
+          # informative
+          git branch -a
+          git tag
+
+          # Create & push tag
+          git tag --force ${{ inputs.version }}
+          git push --force origin ${{ inputs.version }}
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          tag: ${{ inputs.version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          makeLatest: false
+          removeArtifacts: true
+
+  publish-to-swaggerhub:
+    name: "Publish OpenAPI spec to Swaggerhub"
+    permissions:
+      contents: read
+    needs: [ prepare-bugfix-release, validate-release ]
+    uses: ./.github/workflows/publish-swaggerhub.yaml
+    with:
+      downstream-version: ${{ inputs.version }}
+    secrets: inherit


### PR DESCRIPTION
## WHAT

Brings in the temporary publish-bugfix workflow to main from the bugfix/0.7.4 branch.
This is needed for the workflow to be executed manually from the Actions tab.
