### PR TITLE
feat(snapshot workflow): Allow snapshots from bugfix branches

### DIFF
--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -23,20 +23,17 @@
 
 ---
 name: "Publish new snapshot"
+run_name: "Publish new snapshot from ${{github.ref_name}}"
 
 on:
   workflow_run:
     workflows: [ "Run-All-Tests" ]
     branches:
       - main
-      - releases
       - release/*
-      - hotfix/*
+      - bugfix/*
     types:
       - completed
-  release:
-    types:
-      - published
   workflow_dispatch:
 
   # periodic build triggers are defined in run-all-tests.yml, which triggers this workflow
@@ -107,7 +104,7 @@ jobs:
 
     # do not run on PR branches, do not run on releases
     if: |
-      needs.secret-presence.outputs.HAS_OSSRH && github.event_name != 'pull_request' && github.ref != 'refs/heads/releases'
+      needs.secret-presence.outputs.HAS_OSSRH
     uses: ./.github/workflows/trigger-maven-publish.yaml
     secrets: inherit
     with:

--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -23,7 +23,7 @@
 
 ---
 name: "Publish new snapshot"
-run_name: "Publish new snapshot from ${{github.ref_name}}"
+run-name: "Publish new snapshot from ${{github.ref_name}}"
 
 on:
   workflow_run:

--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -68,6 +68,7 @@ jobs:
           exit 0
 
   determine-version:
+    name: "Determine snapshot version to be published"
     runs-on: ubuntu-latest
     outputs:
       VERSION: ${{ steps.get-version.outputs.VERSION }}
@@ -77,10 +78,12 @@ jobs:
         id: get-version
         run: |
           
-          # only create the version string if the run-all-tests workflow was triggered by a cron event
+          IFS=.- read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH SNAPSHOT<<<$(grep "version" gradle.properties | awk -F= '{print $2}')
           
           if [[ ${{ github.event.workflow_run.event }} == "schedule" ]]; then
-            echo "VERSION=$(IFS=.- read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH SNAPSHOT<<<$(grep "version" gradle.properties | awk -F= '{print $2}') && echo $RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$RELEASE_VERSION_PATCH-$(date +"%Y%m%d")-SNAPSHOT)" >> "$GITHUB_OUTPUT"
+            echo "VERSION=$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$RELEASE_VERSION_PATCH-$(date +"%Y%m%d")-SNAPSHOT" >> "$GITHUB_OUTPUT"
+          else
+            echo "VERSION=$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$RELEASE_VERSION_PATCH-SNAPSHOT" >> "$GITHUB_OUTPUT"
           fi
 
   publish-docker-images:

--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -30,7 +30,6 @@ on:
     workflows: [ "Run-All-Tests" ]
     branches:
       - main
-      - release/*
       - bugfix/*
     types:
       - completed

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -27,13 +27,7 @@ on:
   push:
     branches:
       - main
-      - releases
-      - previews/*
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
-  release:
-    types:
-      - published
+      - bugfix/*
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## WHAT

This PR proposes a refactor to the `determine-version` job of the `publish-new-snapshot` workflow, that improves the job to resolve the correct snapshot version string from the gradle.properties every time. This version string is then used as input for the various publishing workflows.

As the publish-new-snapshot workflow can be manually activated, this improvement also allows for the creation of a snapshot from any branch.

## WHY

To allow snapshots from bugfix branches.

## FURTHER NOTES

In light of #1543, also took the opportunity to remove some unnecessary "listeners" from the run-all-tests workflow, making the file simpler.
- Removed any reference to the releases branch as its not needed anymore.
- Removed any reference to previews/* branches as they are not needed anymore.
- Checking if the `github.event_name == pull_request` is redundant, since that event can't trigger the workflow.
- We don't need to run all tests on tag push or release publication, since the tests were already executed a) on PR and b) on the branch from where the tag/release will be pushed/published.

Closes #1557 
