### PR TITLE
ci: bump k8s versions in deployment test

### DIFF
--- a/.github/actions/run-deployment-test/action.yml
+++ b/.github/actions/run-deployment-test/action.yml
@@ -51,15 +51,8 @@ runs:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-java
 
-    - name: Setup Helm
-      uses: azure/setup-helm@v3.5
-      with:
-        version: v3.8.1
-
-    - name: Setup Kubectl
-      uses: azure/setup-kubectl@v3.2
-      with:
-        version: 'v1.28.2'
+    - uses: ./.github/actions/setup-helm
+    - uses: ./.github/actions/setup-kubectl
 
     - name: Create k8s Kind Cluster
       uses: helm/kind-action@v1.10.0

--- a/.github/actions/setup-helm/action.yml
+++ b/.github/actions/setup-helm/action.yml
@@ -1,0 +1,29 @@
+#################################################################################
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+
+---
+name: "Setup Helm"
+description: "Setup Helm"
+runs:
+  using: "composite"
+  steps:
+    - uses: azure/setup-helm@v4
+      with:
+        version: v3.16.1

--- a/.github/actions/setup-kubectl/action.yml
+++ b/.github/actions/setup-kubectl/action.yml
@@ -1,0 +1,29 @@
+#################################################################################
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+
+---
+name: "Setup Kubectl"
+description: "Setup Kubectl"
+runs:
+  using: "composite"
+  steps:
+    - uses: azure/setup-kubectl@v4
+      with:
+        version: v1.31.1

--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -79,9 +79,9 @@ jobs:
       fail-fast: false
       # this will verify that the official distribution of the Tractus-X EDC Helm chart runs on the last 3 Kubernetes versions
       matrix:
-        k8s-version: [ "v1.30.2",
-                       "v1.29.4",
-                       "v1.28.9" ]
+        k8s-version: [ "v1.31.0",
+                       "v1.30.4",
+                       "v1.29.8" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -48,10 +48,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: helm (setup)
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.8.1
+      - uses: ./.github/actions/setup-helm
       - name: python (setup)
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,10 +84,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.8.1
+      - uses: ./.github/actions/setup-helm
       - name: Package helm, update index.yaml and push to gh-pages
         run: |
           # Prepare git env

--- a/.github/workflows/upgradeability-test.yaml
+++ b/.github/workflows/upgradeability-test.yaml
@@ -45,15 +45,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: "Setup Helm"
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.8.1
-
-      - name: "Setup Kubectl"
-        uses: azure/setup-kubectl@v4
-        with:
-          version: 'v1.28.2'
+      - uses: ./.github/actions/setup-helm
+      - uses: ./.github/actions/setup-kubectl
 
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.10.0


### PR DESCRIPTION
## WHAT

Set the 3 latest k8s versions in deployment-test.

## WHY

TRG 5.10

## FURTHER NOTES

- extracted composite actions for setup-helm and setup-kubectl, to keep the versions in a single file

Closes #1563 
