### PR TITLE
chore: Switch to Tractus-X recommended TruffleHog version

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: TruffleHog OSS
         id: trufflehog
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@7e78ca385fb82c19568c7a4b341c97d57d9aa5e1
         continue-on-error: true
         with:
           path: ./  # Scan the entire repository

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -650,17 +650,17 @@ maven/mavencentral/org.yaml/snakeyaml/1.33, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #10232
 maven/mavencentral/org.yaml/snakeyaml/2.3, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #16046
 maven/mavencentral/software.amazon.awssdk/annotations/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/annotations/2.28.6, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/annotations/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/apache-client/2.26.27, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/apache-client/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/arns/2.26.27, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/arns/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/auth/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/auth/2.28.6, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/auth/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/aws-core/2.26.27, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/aws-core/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.28.6, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/aws-xml-protocol/2.26.27, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/aws-xml-protocol/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/checksums-spi/2.26.27, Apache-2.0, approved, clearlydefined
@@ -680,7 +680,7 @@ maven/mavencentral/software.amazon.awssdk/http-auth-spi/2.28.6, Apache-2.0, appr
 maven/mavencentral/software.amazon.awssdk/http-auth/2.26.27, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/http-auth/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/http-client-spi/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/http-client-spi/2.28.6, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/http-client-spi/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/iam/2.26.27, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/identity-spi/2.26.27, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/identity-spi/2.28.6, Apache-2.0, approved, clearlydefined
@@ -689,13 +689,13 @@ maven/mavencentral/software.amazon.awssdk/json-utils/2.28.6, Apache-2.0, approve
 maven/mavencentral/software.amazon.awssdk/metrics-spi/2.26.27, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/metrics-spi/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/netty-nio-client/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/netty-nio-client/2.28.6, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/netty-nio-client/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/profiles/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/profiles/2.28.6, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/profiles/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/protocol-core/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/protocol-core/2.28.6, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/protocol-core/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/regions/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/regions/2.28.6, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/regions/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/retries-spi/2.26.27, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/retries-spi/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/retries/2.26.27, Apache-2.0, approved, clearlydefined
@@ -704,10 +704,10 @@ maven/mavencentral/software.amazon.awssdk/s3-transfer-manager/2.28.6, , restrict
 maven/mavencentral/software.amazon.awssdk/s3/2.26.27, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/s3/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/sdk-core/2.26.27, Apache-2.0, approved, #15695
-maven/mavencentral/software.amazon.awssdk/sdk-core/2.28.6, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/sdk-core/2.28.6, Apache-2.0, restricted, clearlydefined
 maven/mavencentral/software.amazon.awssdk/sts/2.26.27, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.26.27, Apache-2.0, approved, #15693
 maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.28.6, Apache-2.0 AND BSD-2-Clause, restricted, clearlydefined
 maven/mavencentral/software.amazon.awssdk/utils/2.26.27, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/utils/2.28.6, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/utils/2.28.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.eventstream/eventstream/1.0.1, Apache-2.0, approved, clearlydefined


### PR DESCRIPTION
## WHAT

Adapt the TruffleHog workflow to use a dedicated commit version

## WHY

As mentioned in https://github.com/eclipse-tractusx/sig-security/issues/86, the commit hash is the version the Eclipse Tractus-X project has agreed upon.

## FURTHER NOTES

Closes #1581 
