### PR TITLE
build: fix publish openapi ui

### DIFF
--- a/.github/workflows/publish-openapi-ui.yml
+++ b/.github/workflows/publish-openapi-ui.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           output: dist/${{ env.VERSION }}
           spec-file: resources/openapi/yaml/${{ matrix.apiGroup.name }}.yaml
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate Swagger UI stable version
         uses: Legion2/swagger-ui-action@v1
@@ -98,6 +99,7 @@ jobs:
         with:
           output: dist
           spec-file: resources/openapi/yaml/${{ matrix.apiGroup.name }}.yaml
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## WHAT

Add missing `GITHUB_TOKEN` attribute, that became mandatory after a [breaking change release](https://github.com/Legion2/swagger-ui-action/pull/464) of `Legion2/swagger-ui-action`

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
