### PR TITLE
fix: add default empty array value for null policy profiles

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -298,7 +298,7 @@ maven/mavencentral/org.apache.velocity.tools/velocity-tools-generic/3.1, Apache-
 maven/mavencentral/org.apache.velocity/velocity-engine-core/2.3, Apache-2.0, approved, #2478
 maven/mavencentral/org.apache.velocity/velocity-engine-scripting/2.3, Apache-2.0 AND BSD-3-Clause, approved, #15744
 maven/mavencentral/org.apache.xbean/xbean-reflect/3.7, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, #17641
 maven/mavencentral/org.assertj/assertj-core/3.26.3, Apache-2.0, approved, #14886
 maven/mavencentral/org.awaitility/awaitility/4.2.2, Apache-2.0, approved, #14178
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.72, MIT, approved, #3789
@@ -565,7 +565,7 @@ maven/mavencentral/org.glassfish/jakarta.json/2.0.1, EPL-2.0 OR GPL-2.0-only wit
 maven/mavencentral/org.hamcrest/hamcrest-core/1.3, BSD-2-Clause, approved, CQ11429
 maven/mavencentral/org.hamcrest/hamcrest-core/2.2, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.hamcrest/hamcrest/2.1, BSD-3-Clause, approved, clearlydefined
-maven/mavencentral/org.hamcrest/hamcrest/2.2, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/org.hamcrest/hamcrest/2.2, None, restricted, #17677
 maven/mavencentral/org.hdrhistogram/HdrHistogram/2.2.2, BSD-2-Clause AND CC0-1.0 AND CC0-1.0, approved, #14828
 maven/mavencentral/org.jacoco/org.jacoco.agent/0.8.12, EPL-2.0, approved, CQ23285
 maven/mavencentral/org.jacoco/org.jacoco.ant/0.8.12, EPL-2.0, approved, #1068
@@ -630,12 +630,12 @@ maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-C
 maven/mavencentral/org.yaml/snakeyaml/2.3, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #16046
 maven/mavencentral/software.amazon.awssdk/annotations/2.29.15, Apache-2.0, approved, #17015
 maven/mavencentral/software.amazon.awssdk/annotations/2.29.24, Apache-2.0, approved, #17015
-maven/mavencentral/software.amazon.awssdk/apache-client/2.29.15, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/apache-client/2.29.24, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/apache-client/2.29.15, Apache-2.0, approved, #17627
+maven/mavencentral/software.amazon.awssdk/apache-client/2.29.24, Apache-2.0, approved, #17627
 maven/mavencentral/software.amazon.awssdk/arns/2.29.15, Apache-2.0, approved, #16994
 maven/mavencentral/software.amazon.awssdk/arns/2.29.24, Apache-2.0, approved, #16994
-maven/mavencentral/software.amazon.awssdk/auth/2.29.15, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/auth/2.29.24, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/auth/2.29.15, Apache-2.0, approved, #17626
+maven/mavencentral/software.amazon.awssdk/auth/2.29.24, Apache-2.0, approved, #17626
 maven/mavencentral/software.amazon.awssdk/aws-core/2.29.15, Apache-2.0, approved, #17095
 maven/mavencentral/software.amazon.awssdk/aws-core/2.29.24, Apache-2.0, approved, #17095
 maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.29.15, Apache-2.0, approved, #16999
@@ -673,20 +673,20 @@ maven/mavencentral/software.amazon.awssdk/profiles/2.29.15, Apache-2.0, approved
 maven/mavencentral/software.amazon.awssdk/profiles/2.29.24, Apache-2.0, approved, #17012
 maven/mavencentral/software.amazon.awssdk/protocol-core/2.29.15, Apache-2.0, approved, #17000
 maven/mavencentral/software.amazon.awssdk/protocol-core/2.29.24, Apache-2.0, approved, #17000
-maven/mavencentral/software.amazon.awssdk/regions/2.29.15, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/regions/2.29.24, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/regions/2.29.15, Apache-2.0, approved, #17631
+maven/mavencentral/software.amazon.awssdk/regions/2.29.24, Apache-2.0, approved, #17631
 maven/mavencentral/software.amazon.awssdk/retries-spi/2.29.15, Apache-2.0, approved, #16997
 maven/mavencentral/software.amazon.awssdk/retries-spi/2.29.24, Apache-2.0, approved, #16997
 maven/mavencentral/software.amazon.awssdk/retries/2.29.15, Apache-2.0, approved, #17009
 maven/mavencentral/software.amazon.awssdk/retries/2.29.24, Apache-2.0, approved, #17009
 maven/mavencentral/software.amazon.awssdk/s3-transfer-manager/2.29.24, , restricted, clearlydefined
-maven/mavencentral/software.amazon.awssdk/s3/2.29.15, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/s3/2.29.24, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/s3/2.29.15, Apache-2.0, approved, #17629
+maven/mavencentral/software.amazon.awssdk/s3/2.29.24, Apache-2.0, approved, #17629
 maven/mavencentral/software.amazon.awssdk/sdk-core/2.29.15, Apache-2.0, approved, #17016
 maven/mavencentral/software.amazon.awssdk/sdk-core/2.29.24, Apache-2.0, approved, #17016
-maven/mavencentral/software.amazon.awssdk/sts/2.29.15, Apache-2.0, approved, clearlydefined
+maven/mavencentral/software.amazon.awssdk/sts/2.29.15, Apache-2.0, approved, #17630
 maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.29.15, Apache-2.0, approved, #17008
 maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.29.24, Apache-2.0, approved, #17008
-maven/mavencentral/software.amazon.awssdk/utils/2.29.15, Apache-2.0, approved, clearlydefined
-maven/mavencentral/software.amazon.awssdk/utils/2.29.24, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/utils/2.29.15, Apache-2.0, approved, #17625
+maven/mavencentral/software.amazon.awssdk/utils/2.29.24, Apache-2.0, approved, #17625
 maven/mavencentral/software.amazon.eventstream/eventstream/1.0.1, Apache-2.0, approved, clearlydefined

--- a/docs/migration/Version_0.7.x_0.8.x.md
+++ b/docs/migration/Version_0.7.x_0.8.x.md
@@ -38,6 +38,9 @@ For those who are not using either the Helm Charts or the provided [`migration` 
 - [federated catalog - init schema](../../edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/federatedcatalog/V0_0_1__Init_FederatedCatalogCache_Database_Schema.sql)
 - [policy monitor - create state index](../../edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/policy-monitor/V0_0_2__Alter_PolicyMonitor_CreateStateIndex.sql)
 - [policy definition - add profiles column](../../edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/policy/V0_0_5__Add_Profiles.sql)
+  - **WARNING**: in version 0.8.0 this could give runtime errors, eventually you can manually run the query contained in the 
+    [subsequent migration](../../edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/policy/V0_0_6__Avoid_null_profiles.sql).
+    The migration fix will be available from 0.8.1 on.  
 - [transfer process - create state index](../../edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/transferprocess/V0_0_16__Alter_TransferProcess_CreateStateIndex.sql)
 
 ### 2.2. Data plane:

--- a/docs/migration/Version_0.7.x_0.8.x.md
+++ b/docs/migration/Version_0.7.x_0.8.x.md
@@ -38,7 +38,8 @@ For those who are not using either the Helm Charts or the provided [`migration` 
 - [federated catalog - init schema](../../edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/federatedcatalog/V0_0_1__Init_FederatedCatalogCache_Database_Schema.sql)
 - [policy monitor - create state index](../../edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/policy-monitor/V0_0_2__Alter_PolicyMonitor_CreateStateIndex.sql)
 - [policy definition - add profiles column](../../edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/policy/V0_0_5__Add_Profiles.sql)
-  - **WARNING**: in version 0.8.0 this could give runtime errors, eventually you can manually run the query contained in the 
+  - **WARNING**: When upgrading from 0.7.X, if your policy definition table already has data, this migration will lead
+    the PolicyDefinitionStore to throw runtime errors. As a workaround you can manually run the query contained in the 
     [subsequent migration](../../edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/policy/V0_0_6__Avoid_null_profiles.sql).
     The migration fix will be available from 0.8.1 on.  
 - [transfer process - create state index](../../edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/transferprocess/V0_0_16__Alter_TransferProcess_CreateStateIndex.sql)

--- a/edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/policy/V0_0_6__Avoid_null_profiles.sql
+++ b/edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/policy/V0_0_6__Avoid_null_profiles.sql
@@ -1,0 +1,14 @@
+--
+--  Copyright (c) 2024 Contributors to the Eclipse Foundation
+--
+--  This program and the accompanying materials are made available under the
+--  terms of the Apache License, Version 2.0 which is available at
+--  https://www.apache.org/licenses/LICENSE-2.0
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+--  Contributors:
+--       Contributors to the Eclipse Foundation - initial API and implementation
+--
+
+UPDATE edc_policydefinitions SET profiles='[]'::json where profiles is NULL;


### PR DESCRIPTION
## WHAT

Add migration to fix the problem of null `profiles` column.

## WHY

Avoid NPE

## FURTHER NOTES

- there's a workaround for this error that can be applied before an 0.8.1 is released. Added a description in the migration guide.

Closes # <-- _insert Issue number if one exists_
