### PR TITLE
docs(ContractDefinitions): Added description how to use private Properties in asset selectors

### DIFF
--- a/docs/usage/management-api-walkthrough/03_contractdefinitions.md
+++ b/docs/usage/management-api-walkthrough/03_contractdefinitions.md
@@ -88,6 +88,22 @@ part of the `edc:QuerySpec` objects that also allow pagination:
 - `POST /v3/policydefinitions/request`
 - `POST /v3/contractdefinitions/request`
 
+## Using Private Properties as Asset Selectors
+When using a private property as an asset selector, the property defined in the left operator must be prefixed as follows: `"privateProperties.'https://w3id.org/edc/v0.0.1/ns/myCommonProperty'"`.  
+
+```json
+{
+  "assetsSelector":
+    {
+      "@type": "Criterion",
+      "operandLeft": "privateProperties.'https://w3id.org/edc/v0.0.1/ns/myCommonProperty'",
+      "operator": "=",
+      "operandRight": "sharedValue"
+    }
+}
+```
+
+
 ## Side-Effects
 
 The [Domain Model](../README) shows the basic connection between the core concepts of
@@ -99,6 +115,7 @@ After contract definition, an EDC will automatically allow data access if a requ
 
 Contract Definitions thus must be created with great care. It is essential to align the backend-credentials with the
 Access and Contract Policies to manage access consistently from the Dataspace to the backend data.
+
 
 ## Notice
 


### PR DESCRIPTION
## WHAT

Added description on how to use private properties as asset selectors 

## WHY

The docs are currently incomplete and the behaviour has changed between 0.5 and 0.7.

## FURTHER NOTES

Not using the "privateProperties." prefix will still show the asset in the catalogue but then it's not negotiatable. A separate defect will be opened on that. 
