### PR TITLE
docs: Correct BPNL Group Validation documentation for a valid Policy with a Collection

### DIFF
--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3.java
@@ -93,7 +93,7 @@ public interface BusinessPartnerGroupApiV3 {
                         "tx": "https://w3id.org/tractusx/v0.0.1/ns/"
                     },
                     "@id": "BPN000001234",
-                    "tx:groups": ["group1", "group2", "group3"]
+                    "tx:groups": "group1,group2,group3"
                 }
                 """;
     }


### PR DESCRIPTION
## WHAT

Correct the documentation for creating a Policy with a constraint to match if the groups a BPNL is assigned are allowed to fetch the respective catalog.

## WHY

Current documentation is not correct

## FURTHER NOTES

Closes #1720
