### PR TITLE
chore: add generated files in 'bin' folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,4 +112,7 @@ buildNumber.properties
 **/*.lock
 **/*.tgz
 
+# Generated bin folders
+**/bin/
+
 edc-tests/miw-tests/src/test/resources/docker-environment/postgres_data/


### PR DESCRIPTION
## WHAT

I had lots of generated files in my workspace, all of them in 'bin' folders. Added the folders to the .gitignore file to get rid of false proposals of unstaged files.

## WHY

To keep the stage area clean

