### PR TITLE
feat: add implementation for Version Protocol Service Stub

### DIFF
--- a/edc-tests/runtime/mock-connector/build.gradle.kts
+++ b/edc-tests/runtime/mock-connector/build.gradle.kts
@@ -38,7 +38,6 @@ dependencies {
     runtimeOnly(libs.edc.boot)
     runtimeOnly(libs.edc.api.management) {
         exclude("org.eclipse.edc", "edr-cache-api")
-        exclude("org.eclipse.edc", "protocol-version-api")
     }
     runtimeOnly(libs.edc.api.management.config)
 

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/MockServiceExtension.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/MockServiceExtension.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.Con
 import org.eclipse.edc.connector.controlplane.services.spi.contractdefinition.ContractDefinitionService;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.connector.controlplane.services.spi.policydefinition.PolicyDefinitionService;
+import org.eclipse.edc.connector.controlplane.services.spi.protocol.VersionProtocolService;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
@@ -44,6 +45,7 @@ import org.eclipse.tractusx.edc.mock.services.ContractDefinitionServiceStub;
 import org.eclipse.tractusx.edc.mock.services.ContractNegotiationServiceStub;
 import org.eclipse.tractusx.edc.mock.services.PolicyDefinitionServiceStub;
 import org.eclipse.tractusx.edc.mock.services.TransferProcessServiceStub;
+import org.eclipse.tractusx.edc.mock.services.VersionProtocolServiceStub;
 
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
@@ -116,6 +118,11 @@ public class MockServiceExtension implements ServiceExtension {
     @Provider
     public TransferProcessService mockTransferProcessService() {
         return new TransferProcessServiceStub(new ResponseQueue(recordedRequests, monitor));
+    }
+
+    @Provider
+    public VersionProtocolService mockVersionProtocolService() {
+        return new VersionProtocolServiceStub(new ResponseQueue(recordedRequests, monitor));
     }
 
 }

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/VersionProtocolServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/VersionProtocolServiceStub.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.mock.services;
+
+import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersions;
+import org.eclipse.edc.connector.controlplane.services.spi.protocol.VersionProtocolService;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.tractusx.edc.mock.ResponseQueue;
+
+public class VersionProtocolServiceStub extends AbstractServiceStub implements VersionProtocolService {
+
+    public VersionProtocolServiceStub(ResponseQueue responseQueue) {
+        super(responseQueue);
+    }
+
+    @Override
+    public ServiceResult<ProtocolVersions> getAll(TokenRepresentation tokenRepresentation) {
+        return responseQueue.getNext(ProtocolVersions.class, "Error retrieving ProtocolVersions: %s");
+    }
+}


### PR DESCRIPTION
## WHAT

Adds implementation for a stub Version Protocol Service, similar to existent [ones](https://github.com/eclipse-tractusx/tractusx-edc/tree/638909cc41370dbc5808318cf59118a793cb4743/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services).

## WHY

To allow mocking the protocol api.

## FURTHER NOTES

Helpful context on this approach: https://github.com/eclipse-tractusx/tractusx-edc/pull/1264

Closes #https://github.com/eclipse-tractusx/tractusx-edc/issues/1733
