### PR TITLE
chore: Add known issues section to readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Build Tractus-X EDC together with its Container Images
 ./gradlew dockerize
 ```
 
+## Known Incompatibilities
+
+- Hashicorp Vault 1.18.1 is not compatible with the EDC due to a bug in the vault concerning path handling
+
 ## License
 
 Distributed under the Apache 2.0 License.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Build Tractus-X EDC together with its Container Images
 ## Known Incompatibilities
 
 - Hashicorp Vault 1.18.1 is not compatible with the EDC due to a bug in the vault concerning path handling
+  - [Internal Issue](https://github.com/eclipse-tractusx/tractusx-edc/issues/1772)
+  - [Hashicorp Vault Issue](https://github.com/hashicorp/vault/issues/29357)
 
 ## License
 


### PR DESCRIPTION
## WHAT

Add a note to the readme to indicate, that Hashicorp Vault 1.18.1 is incompatible with the EDC

## WHY

Discussed in the last weekly, see comment in #1772 

Closes #1772
