### PR TITLE
docs: Added 0.8.X -> 0.9.X migration guide

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -570,7 +570,7 @@ maven/mavencentral/org.eclipse.jetty/jetty-util/11.0.24, EPL-2.0 OR Apache-2.0, 
 maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.24, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.24, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.parsson/parsson/1.1.7, EPL-2.0, approved, ee4j.parsson
-maven/mavencentral/org.flywaydb/flyway-core/11.3.2, , restricted, clearlydefined
+maven/mavencentral/org.flywaydb/flyway-core/11.3.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.flywaydb/flyway-database-postgresql/11.3.2, , restricted, clearlydefined
 maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
@@ -660,7 +660,7 @@ maven/mavencentral/org.yaml/snakeyaml/2.4, Apache-2.0, approved, #19469
 maven/mavencentral/software.amazon.awssdk/annotations/2.29.50, Apache-2.0, approved, #17015
 maven/mavencentral/software.amazon.awssdk/annotations/2.30.21, Apache-2.0, approved, #19166
 maven/mavencentral/software.amazon.awssdk/apache-client/2.29.50, Apache-2.0, approved, #17627
-maven/mavencentral/software.amazon.awssdk/apache-client/2.30.21, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/apache-client/2.30.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/arns/2.29.50, Apache-2.0, approved, #16994
 maven/mavencentral/software.amazon.awssdk/arns/2.30.21, , restricted, clearlydefined
 maven/mavencentral/software.amazon.awssdk/auth/2.29.50, Apache-2.0, approved, #17626
@@ -672,7 +672,7 @@ maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.30.21, Apache-2.0
 maven/mavencentral/software.amazon.awssdk/aws-xml-protocol/2.29.50, Apache-2.0, approved, #17004
 maven/mavencentral/software.amazon.awssdk/aws-xml-protocol/2.30.21, , restricted, clearlydefined
 maven/mavencentral/software.amazon.awssdk/checksums-spi/2.29.50, Apache-2.0, approved, #17010
-maven/mavencentral/software.amazon.awssdk/checksums-spi/2.30.21, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/checksums-spi/2.30.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/checksums/2.29.50, Apache-2.0, approved, #17003
 maven/mavencentral/software.amazon.awssdk/checksums/2.30.21, , restricted, clearlydefined
 maven/mavencentral/software.amazon.awssdk/crt-core/2.29.50, Apache-2.0, approved, #17002
@@ -680,9 +680,9 @@ maven/mavencentral/software.amazon.awssdk/crt-core/2.30.21, , restricted, clearl
 maven/mavencentral/software.amazon.awssdk/endpoints-spi/2.29.50, Apache-2.0, approved, #16996
 maven/mavencentral/software.amazon.awssdk/endpoints-spi/2.30.21, , restricted, clearlydefined
 maven/mavencentral/software.amazon.awssdk/http-auth-aws-eventstream/2.29.50, Apache-2.0, approved, #16995
-maven/mavencentral/software.amazon.awssdk/http-auth-aws-eventstream/2.30.21, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/http-auth-aws-eventstream/2.30.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/http-auth-aws/2.29.50, Apache-2.0, approved, #17001
-maven/mavencentral/software.amazon.awssdk/http-auth-aws/2.30.21, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/http-auth-aws/2.30.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/http-auth-spi/2.29.50, Apache-2.0, approved, #17005
 maven/mavencentral/software.amazon.awssdk/http-auth-spi/2.30.21, , restricted, clearlydefined
 maven/mavencentral/software.amazon.awssdk/http-auth/2.29.50, Apache-2.0, approved, #16998
@@ -717,5 +717,5 @@ maven/mavencentral/software.amazon.awssdk/sts/2.29.50, Apache-2.0, approved, #17
 maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.29.50, Apache-2.0, approved, #17008
 maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.30.21, , restricted, clearlydefined
 maven/mavencentral/software.amazon.awssdk/utils/2.29.50, Apache-2.0, approved, #17625
-maven/mavencentral/software.amazon.awssdk/utils/2.30.21, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/utils/2.30.21, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.eventstream/eventstream/1.0.1, Apache-2.0, approved, clearlydefined

--- a/docs/migration/Version_0.8.x_0.9.x.md
+++ b/docs/migration/Version_0.8.x_0.9.x.md
@@ -1,0 +1,53 @@
+# Migration Guide `0.8.x -> 0.9.x`
+
+This document outlines the necessary changes for migrating your tractusx-edc installation from version 0.8.0 to 0.9.0.
+It also outlines some points that adopters and operators should pay close attention to when migrating from one version
+to another.
+
+This document is not a comprehensive feature list.
+
+
+<!-- TOC -->
+
+* [Migration Guide `0.8.x -> 0.9.x`](#migration-guide-08x---09x)
+    * [1. Strict Policy Definition Validation](#1-strict-policy-definition-validation)
+    * [2. Removal of Azure based distributions](#2-removal-of-azure-based-distributions)
+    * [3. Removed BPNL Group operators](#3-removed-bpnl-group-operators)
+
+<!-- TOC -->
+
+## 1. Strict Policy Definition Validation
+
+A new feature was added with EDC 0.11.0 that requires the connector to perform a deeper validation of a
+policy definition during its creation/update. This feature prevents any new policy definition of having:
+
+- an action, within a rule, that doesn't bound to any evaluation scope
+- a constraint, within a rule, that its leftOperand is not bound to any evaluation scope or any evaluation function.
+
+On simpler terms, it prevents the creation of any policy definition which will evaluate nothing.
+
+This feature is enabled by default in the distributed tractusx-edc helm charts.
+If you don't use the distributed helm chart, and you still require this feature, it can be enabled via configuration
+or environment variable via the following config:
+
+`edc.policy.validation.enabled=true`
+
+## 2. Removal of Azure based distributions
+
+As they were previously marked for deprecation, the azure based distributions were effectively removed and WILL NOT be
+distributed any longer.
+
+If you installation relied on any tractusx-edc `azure-vault` distribution (either docker image or helm chart), please
+be notified that you will no longer find a distribution for this or future releases.
+
+## 3. Removed BPNL Group operators
+
+Special attention is necessary towards policy definitions that contain BPNL group constrains using either the `eq` or
+`neq` operators. These have been deprecated in favor of the `isAllOf`, `isAnyOf` and `isNoneOf` operators.
+
+Additionally, the behavior of the `isAllOf` operator has been fixed since it previously failed validation for BPNLs
+that were assigned to 3 distinct groups, 2 of which were the same as listed in the policy constrain.
+The `isAllOf` now checks if a certain BPNL is assigned to all the groups allowed in the policy definition.
+
+The `IN` operator was also fixed, since it evaluated the same as the faulty `isAllOf` operator.
+It now performs the same as the `isAnyOf` operator.

--- a/docs/migration/Version_0.8.x_0.9.x.md
+++ b/docs/migration/Version_0.8.x_0.9.x.md
@@ -6,12 +6,12 @@ to another.
 
 This document is not a comprehensive feature list.
 
-
 <!-- TOC -->
 * [Migration Guide `0.8.x -> 0.9.x`](#migration-guide-08x---09x)
   * [1. Strict Policy Definition Validation](#1-strict-policy-definition-validation)
   * [2. Removal of Azure based distributions](#2-removal-of-azure-based-distributions)
   * [3. Updated and Deprecated BPNL Group operators](#3-updated-and-deprecated-bpnl-group-operators)
+  * [4. Database Migrations](#4-database-migrations)
 <!-- TOC -->
 
 ## 1. Strict Policy Definition Validation
@@ -49,3 +49,11 @@ The `isAllOf` now checks if a certain BPNL is assigned to all the groups allowed
 
 The `IN` operator was also fixed, since it evaluated the same as the faulty `isAllOf` operator.
 It now performs the same as the `isAnyOf` operator.
+
+## 4. Store Migrations
+
+For connector operators who maintain specific flyway migration files, please be aware of new migrations added
+in these PRs:
+
+- https://github.com/eclipse-tractusx/tractusx-edc/pull/1706
+- https://github.com/eclipse-tractusx/tractusx-edc/pull/1713

--- a/docs/migration/Version_0.8.x_0.9.x.md
+++ b/docs/migration/Version_0.8.x_0.9.x.md
@@ -8,12 +8,10 @@ This document is not a comprehensive feature list.
 
 
 <!-- TOC -->
-
 * [Migration Guide `0.8.x -> 0.9.x`](#migration-guide-08x---09x)
-    * [1. Strict Policy Definition Validation](#1-strict-policy-definition-validation)
-    * [2. Removal of Azure based distributions](#2-removal-of-azure-based-distributions)
-    * [3. Removed BPNL Group operators](#3-removed-bpnl-group-operators)
-
+  * [1. Strict Policy Definition Validation](#1-strict-policy-definition-validation)
+  * [2. Removal of Azure based distributions](#2-removal-of-azure-based-distributions)
+  * [3. Updated and Deprecated BPNL Group operators](#3-updated-and-deprecated-bpnl-group-operators)
 <!-- TOC -->
 
 ## 1. Strict Policy Definition Validation
@@ -40,7 +38,7 @@ distributed any longer.
 If you installation relied on any tractusx-edc `azure-vault` distribution (either docker image or helm chart), please
 be notified that you will no longer find a distribution for this or future releases.
 
-## 3. Removed BPNL Group operators
+## 3. Updated and Deprecated BPNL Group operators
 
 Special attention is necessary towards policy definitions that contain BPNL group constrains using either the `eq` or
 `neq` operators. These have been deprecated in favor of the `isAllOf`, `isAnyOf` and `isNoneOf` operators.

--- a/docs/migration/Version_0.8.x_0.9.x.md
+++ b/docs/migration/Version_0.8.x_0.9.x.md
@@ -11,12 +11,12 @@ This document is not a comprehensive feature list.
   * [1. Strict Policy Definition Validation](#1-strict-policy-definition-validation)
   * [2. Removal of Azure based distributions](#2-removal-of-azure-based-distributions)
   * [3. Updated and Deprecated BPNL Group operators](#3-updated-and-deprecated-bpnl-group-operators)
-  * [4. Database Migrations](#4-database-migrations)
+  * [4. Store Migrations](#4-store-migrations)
 <!-- TOC -->
 
 ## 1. Strict Policy Definition Validation
 
-A new feature was added with EDC 0.11.0 that requires the connector to perform a deeper validation of a
+A new feature was added with upstream EDC 0.11.0 that requires the connector to perform a deeper validation of a
 policy definition during its creation/update. This feature prevents any new policy definition of having:
 
 - an action, within a rule, that doesn't bound to any evaluation scope
@@ -33,15 +33,17 @@ or environment variable via the following config:
 ## 2. Removal of Azure based distributions
 
 As they were previously marked for deprecation, the azure based distributions were effectively removed and WILL NOT be
-distributed any longer.
+distributed any longer. Be aware this has nothing to do with the cloud related extensions we support, such as Azure blob
+or AWS S3 provisioners and dataplanes. Those are still included as part of the base tractusx-edc distribution.
 
 If you installation relied on any tractusx-edc `azure-vault` distribution (either docker image or helm chart), please
-be notified that you will no longer find a distribution for this or future releases.
+also be aware that you will no longer find a distribution for this or future releases.
 
 ## 3. Updated and Deprecated BPNL Group operators
 
 Special attention is necessary towards policy definitions that contain BPNL group constrains using either the `eq` or
-`neq` operators. These have been deprecated in favor of the `isAllOf`, `isAnyOf` and `isNoneOf` operators.
+`neq` operators. These have been deprecated in favor of the `isAllOf`, `isAnyOf` and `isNoneOf` operators which are the
+proper operators for sets.
 
 Additionally, the behavior of the `isAllOf` operator has been fixed since it previously failed validation for BPNLs
 that were assigned to 3 distinct groups, 2 of which were the same as listed in the policy constrain.

--- a/docs/migration/Version_0.8.x_0.9.x.md
+++ b/docs/migration/Version_0.8.x_0.9.x.md
@@ -32,9 +32,10 @@ or environment variable via the following config:
 
 ## 2. Removal of Azure based distributions
 
-As they were previously marked for deprecation, the azure based distributions were effectively removed and WILL NOT be
-distributed any longer. Be aware this has nothing to do with the cloud related extensions we support, such as Azure blob
-or AWS S3 provisioners and dataplanes. Those are still included as part of the base tractusx-edc distribution.
+As they were previously marked for deprecation, the azure vault based distributions were effectively removed and WILL
+NOT
+be distributed any longer. Be aware this has nothing to do with the cloud related extensions we support, such as Azure
+blob or AWS S3 provisioners and dataplanes. Those are still included as part of the base tractusx-edc distribution.ß
 
 If you installation relied on any tractusx-edc `azure-vault` distribution (either docker image or helm chart), please
 also be aware that you will no longer find a distribution for this or future releases.

--- a/docs/migration/Version_0.8.x_0.9.x.md
+++ b/docs/migration/Version_0.8.x_0.9.x.md
@@ -24,11 +24,11 @@ policy definition during its creation/update. This feature prevents any new poli
 
 On simpler terms, it prevents the creation of any policy definition which will evaluate nothing.
 
-This feature is enabled by default in the distributed tractusx-edc helm charts.
-If you don't use the distributed helm chart, and you still require this feature, it can be enabled via configuration
-or environment variable via the following config:
+This feature is enabled by default in the distributed tractusx-edc helm charts. In order to disable the feature or
+if you don't use the distributed helm chart, and you want to enable this feature, it can be toggled via configuration
+or environment variable using the following config:
 
-`edc.policy.validation.enabled=true`
+`edc.policy.validation.enabled=true|false`
 
 ## 2. Removal of Azure based distributions
 


### PR DESCRIPTION
## WHAT & WHY

Adds a guide to aid migration from tractusx-edc 0.8.X to 0.9.X.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #1784 
