### PR TITLE
Add dataplane proxy public api extension module

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -17,7 +17,7 @@ maven/mavencentral/com.azure/azure-core-http-netty/1.15.7, MIT AND Apache-2.0, a
 maven/mavencentral/com.azure/azure-core/1.54.0, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-core/1.54.1, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-core/1.55.2, MIT, approved, clearlydefined
-maven/mavencentral/com.azure/azure-core/1.55.3, , restricted, clearlydefined
+maven/mavencentral/com.azure/azure-core/1.55.3, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-identity/1.15.0, MIT, approved, #18662
 maven/mavencentral/com.azure/azure-json/1.3.0, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-json/1.4.0, MIT, approved, clearlydefined
@@ -324,6 +324,7 @@ maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.72, MIT, approved, #3789
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.80, MIT, approved, #18697
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.72, MIT AND CC0-1.0, approved, #3538
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.80, MIT AND CC0-1.0, approved, #18694
+maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.72, MIT, approved, #3790
 maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.48.3, MIT, approved, #17162
@@ -398,7 +399,6 @@ maven/mavencentral/org.eclipse.edc/data-plane-http-spi/0.12.0, Apache-2.0, appro
 maven/mavencentral/org.eclipse.edc/data-plane-http/0.12.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-iam/0.12.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-instance-store-sql/0.12.0, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/data-plane-public-api-v2/0.12.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-selector-client/0.12.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-selector-control-api/0.12.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-selector-core/0.12.0, Apache-2.0, approved, technology.edc

--- a/edc-dataplane/edc-dataplane-base/build.gradle.kts
+++ b/edc-dataplane/edc-dataplane-base/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     runtimeOnly(project(":edc-extensions:dataplane:dataplane-proxy:edc-dataplane-proxy-consumer-api"))
     runtimeOnly(project(":edc-extensions:dataplane:dataplane-token-refresh:token-refresh-core"))
     runtimeOnly(project(":edc-extensions:dataplane:dataplane-token-refresh:token-refresh-api"))
+    runtimeOnly(project(":edc-extensions:dataplane:dataplane-proxy:dataplane-public-api-v2"))
 
     runtimeOnly(libs.edc.jsonld) // needed by the DataPlaneSignalingApi
     runtimeOnly(libs.edc.core.did) // for the DID Public Key Resolver
@@ -50,7 +51,6 @@ dependencies {
     runtimeOnly(libs.edc.dpf.api.signaling)
 
     runtimeOnly(libs.edc.api.control.config)
-    runtimeOnly(libs.edc.dpf.api.public.v2)
     runtimeOnly(libs.edc.core.connector)
     runtimeOnly(libs.edc.boot)
     runtimeOnly(libs.edc.core.edrstore)

--- a/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/build.gradle.kts
+++ b/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/build.gradle.kts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2022 Microsoft Corporation - initial API and implementation
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ * Copyright (c) 2024 Mercedes-Benz Tech Innovation GmbH - publish public api context into dedicated swagger hub page
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+plugins {
+    `java-library`
+    id(libs.plugins.swagger.get().pluginId)
+}
+
+dependencies {
+    api(libs.edc.spi.http)
+    api(libs.edc.spi.web)
+    api(libs.edc.spi.dataplane.dataplane)
+    implementation(libs.edc.lib.util)
+
+    implementation(libs.edc.dpf.util)
+    implementation(libs.jakarta.rsApi)
+
+    testImplementation(libs.edc.ext.http)
+    testImplementation(libs.edc.junit)
+    testImplementation(libs.edc.core.jersey)
+
+    testImplementation(libs.restAssured)
+    testImplementation(libs.netty.mockserver)
+    testImplementation(testFixtures(libs.edc.core.jersey))
+}
+edcBuild {
+    swagger {
+        apiGroup.set("public-api")
+    }
+}
+
+

--- a/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/api/DataPlanePublicApiV2Extension.java
+++ b/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/api/DataPlanePublicApiV2Extension.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+package org.eclipse.tractusx.edc.dataplane.proxy.api;
+
+import org.eclipse.edc.connector.dataplane.spi.Endpoint;
+import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAuthorizationService;
+import org.eclipse.edc.connector.dataplane.spi.iam.PublicEndpointGeneratorService;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+import org.eclipse.edc.spi.system.ExecutorInstrumentation;
+import org.eclipse.edc.spi.system.Hostname;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+import org.eclipse.edc.web.spi.configuration.PortMapping;
+import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
+import org.eclipse.tractusx.edc.dataplane.proxy.api.controller.DataPlanePublicApiV2Controller;
+
+import java.util.concurrent.Executors;
+
+/**
+ * This extension provides generic endpoints which are open to public participants of the Dataspace to execute
+ * requests on the actual data source.
+ */
+@Extension(value = DataPlanePublicApiV2Extension.NAME)
+public class DataPlanePublicApiV2Extension implements ServiceExtension {
+    public static final String NAME = "Data Plane Public API";
+
+    private static final int DEFAULT_PUBLIC_PORT = 8185;
+    private static final String DEFAULT_PUBLIC_PATH = "/api/public";
+    private static final int DEFAULT_THREAD_POOL = 10;
+    @Setting(description = "Base url of the public API endpoint without the trailing slash. This should point to the public endpoint configured.",
+            required = false,
+            key = "edc.dataplane.api.public.baseurl", warnOnMissingConfig = true)
+    private String publicBaseUrl;
+    @Setting(description = "Optional base url of the response channel endpoint without the trailing slash. A common practice is to use <PUBLIC_ENDPOINT>/responseChannel", key = "edc.dataplane.api.public.response.baseurl", required = false)
+    private String publicApiResponseUrl;
+    @Configuration
+    private PublicApiConfiguration apiConfiguration;
+    @Inject
+    private PortMappingRegistry portMappingRegistry;
+    @Inject
+    private PipelineService pipelineService;
+    @Inject
+    private WebService webService;
+    @Inject
+    private ExecutorInstrumentation executorInstrumentation;
+    @Inject
+    private DataPlaneAuthorizationService authorizationService;
+    @Inject
+    private PublicEndpointGeneratorService generatorService;
+    @Inject
+    private Hostname hostname;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var portMapping = new PortMapping(ApiContext.PUBLIC, apiConfiguration.port(), apiConfiguration.path());
+        portMappingRegistry.register(portMapping);
+        var executorService = executorInstrumentation.instrument(
+                Executors.newFixedThreadPool(DEFAULT_THREAD_POOL),
+                "Data plane proxy transfers"
+        );
+
+        if (publicBaseUrl == null) {
+            publicBaseUrl = "http://%s:%d%s".formatted(hostname.get(), portMapping.port(), portMapping.path());
+            context.getMonitor().warning("The public API endpoint was not explicitly configured, the default '%s' will be used.".formatted(publicBaseUrl));
+        }
+        var endpoint = Endpoint.url(publicBaseUrl);
+        generatorService.addGeneratorFunction("HttpData", dataAddress -> endpoint);
+
+        if (publicApiResponseUrl != null) {
+            generatorService.addGeneratorFunction("HttpData", () -> Endpoint.url(publicApiResponseUrl));
+        }
+
+        var publicApiController = new DataPlanePublicApiV2Controller(pipelineService, executorService, authorizationService);
+        webService.registerResource(ApiContext.PUBLIC, publicApiController);
+    }
+
+    @Settings
+    record PublicApiConfiguration(
+            @Setting(key = "web.http." + ApiContext.PUBLIC + ".port", description = "Port for " + ApiContext.PUBLIC + " api context", defaultValue = DEFAULT_PUBLIC_PORT + "")
+            int port,
+            @Setting(key = "web.http." + ApiContext.PUBLIC + ".path", description = "Path for " + ApiContext.PUBLIC + " api context", defaultValue = DEFAULT_PUBLIC_PATH)
+            String path
+    ) {
+
+    }
+}

--- a/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/api/controller/ContainerRequestContextApi.java
+++ b/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/api/controller/ContainerRequestContextApi.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2022 Amadeus - initial API and implementation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+package org.eclipse.tractusx.edc.dataplane.proxy.api.controller;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+
+import java.util.Map;
+
+/**
+ * Wrapper around {@link ContainerRequestContext} enabling mocking.
+ */
+public interface ContainerRequestContextApi {
+
+    /**
+     * Get the request headers. Note that if more than one value is associated to a specific header,
+     * only the first one is retained.
+     *
+     * @return Headers map.
+     */
+    Map<String, String> headers();
+
+    /**
+     * Format query of the request as string, e.g. "hello=world\&amp;foo=bar".
+     *
+     * @return Query param string.
+     */
+    String queryParams();
+
+    /**
+     * Format the request body into a string.
+     *
+     * @return Request body.
+     */
+    String body();
+
+    /**
+     * Get the media type from incoming request.
+     *
+     * @return Media type.
+     */
+    String mediaType();
+
+    /**
+     * Return request path, e.g. "hello/world/foo/bar".
+     *
+     * @return Path string.
+     */
+    String path();
+
+    /**
+     * Get http method from the incoming request, e.g. "GET", "POST"...
+     *
+     * @return Http method.
+     */
+    String method();
+}

--- a/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/api/controller/ContainerRequestContextApiImpl.java
+++ b/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/api/controller/ContainerRequestContextApiImpl.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2022 Amadeus - initial API and implementation
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - allow multiple identical query params
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+package org.eclipse.tractusx.edc.dataplane.proxy.api.controller;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.edc.spi.EdcException;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * This class provides a set of API wrapping a {@link ContainerRequestContext}.
+ */
+public class ContainerRequestContextApiImpl implements ContainerRequestContextApi {
+
+    private static final String QUERY_PARAM_SEPARATOR = "&";
+
+    private final ContainerRequestContext context;
+
+    public ContainerRequestContextApiImpl(ContainerRequestContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public Map<String, String> headers() {
+        return context.getHeaders().entrySet()
+                .stream()
+                .filter(entry -> !entry.getValue().isEmpty())
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().get(0)));
+    }
+
+    @Override
+    public String queryParams() {
+        return context.getUriInfo().getQueryParameters().entrySet()
+                .stream()
+                .flatMap(entry -> entry.getValue().stream().map(val -> new QueryParam(entry.getKey(), val)))
+                .map(QueryParam::toString)
+                .collect(Collectors.joining(QUERY_PARAM_SEPARATOR));
+    }
+
+    @Override
+    public String body() {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(context.getEntityStream()))) {
+            return br.lines().collect(Collectors.joining("\n"));
+        } catch (IOException e) {
+            throw new EdcException("Failed to read request body: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public String mediaType() {
+        return Optional.ofNullable(context.getMediaType())
+                .map(MediaType::toString)
+                .orElse(null);
+    }
+
+    @Override
+    public String path() {
+        var pathInfo = context.getUriInfo().getPath();
+        return pathInfo.startsWith("/") ? pathInfo.substring(1) : pathInfo;
+    }
+
+    @Override
+    public String method() {
+        return context.getMethod();
+    }
+
+    private static final class QueryParam {
+
+        private final String key;
+        private final String values;
+        private final boolean valid;
+
+        private QueryParam(String key, String values) {
+            this.key = key;
+            this.values = values;
+            this.valid = key != null && values != null && !values.isEmpty();
+        }
+
+        public boolean isValid() {
+            return valid;
+        }
+
+        @Override
+        public String toString() {
+            return valid ? key + "=" + values : "";
+        }
+    }
+}

--- a/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/api/controller/DataFlowRequestSupplier.java
+++ b/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/api/controller/DataFlowRequestSupplier.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2022 Amadeus - initial API and implementation
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - make it a PULL request by default
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+package org.eclipse.tractusx.edc.dataplane.proxy.api.controller;
+
+import org.eclipse.edc.connector.dataplane.util.sink.AsyncStreamingDataSink;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.edc.spi.types.domain.transfer.FlowType;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.BiFunction;
+
+import static org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSchema.BODY;
+import static org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSchema.MEDIA_TYPE;
+import static org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSchema.METHOD;
+import static org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSchema.PATH;
+import static org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSchema.QUERY_PARAMS;
+
+public class DataFlowRequestSupplier implements BiFunction<ContainerRequestContextApi, DataAddress, DataFlowStartMessage> {
+
+    /**
+     * Put all properties of the incoming request (method, request body, query params...) into a map.
+     */
+    private static Map<String, String> createProps(ContainerRequestContextApi contextApi) {
+        var props = new HashMap<String, String>();
+        props.put(METHOD, contextApi.method());
+        props.put(QUERY_PARAMS, contextApi.queryParams());
+        props.put(PATH, contextApi.path());
+        Optional.ofNullable(contextApi.mediaType())
+                .ifPresent(mediaType -> {
+                    props.put(MEDIA_TYPE, mediaType);
+                    props.put(BODY, contextApi.body());
+                });
+        return props;
+    }
+
+    /**
+     * Create a {@link DataFlowStartMessage} based on incoming request and claims decoded from the access token.
+     *
+     * @param contextApi  Api for accessing request properties.
+     * @param dataAddress Source data address.
+     * @return DataFlowRequest
+     */
+    @Override
+    public DataFlowStartMessage apply(ContainerRequestContextApi contextApi, DataAddress dataAddress) {
+        var props = createProps(contextApi);
+        return DataFlowStartMessage.Builder.newInstance()
+                .processId(UUID.randomUUID().toString())
+                .sourceDataAddress(dataAddress)
+                .flowType(FlowType.PULL) // if a request hits the public DP API, we can assume a PULL transfer
+                .destinationDataAddress(DataAddress.Builder.newInstance()
+                        .type(AsyncStreamingDataSink.TYPE)
+                        .build())
+                .id(UUID.randomUUID().toString())
+                .properties(props)
+                .build();
+    }
+}

--- a/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/api/controller/DataPlanePublicApiV2.java
+++ b/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/api/controller/DataPlanePublicApiV2.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2022 Amadeus - Initial implementation
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - handle HEAD requests
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+package org.eclipse.tractusx.edc.dataplane.proxy.api.controller;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.ContainerRequestContext;
+
+@OpenAPIDefinition
+@Tag(name = "Data Plane public API",
+        description = "The public API of the Data Plane is a data proxy enabling a data consumer to actively query" +
+                "data from the provider data source (e.g. backend Rest API, internal database...) through its Data Plane" +
+                "instance. Thus the Data Plane is the only entry/output door for the data, which avoids the provider to expose" +
+                "directly its data externally." +
+                "The Data Plane public API being a proxy, it supports all verbs (i.e. GET, POST, PUT, PATCH, DELETE), which" +
+                "can then conveyed until the data source is required. This is especially useful when the actual data source" +
+                "is a Rest API itself." +
+                "In the same manner, any set of arbitrary query parameters, path parameters and request body are supported " +
+                "(in the limits fixed by the HTTP server) and can also conveyed to the actual data source.")
+public interface DataPlanePublicApiV2 {
+
+    @Operation(description = "Send `GET` data query to the Data Plane.",
+            responses = {
+                    @ApiResponse(responseCode = "400", description = "Missing access token"),
+                    @ApiResponse(responseCode = "403", description = "Access token is expired or invalid"),
+                    @ApiResponse(responseCode = "500", description = "Failed to transfer data")
+            }
+    )
+    void get(ContainerRequestContext context, AsyncResponse response);
+
+    @Operation(description = "Send `HEAD` data query to the Data Plane.",
+            responses = {
+                    @ApiResponse(responseCode = "400", description = "Missing access token"),
+                    @ApiResponse(responseCode = "403", description = "Access token is expired or invalid"),
+                    @ApiResponse(responseCode = "500", description = "Failed to transfer data")
+            }
+    )
+    void head(ContainerRequestContext context, AsyncResponse response);
+
+    @Operation(description = "Send `POST` data query to the Data Plane.",
+            responses = {
+                    @ApiResponse(responseCode = "400", description = "Missing access token"),
+                    @ApiResponse(responseCode = "403", description = "Access token is expired or invalid"),
+                    @ApiResponse(responseCode = "500", description = "Failed to transfer data")
+            }
+    )
+    void post(ContainerRequestContext context, AsyncResponse response);
+
+    @Operation(description = "Send `PUT` data query to the Data Plane.",
+            responses = {
+                    @ApiResponse(responseCode = "400", description = "Missing access token"),
+                    @ApiResponse(responseCode = "403", description = "Access token is expired or invalid"),
+                    @ApiResponse(responseCode = "500", description = "Failed to transfer data")
+            }
+    )
+    void put(ContainerRequestContext context, AsyncResponse response);
+
+    @Operation(description = "Send `DELETE` data query to the Data Plane.",
+            responses = {
+                    @ApiResponse(responseCode = "400", description = "Missing access token"),
+                    @ApiResponse(responseCode = "403", description = "Access token is expired or invalid"),
+                    @ApiResponse(responseCode = "500", description = "Failed to transfer data")
+            }
+    )
+    void delete(ContainerRequestContext context, AsyncResponse response);
+
+    @Operation(description = "Send `PATCH` data query to the Data Plane.",
+            responses = {
+                    @ApiResponse(responseCode = "400", description = "Missing access token"),
+                    @ApiResponse(responseCode = "403", description = "Access token is expired or invalid"),
+                    @ApiResponse(responseCode = "500", description = "Failed to transfer data")
+            }
+    )
+    void patch(ContainerRequestContext context, AsyncResponse response);
+}

--- a/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/api/controller/DataPlanePublicApiV2Controller.java
+++ b/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/api/controller/DataPlanePublicApiV2Controller.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+package org.eclipse.tractusx.edc.dataplane.proxy.api.controller;
+
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HEAD;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAuthorizationService;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
+import org.eclipse.edc.connector.dataplane.spi.response.TransferErrorResponse;
+import org.eclipse.edc.connector.dataplane.util.sink.AsyncStreamingDataSink;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.WILDCARD;
+import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
+import static jakarta.ws.rs.core.Response.status;
+
+@Path("{any:.*}")
+@Produces(WILDCARD)
+public class DataPlanePublicApiV2Controller implements DataPlanePublicApiV2 {
+
+    private final PipelineService pipelineService;
+    private final DataFlowRequestSupplier requestSupplier;
+    private final ExecutorService executorService;
+    private final DataPlaneAuthorizationService authorizationService;
+
+    public DataPlanePublicApiV2Controller(PipelineService pipelineService,
+                                          ExecutorService executorService,
+                                          DataPlaneAuthorizationService authorizationService) {
+        this.pipelineService = pipelineService;
+        this.authorizationService = authorizationService;
+        this.requestSupplier = new DataFlowRequestSupplier();
+        this.executorService = executorService;
+    }
+
+    private static Response error(Response.Status status, List<String> errors) {
+        return status(status).type(APPLICATION_JSON).entity(new TransferErrorResponse(errors)).build();
+    }
+
+    @GET
+    @Override
+    public void get(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response) {
+        handle(requestContext, response);
+    }
+
+    @HEAD
+    @Override
+    public void head(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response) {
+        handle(requestContext, response);
+    }
+
+    /**
+     * Sends a {@link POST} request to the data source and returns data.
+     *
+     * @param requestContext Request context.
+     * @param response       Data fetched from the data source.
+     */
+    @POST
+    @Override
+    public void post(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response) {
+        handle(requestContext, response);
+    }
+
+    /**
+     * Sends a {@link PUT} request to the data source and returns data.
+     *
+     * @param requestContext Request context.
+     * @param response       Data fetched from the data source.
+     */
+    @PUT
+    @Override
+    public void put(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response) {
+        handle(requestContext, response);
+    }
+
+    /**
+     * Sends a {@link DELETE} request to the data source and returns data.
+     *
+     * @param requestContext Request context.
+     * @param response       Data fetched from the data source.
+     */
+    @DELETE
+    @Override
+    public void delete(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response) {
+        handle(requestContext, response);
+    }
+
+    /**
+     * Sends a {@link PATCH} request to the data source and returns data.
+     *
+     * @param requestContext Request context.
+     * @param response       Data fetched from the data source.
+     */
+    @PATCH
+    @Override
+    public void patch(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response) {
+        handle(requestContext, response);
+    }
+
+    private void handle(ContainerRequestContext requestContext, AsyncResponse response) {
+        var contextApi = new ContainerRequestContextApiImpl(requestContext);
+
+        var token = contextApi.headers().get(HttpHeaders.AUTHORIZATION);
+        if (token == null) {
+            response.resume(error(UNAUTHORIZED, List.of("Missing Authorization Header")));
+            return;
+        }
+
+        var sourceDataAddress = authorizationService.authorize(token, buildRequestData(requestContext));
+        if (sourceDataAddress.failed()) {
+            response.resume(error(FORBIDDEN, sourceDataAddress.getFailureMessages()));
+            return;
+        }
+
+        var startMessage = requestSupplier.apply(contextApi, sourceDataAddress.getContent());
+
+        processRequest(startMessage, response);
+    }
+
+    private Map<String, Object> buildRequestData(ContainerRequestContext requestContext) {
+        var requestData = new HashMap<String, Object>();
+        requestData.put("headers", requestContext.getHeaders());
+        requestData.put("path", requestContext.getUriInfo());
+        requestData.put("method", requestContext.getMethod());
+        requestData.put("content-type", requestContext.getMediaType());
+        return requestData;
+    }
+
+    private void processRequest(DataFlowStartMessage dataFlowStartMessage, AsyncResponse response) {
+
+        AsyncStreamingDataSink.AsyncResponseContext asyncResponseContext = callback -> {
+            StreamingOutput output = t -> callback.outputStreamConsumer().accept(t);
+            var resp = Response.ok(output).type(callback.mediaType()).build();
+            return response.resume(resp);
+        };
+
+        var sink = new AsyncStreamingDataSink(asyncResponseContext, executorService);
+
+        pipelineService.transfer(dataFlowStartMessage, sink)
+                .whenComplete((result, throwable) -> {
+                    if (throwable == null) {
+                        if (result.failed()) {
+                            response.resume(error(INTERNAL_SERVER_ERROR, result.getFailureMessages()));
+                        }
+                    } else {
+                        var error = "Unhandled exception occurred during data transfer: " + throwable.getMessage();
+                        response.resume(error(INTERNAL_SERVER_ERROR, List.of(error)));
+                    }
+                });
+    }
+
+}

--- a/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,20 @@
+#################################################################################
+#  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+org.eclipse.tractusx.edc.dataplane.proxy.api.DataPlanePublicApiV2Extension

--- a/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/resources/public-api-version.json
+++ b/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/resources/public-api-version.json
@@ -1,0 +1,8 @@
+[
+  {
+    "version": "2.0.1",
+    "urlPath": "/v2",
+    "lastUpdated": "2024-07-10T08:56:00Z",
+    "maturity": "stable"
+  }
+]

--- a/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/test/java/org/eclipse/tractusx/edc/dataplane/proxy/api/controller/DataFlowStartMessageSupplierTest.java
+++ b/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/test/java/org/eclipse/tractusx/edc/dataplane/proxy/api/controller/DataFlowStartMessageSupplierTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2022 Amadeus - initial API and implementation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+package org.eclipse.tractusx.edc.dataplane.proxy.api.controller;
+
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSchema;
+import org.eclipse.edc.connector.dataplane.util.sink.AsyncStreamingDataSink;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DataFlowStartMessageSupplierTest {
+
+
+    private final DataFlowRequestSupplier supplier = new DataFlowRequestSupplier();
+
+    private static DataAddress createDataAddress() {
+        return DataAddress.Builder.newInstance().type("test-type").build();
+    }
+
+    @Test
+    void verifyMapping_noInputBody() {
+        var contextApi = mock(ContainerRequestContextApi.class);
+        var address = createDataAddress();
+
+        var method = HttpMethod.GET;
+        var queryParams = "test-query-param";
+        var path = "test-path";
+
+        when(contextApi.method()).thenReturn(method);
+        when(contextApi.queryParams()).thenReturn(queryParams);
+        when(contextApi.path()).thenReturn(path);
+
+        var request = supplier.apply(contextApi, address);
+
+        assertThat(request.getId()).isNotBlank();
+        assertThat(request.getDestinationDataAddress().getType()).isEqualTo(AsyncStreamingDataSink.TYPE);
+        assertThat(request.getSourceDataAddress().getType()).isEqualTo(address.getType());
+        assertThat(request.getProperties()).containsExactlyInAnyOrderEntriesOf(Map.of(
+                DataFlowRequestSchema.PATH, path,
+                DataFlowRequestSchema.METHOD, method,
+                DataFlowRequestSchema.QUERY_PARAMS, queryParams
+
+        ));
+    }
+
+    @Test
+    void verifyMapping_withInputBody() {
+        var contextApi = mock(ContainerRequestContextApi.class);
+        var address = createDataAddress();
+
+        var method = HttpMethod.GET;
+        var queryParams = "test-query-param";
+        var path = "test-path";
+        var body = "Test request body";
+
+        when(contextApi.method()).thenReturn(method);
+        when(contextApi.queryParams()).thenReturn(queryParams);
+        when(contextApi.path()).thenReturn(path);
+        when(contextApi.mediaType()).thenReturn(MediaType.TEXT_PLAIN);
+        when(contextApi.body()).thenReturn(body);
+
+        var request = supplier.apply(contextApi, address);
+
+        assertThat(request.getId()).isNotBlank();
+        assertThat(request.getDestinationDataAddress().getType()).isEqualTo(AsyncStreamingDataSink.TYPE);
+        assertThat(request.getSourceDataAddress().getType()).isEqualTo(address.getType());
+        assertThat(request.getProperties()).containsExactlyInAnyOrderEntriesOf(Map.of(
+                DataFlowRequestSchema.PATH, path,
+                DataFlowRequestSchema.METHOD, method,
+                DataFlowRequestSchema.QUERY_PARAMS, queryParams,
+                DataFlowRequestSchema.BODY, body,
+                DataFlowRequestSchema.MEDIA_TYPE, MediaType.TEXT_PLAIN
+        ));
+    }
+}

--- a/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/test/java/org/eclipse/tractusx/edc/dataplane/proxy/api/controller/DataPlanePublicApiV2ControllerTest.java
+++ b/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/test/java/org/eclipse/tractusx/edc/dataplane/proxy/api/controller/DataPlanePublicApiV2ControllerTest.java
@@ -1,0 +1,231 @@
+/**
+ * Copyright (c) 2022 Amadeus - initial API and implementation
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **/
+
+package org.eclipse.tractusx.edc.dataplane.proxy.api.controller;
+
+import io.restassured.specification.RequestSpecification;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAuthorizationService;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamFailure;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
+import org.eclipse.edc.connector.dataplane.spi.resolver.DataAddressResolver;
+import org.eclipse.edc.connector.dataplane.util.sink.AsyncStreamingDataSink;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.stream.Stream;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.hamcrest.CoreMatchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ApiTest
+class DataPlanePublicApiV2ControllerTest extends RestControllerTestBase {
+
+    private final PipelineService pipelineService = mock();
+    private final DataAddressResolver dataAddressResolver = mock();
+    private final DataPlaneAuthorizationService authorizationService = mock();
+
+    @BeforeEach
+    void setup() {
+        when(authorizationService.authorize(anyString(), anyMap()))
+                .thenReturn(Result.success(testDestAddress()));
+    }
+
+    @Test
+    void should_returnBadRequest_if_missingAuthorizationHeader() {
+        baseRequest()
+                .post("/any")
+                .then()
+                .statusCode(Response.Status.UNAUTHORIZED.getStatusCode())
+                .body("errors[0]", is("Missing Authorization Header"));
+    }
+
+    @Test
+    void shouldNotReturn302_whenUrlWithoutTrailingSlash() {
+        baseRequest()
+                .post("")
+                .then()
+                .statusCode(not(302));
+    }
+
+    @Test
+    void should_returnForbidden_if_tokenValidationFails() {
+        var token = UUID.randomUUID().toString();
+        when(authorizationService.authorize(anyString(), anyMap())).thenReturn(Result.failure("token is not valid"));
+
+        baseRequest()
+                .header(AUTHORIZATION, token)
+                .post("/any")
+                .then()
+                .statusCode(Response.Status.FORBIDDEN.getStatusCode())
+                .contentType(JSON)
+                .body("errors.size()", is(1));
+
+        verify(authorizationService).authorize(eq(token), anyMap());
+    }
+
+    @Test
+    void should_returnInternalServerError_if_transferFails() {
+        var token = UUID.randomUUID().toString();
+        var errorMsg = UUID.randomUUID().toString();
+        when(dataAddressResolver.resolve(any())).thenReturn(Result.success(testDestAddress()));
+        when(pipelineService.transfer(any(), any()))
+                .thenReturn(completedFuture(StreamResult.error(errorMsg)));
+
+        baseRequest()
+                .header(AUTHORIZATION, token)
+                .when()
+                .post("/any")
+                .then()
+                .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
+                .contentType(JSON)
+                .body("errors[0]", is(errorMsg));
+    }
+    
+    @Test
+    void should_returnListOfErrorsAsResponse_if_anythingFails() {
+        var token = UUID.randomUUID().toString();
+        var firstErrorMsg = UUID.randomUUID().toString();
+        var secondErrorMsg = UUID.randomUUID().toString();
+
+        when(dataAddressResolver.resolve(any())).thenReturn(Result.success(testDestAddress()));
+        when(pipelineService.transfer(any(), any()))
+                .thenReturn(completedFuture(StreamResult.failure(new StreamFailure(List.of(firstErrorMsg, secondErrorMsg), StreamFailure.Reason.GENERAL_ERROR))));
+
+        baseRequest()
+                .header(AUTHORIZATION, token)
+                .when()
+                .post("/any")
+                .then()
+                .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
+                .contentType(JSON)
+                .body("errors", isA(List.class))
+                .body("errors[0]", is(firstErrorMsg))
+                .body("errors[1]", is(secondErrorMsg));
+    }
+
+    @Test
+    void should_returnInternalServerError_if_transferThrows() {
+        var token = UUID.randomUUID().toString();
+        var errorMsg = UUID.randomUUID().toString();
+        when(dataAddressResolver.resolve(any())).thenReturn(Result.success(testDestAddress()));
+        when(pipelineService.transfer(any(DataFlowStartMessage.class), any()))
+                .thenReturn(failedFuture(new RuntimeException(errorMsg)));
+
+        baseRequest()
+                .header(AUTHORIZATION, token)
+                .when()
+                .post("/any")
+                .then()
+                .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
+                .contentType(JSON)
+                .body("errors[0]", is("Unhandled exception occurred during data transfer: " + errorMsg));
+    }
+
+    @Test
+    void shouldStreamSourceToResponse() {
+        when(dataAddressResolver.resolve(any())).thenReturn(Result.success(testDestAddress()));
+        when(pipelineService.transfer(any(), any())).thenAnswer(i -> {
+            ((AsyncStreamingDataSink) i.getArgument(1)).transfer(new TestDataSource("application/something", "data"));
+            return CompletableFuture.completedFuture(StreamResult.success());
+        });
+
+        var responseBody = baseRequest()
+                .header(AUTHORIZATION, UUID.randomUUID().toString())
+                .when()
+                .post("/any?foo=bar")
+                .then()
+                .log().ifError()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .contentType("application/something")
+                .extract().body().asString();
+
+        assertThat(responseBody).isEqualTo("data");
+        var requestCaptor = ArgumentCaptor.forClass(DataFlowStartMessage.class);
+        verify(pipelineService).transfer(requestCaptor.capture(), any());
+        var request = requestCaptor.getValue();
+        assertThat(request.getDestinationDataAddress().getType()).isEqualTo(AsyncStreamingDataSink.TYPE);
+        assertThat(request.getSourceDataAddress().getType()).isEqualTo("test");
+        assertThat(request.getProperties()).containsEntry("method", "POST").containsEntry("pathSegments", "any").containsEntry("queryParams", "foo=bar");
+    }
+
+    @Override
+    protected Object controller() {
+        return new DataPlanePublicApiV2Controller(pipelineService, Executors.newSingleThreadExecutor(), authorizationService);
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port)
+                .when();
+    }
+
+    private DataAddress testDestAddress() {
+        return DataAddress.Builder.newInstance().type("test").build();
+    }
+
+    private record TestDataSource(String mediaType, String data) implements DataSource, DataSource.Part {
+
+        @Override
+        public StreamResult<Stream<Part>> openPartStream() {
+            return StreamResult.success(Stream.of(this));
+        }
+
+        @Override
+        public String name() {
+            return "test";
+        }
+
+        @Override
+        public InputStream openStream() {
+            return new ByteArrayInputStream(data.getBytes());
+        }
+
+    }
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -177,7 +177,6 @@ edc-dpf-util = { module = "org.eclipse.edc:data-plane-util", version.ref = "edc"
 
 edc-dpf-http = { module = "org.eclipse.edc:data-plane-http", version.ref = "edc" }
 edc-dpf-oauth2 = { module = "org.eclipse.edc:data-plane-http-oauth2", version.ref = "edc" }
-edc-dpf-api-public-v2 = { module = "org.eclipse.edc:data-plane-public-api-v2", version.ref = "edc" }
 
 edc-dpf-api-signaling = { module = "org.eclipse.edc:data-plane-signaling-api", version.ref = "edc" }
 edc-data-plane-self-registration = { module = "org.eclipse.edc:data-plane-self-registration", version.ref = "edc" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -65,6 +65,7 @@ include(":edc-extensions:dataplane:dataplane-proxy:edc-dataplane-proxy-consumer-
 include(":edc-extensions:dataplane:dataplane-selector-configuration")
 include(":edc-extensions:dataplane:dataplane-token-refresh:token-refresh-core")
 include(":edc-extensions:dataplane:dataplane-token-refresh:token-refresh-api")
+include(":edc-extensions:dataplane:dataplane-proxy:dataplane-public-api-v2")
 
 // test modules
 include(":edc-tests:e2e-fixtures")


### PR DESCRIPTION
## WHAT

Adds `dataplane-public-api-v2` in `dataplane` extensions.

## WHY

As the `data-plane-public-api-v2` will be deprecated in the upstream, this PR adds an extension for this proxy implementation.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #1780
