### PR TITLE
refactor: cleanup test dependencies

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -17,7 +17,7 @@ maven/mavencentral/com.azure/azure-core-http-netty/1.15.7, MIT AND Apache-2.0, a
 maven/mavencentral/com.azure/azure-core/1.54.0, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-core/1.54.1, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-core/1.55.2, MIT, approved, clearlydefined
-maven/mavencentral/com.azure/azure-core/1.55.3, , restricted, clearlydefined
+maven/mavencentral/com.azure/azure-core/1.55.3, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-identity/1.15.0, MIT, approved, #18662
 maven/mavencentral/com.azure/azure-json/1.3.0, MIT, approved, clearlydefined
 maven/mavencentral/com.azure/azure-json/1.4.0, MIT, approved, clearlydefined
@@ -612,10 +612,8 @@ maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib/1.9.10, Apache-2.0, approv
 maven/mavencentral/org.jetbrains/annotations/13.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/17.0.0, Apache-2.0, approved, #19678
 maven/mavencentral/org.jetbrains/annotations/26.0.2, Apache-2.0, approved, #16629
-maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.11.4, EPL-2.0, approved, #15935
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.12.0, EPL-2.0, approved, #19509
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.12.0, EPL-2.0, approved, #19514
-maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.11.4, EPL-2.0, approved, #15940
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.12.0, EPL-2.0, approved, #19517
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.12.0, EPL-2.0, approved, #19511
 maven/mavencentral/org.junit.platform/junit-platform-engine/1.12.0, EPL-2.0, approved, #19519

--- a/edc-extensions/agreements/retirement-evaluation-core/build.gradle.kts
+++ b/edc-extensions/agreements/retirement-evaluation-core/build.gradle.kts
@@ -37,6 +37,4 @@ dependencies {
 
     testImplementation(libs.edc.junit)
     testFixturesImplementation(libs.edc.junit)
-    testFixturesImplementation(libs.junit.jupiter.api)
-    testFixturesImplementation(libs.assertj)
 }

--- a/edc-extensions/bpn-validation/bpn-validation-core/build.gradle.kts
+++ b/edc-extensions/bpn-validation/bpn-validation-core/build.gradle.kts
@@ -35,6 +35,4 @@ dependencies {
 
     testImplementation(libs.edc.junit)
     testFixturesImplementation(libs.edc.junit)
-    testFixturesImplementation(libs.junit.jupiter.api)
-    testFixturesImplementation(libs.assertj)
 }

--- a/edc-tests/e2e-fixtures/build.gradle.kts
+++ b/edc-tests/e2e-fixtures/build.gradle.kts
@@ -43,13 +43,10 @@ dependencies {
     testFixturesApi(libs.edc.spi.transfer)
     testFixturesApi(testFixtures(libs.edc.api.management.test.fixtures))
 
-    testFixturesApi(libs.assertj)
     testFixturesApi(libs.awaitility)
     testFixturesApi(libs.aws.s3)
     testFixturesApi(libs.azure.storage.blob)
     testFixturesApi(libs.jakartaJson)
-    testFixturesApi(libs.junit.jupiter.api)
-    testFixturesApi(libs.junit.jupiter.params)
     testFixturesApi(libs.netty.mockserver)
     testFixturesApi(libs.postgres)
     testFixturesApi(libs.restAssured)

--- a/edc-tests/runtime/mock-connector/build.gradle.kts
+++ b/edc-tests/runtime/mock-connector/build.gradle.kts
@@ -48,7 +48,6 @@ dependencies {
     runtimeOnly(libs.edc.ext.jsonld)
 
     testImplementation(libs.edc.junit)
-    testImplementation(libs.assertj)
 }
 
 application {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,6 @@ format.version = "1.1"
 
 [versions]
 edc = "0.12.0"
-assertj = "3.27.3"
 awaitility = "4.2.2"
 aws = "2.31.1"
 azure-storage-blob = "12.30.0"
@@ -11,7 +10,6 @@ bouncyCastle-jdk18on = "1.80"
 flyway = "11.4.0"
 jackson = "2.18.2"
 jakarta-json = "2.0.1"
-jupiter = "5.11.4"
 nimbus = "10.0.2"
 netty-mockserver = "5.15.0"
 opentelemetry = "2.13.3"
@@ -190,7 +188,6 @@ edc-edr-store-receiver = { module = "org.eclipse.edc:edr-store-receiver", versio
 
 # other deps
 
-assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
 aws-s3 = { module = "software.amazon.awssdk:s3", version.ref = "aws" }
 aws-s3transfer = { module = "software.amazon.awssdk:s3-transfer-manager", version.ref = "aws" }
@@ -200,8 +197,6 @@ flyway-database-postgres = { module = "org.flywaydb:flyway-database-postgresql",
 jacksonJsonP = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jakarta-jsonp", version.ref = "jackson" }
 jakarta-rsApi = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version.ref = "rsApi" }
 jakartaJson = { module = "org.glassfish:jakarta.json", version.ref = "jakarta-json" }
-junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jupiter" }
-junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "jupiter" }
 nimbus-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbus" }
 opentelemetry-javaagent = { module = "io.opentelemetry.javaagent:opentelemetry-javaagent", version.ref = "opentelemetry" }
 netty-mockserver = { module = "org.mock-server:mockserver-netty", version.ref = "netty-mockserver" }

--- a/spi/edr-spi/build.gradle.kts
+++ b/spi/edr-spi/build.gradle.kts
@@ -30,8 +30,6 @@ dependencies {
 
     testFixturesImplementation(project(":spi:core-spi"))
     testFixturesImplementation(libs.edc.junit)
-    testFixturesImplementation(libs.junit.jupiter.api)
-    testFixturesImplementation(libs.assertj)
     testFixturesImplementation(libs.awaitility)
     testFixturesImplementation(libs.edc.spi.edrstore)
 


### PR DESCRIPTION
## WHAT

Cleans up `junit` and `assertj` dependencies, that are provided by the `edc-build` gradle plugin.

## WHY

Reduce dependencies maintenance

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Part of #1848 
