### PR TITLE
feat: publish dependencies to GitHub pages

### DIFF
--- a/.github/workflows/generate-and-publish-dependencies.yaml
+++ b/.github/workflows/generate-and-publish-dependencies.yaml
@@ -18,7 +18,7 @@
 #################################################################################
 
 
-name: "Generate and check DEPENDENCIES"
+name: "Generate DEPENDENCIES file and publish to GitHub pages"
 
 on:
   workflow_dispatch:
@@ -39,3 +39,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-java
       - uses: ./.github/actions/generate-and-check-dependencies
+      - name: Prepare to publish
+        shell: bash
+        run: |
+          mkdir public
+          cp DEPENDENCIES public/
+      - name: Publish to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: public
+          keep_files: true

--- a/.github/workflows/generate-and-publish-dependencies.yaml
+++ b/.github/workflows/generate-and-publish-dependencies.yaml
@@ -25,9 +25,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
## WHAT

Publishes the new DEPEDENCIES file to the GitHub pages.

## WHY

To keep deps information up to date, once the DEPENDENCIES file is updated the new version should be published in GH pages.

## FURTHER NOTES

The change regarding PR to main triggering workflow is done now since it avoids publishing on new PR's and since is a change to be done related with the issue, was made here.

A following PR to update the NOTICE file will be proposed, was not included here to keep the focus on GH pages.

Relates to https://github.com/eclipse-tractusx/tractusx-edc/issues/1743