### PR TITLE
feat: change shadow plugin id and move into version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ plugins {
     `maven-publish`
     `jacoco-report-aggregation`
     `java-test-fixtures`
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    alias(libs.plugins.shadow)
     id("com.bmuschko.docker-remote-api") version "9.4.0"
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
@@ -158,7 +158,7 @@ allprojects {
 subprojects {
     afterEvaluate {
         // the "dockerize" task is added to all projects that use the `shadowJar` plugin
-        if (project.plugins.hasPlugin("com.github.johnrengelman.shadow")) {
+        if (project.plugins.hasPlugin(libs.plugins.shadow.get().pluginId)) {
             val downloadOpentelemetryAgent = tasks.create("downloadOpentelemetryAgent", Copy::class) {
                 val openTelemetry = configurations.create("open-telemetry")
 

--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/build.gradle.kts
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/build.gradle.kts
@@ -23,7 +23,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    alias(libs.plugins.shadow)
 }
 
 dependencies {

--- a/edc-controlplane/edc-runtime-memory/build.gradle.kts
+++ b/edc-controlplane/edc-runtime-memory/build.gradle.kts
@@ -20,7 +20,7 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    alias(libs.plugins.shadow)
 }
 
 dependencies {

--- a/edc-dataplane/edc-dataplane-hashicorp-vault/build.gradle.kts
+++ b/edc-dataplane/edc-dataplane-hashicorp-vault/build.gradle.kts
@@ -20,7 +20,7 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    alias(libs.plugins.shadow)
 }
 
 dependencies {

--- a/edc-tests/runtime/mock-connector/build.gradle.kts
+++ b/edc-tests/runtime/mock-connector/build.gradle.kts
@@ -22,7 +22,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    alias(libs.plugins.shadow)
     id(libs.plugins.swagger.get().pluginId)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -221,4 +221,5 @@ edc-sts = [
 ]
 
 [plugins]
+shadow = { id = "com.gradleup.shadow", version = "8.3.6" }
 swagger = { id = "io.swagger.core.v3.swagger-gradle-plugin", version = "2.2.29" }

--- a/samples/edc-dast/edc-dast-runtime/build.gradle.kts
+++ b/samples/edc-dast/edc-dast-runtime/build.gradle.kts
@@ -21,7 +21,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    alias(libs.plugins.shadow)
 }
 
 dependencies {

--- a/samples/multi-tenancy/build.gradle.kts
+++ b/samples/multi-tenancy/build.gradle.kts
@@ -20,7 +20,7 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    alias(libs.plugins.shadow)
 }
 
 


### PR DESCRIPTION
## WHAT

This PR updates the Shadow plugin ID from the old `com.github.johnrengelman.shadow` to the actual `com.gradleup.shadow`, and moves the plugin declaration into the version catalog file.

## WHY

To use the actual Shadow plugin ID and unify its declaration across the entire project.

Closes #1882
