### PR TITLE
feature: Implement retrieving BPNs given BPN group identifier

### DIFF
--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/BaseBusinessPartnerGroupApiController.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/BaseBusinessPartnerGroupApiController.java
@@ -40,7 +40,7 @@ import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
 public abstract class BaseBusinessPartnerGroupApiController {
 
     private static final String TX_NAMESPACE_GROUPS = "groups";
-    private static final String TX_NAMESPACE_BPN = "bpns";
+    private static final String TX_NAMESPACE_BPNS = "bpns";
     private final BusinessPartnerStore businessPartnerService;
 
     public BaseBusinessPartnerGroupApiController(BusinessPartnerStore businessPartnerService) {
@@ -61,7 +61,7 @@ public abstract class BaseBusinessPartnerGroupApiController {
     public JsonObject resolveGroup(String group) {
         var result = businessPartnerService.resolveForBpnGroup(group);
         if (result.succeeded()) {
-            return createObject(group, result.getContent(), TX_NAMESPACE_BPN);
+            return createObject(group, result.getContent(), TX_NAMESPACE_BPNS);
         }
 
         throw new ObjectNotFoundException(List.class, result.getFailureDetail());

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/BaseBusinessPartnerGroupApiController.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/BaseBusinessPartnerGroupApiController.java
@@ -39,6 +39,8 @@ import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
 
 public abstract class BaseBusinessPartnerGroupApiController {
 
+    private static final String TX_NAMESPACE_GROUPS = "groups";
+    private static final String TX_NAMESPACE_BPN = "bpn";
     private final BusinessPartnerStore businessPartnerService;
 
     public BaseBusinessPartnerGroupApiController(BusinessPartnerStore businessPartnerService) {
@@ -50,7 +52,16 @@ public abstract class BaseBusinessPartnerGroupApiController {
         // StoreResult does not support the .map() operator, because it does not override newInstance()
         var result = businessPartnerService.resolveForBpn(bpn);
         if (result.succeeded()) {
-            return createObject(bpn, result.getContent());
+            return createObject(bpn, result.getContent(), TX_NAMESPACE_GROUPS);
+        }
+
+        throw new ObjectNotFoundException(List.class, result.getFailureDetail());
+    }
+
+    public JsonObject resolveGroup(String group) {
+        var result = businessPartnerService.resolveForBpnGroup(group);
+        if (result.succeeded()) {
+            return createObject(group, result.getContent(), TX_NAMESPACE_BPN);
         }
 
         throw new ObjectNotFoundException(List.class, result.getFailureDetail());
@@ -75,10 +86,10 @@ public abstract class BaseBusinessPartnerGroupApiController {
                 .orElseThrow(f -> new ObjectConflictException(f.getFailureDetail()));
     }
 
-    private JsonObject createObject(String bpn, List<String> list) {
+    private JsonObject createObject(String id, List<String> list, String namespace) {
         return Json.createObjectBuilder()
-                .add(ID, bpn)
-                .add(TX_NAMESPACE + "groups", Json.createArrayBuilder(list))
+                .add(ID, id)
+                .add(TX_NAMESPACE + namespace, Json.createArrayBuilder(list))
                 .build();
     }
 

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/BaseBusinessPartnerGroupApiController.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/BaseBusinessPartnerGroupApiController.java
@@ -40,7 +40,7 @@ import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
 public abstract class BaseBusinessPartnerGroupApiController {
 
     private static final String TX_NAMESPACE_GROUPS = "groups";
-    private static final String TX_NAMESPACE_BPN = "bpn";
+    private static final String TX_NAMESPACE_BPN = "bpns";
     private final BusinessPartnerStore businessPartnerService;
 
     public BaseBusinessPartnerGroupApiController(BusinessPartnerStore businessPartnerService) {

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3.java
@@ -50,6 +50,15 @@ public interface BusinessPartnerGroupApiV3 {
             })
     JsonObject resolveV3(@Parameter(name = "bpn", description = "The business partner number") String bpn);
 
+    @Operation(description = "Resolves all BPNs for a particular BPN group",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "An object containing an array with the assigned bpn"),
+                    @ApiResponse(responseCode = "404", description = "No entry for the given BPN group was found"),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    JsonObject resolveGroupV3(@Parameter(name = "group", description = "The business partner group") String group);
+
     @Operation(description = "Deletes the entry for a particular BPN",
             responses = {
                     @ApiResponse(responseCode = "204", description = "The object was successfully deleted"),

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3.java
@@ -52,7 +52,7 @@ public interface BusinessPartnerGroupApiV3 {
 
     @Operation(description = "Resolves all BPNs for a particular BPN group",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "An object containing an array with the assigned bpn"),
+                    @ApiResponse(responseCode = "200", description = "An object containing an array with the bpns assigned to the group"),
                     @ApiResponse(responseCode = "404", description = "No entry for the given BPN group was found"),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3Controller.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3Controller.java
@@ -50,6 +50,13 @@ public class BusinessPartnerGroupApiV3Controller extends BaseBusinessPartnerGrou
         return super.resolve(bpn);
     }
 
+    @GET
+    @Path("/group/{group}")
+    @Override
+    public JsonObject resolveGroupV3(@PathParam("group") String group) {
+        return super.resolveGroup(group);
+    }
+
     @DELETE
     @Path("/{bpn}")
     @Override

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/test/java/org/eclipse/tractusx/edc/api/bpn/BaseBusinessPartnerGroupApiControllerTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/test/java/org/eclipse/tractusx/edc/api/bpn/BaseBusinessPartnerGroupApiControllerTest.java
@@ -84,6 +84,25 @@ public abstract class BaseBusinessPartnerGroupApiControllerTest extends RestCont
     }
 
     @Test
+    void resolveForBpnGroup_exists() {
+        when(businessPartnerStore.resolveForBpnGroup(any())).thenReturn(StoreResult.success(List.of("bpn1", "bpn2")));
+        baseRequest()
+                .get("/group/test-bpn-group")
+                .then()
+                .statusCode(200)
+                .body(notNullValue());
+    }
+
+    @Test
+    void resolveForBpnGroup_notExists() {
+        when(businessPartnerStore.resolveForBpnGroup(any())).thenReturn(StoreResult.success(List.of()));
+        baseRequest()
+                .get("/group/test-bpn-group-not-exists")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
     void deleteEntry() {
         when(businessPartnerStore.delete(anyString())).thenReturn(StoreResult.success());
         baseRequest()

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/defaults/InMemoryBusinessPartnerStore.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/defaults/InMemoryBusinessPartnerStore.java
@@ -44,7 +44,9 @@ public class InMemoryBusinessPartnerStore implements BusinessPartnerStore {
                 .filter(bpn -> bpn.getValue().stream().anyMatch(groups -> groups.contains(businessPartnerGroup)))
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());
-        return StoreResult.success(bpns);
+        return bpns.isEmpty() ?
+                StoreResult.notFound(NOT_FOUND_TEMPLATE.formatted(businessPartnerGroup)) :
+                StoreResult.success(bpns);
     }
 
     @Override

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/defaults/InMemoryBusinessPartnerStore.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/defaults/InMemoryBusinessPartnerStore.java
@@ -25,6 +25,7 @@ import org.eclipse.tractusx.edc.validation.businesspartner.spi.BusinessPartnerSt
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class InMemoryBusinessPartnerStore implements BusinessPartnerStore {
     private final Map<String, List<String>> cache = new HashMap<>();
@@ -35,6 +36,15 @@ public class InMemoryBusinessPartnerStore implements BusinessPartnerStore {
         return entry == null ?
                 StoreResult.notFound(NOT_FOUND_TEMPLATE.formatted(businessPartnerNumber)) :
                 StoreResult.success(entry);
+    }
+
+    @Override
+    public StoreResult<List<String>> resolveForBpnGroup(String businessPartnerGroup) {
+        var bpns = cache.entrySet().stream()
+                .filter(bpn -> bpn.getValue().stream().anyMatch(groups -> groups.contains(businessPartnerGroup)))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+        return StoreResult.success(bpns);
     }
 
     @Override

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/testFixtures/java/org/eclipse/tractusx/edc/validation/businesspartner/store/BusinessPartnerStoreTestBase.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/testFixtures/java/org/eclipse/tractusx/edc/validation/businesspartner/store/BusinessPartnerStoreTestBase.java
@@ -47,6 +47,7 @@ public abstract class BusinessPartnerStoreTestBase {
 
     @Test
     void resolveForBpnGroup_multipleBpns() {
+        getStore().save("test-bpn-0", List.of("group2"));
         getStore().save("test-bpn-1", List.of("test-bpn-group", "group2", "group3"));
         getStore().save("test-bpn-2", List.of("test-bpn-group"));
         getStore().save("test-bpn-3", List.of("test-bpn-group", "group17"));

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/testFixtures/java/org/eclipse/tractusx/edc/validation/businesspartner/store/BusinessPartnerStoreTestBase.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/testFixtures/java/org/eclipse/tractusx/edc/validation/businesspartner/store/BusinessPartnerStoreTestBase.java
@@ -46,6 +46,24 @@ public abstract class BusinessPartnerStoreTestBase {
     }
 
     @Test
+    void resolveForBpnGroup_multipleBpns() {
+        getStore().save("test-bpn-1", List.of("test-bpn-group", "group2", "group3"));
+        getStore().save("test-bpn-2", List.of("test-bpn-group"));
+        getStore().save("test-bpn-3", List.of("test-bpn-group", "group17"));
+        assertThat(getStore().resolveForBpnGroup("test-bpn-group").getContent()).containsExactly("test-bpn-1", "test-bpn-2", "test-bpn-3");
+    }
+
+    @Test
+    void resolveForBpnGroup_bpnGroupNotExists() {
+        assertThat(getStore().resolveForBpnGroup("group-not-exist").succeeded()).isFalse();
+    }
+
+    @Test
+    void resolveForBpnGroup_bpnNotExists() {
+        assertThat(getStore().resolveForBpnGroup("not-stored-bpn").succeeded()).isFalse();
+    }
+
+    @Test
     void save() {
         getStore().save("test-bpn", List.of("group1", "group2", "group3"));
         assertThat(getStore().resolveForBpn("test-bpn").getContent()).containsExactly("group1", "group2", "group3");

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/testFixtures/java/org/eclipse/tractusx/edc/validation/businesspartner/store/BusinessPartnerStoreTestBase.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/testFixtures/java/org/eclipse/tractusx/edc/validation/businesspartner/store/BusinessPartnerStoreTestBase.java
@@ -60,11 +60,6 @@ public abstract class BusinessPartnerStoreTestBase {
     }
 
     @Test
-    void resolveForBpnGroup_bpnNotExists() {
-        assertThat(getStore().resolveForBpnGroup("not-stored-bpn").succeeded()).isFalse();
-    }
-
-    @Test
     void save() {
         getStore().save("test-bpn", List.of("group1", "group2", "group3"));
         assertThat(getStore().resolveForBpn("test-bpn").getContent()).containsExactly("group1", "group2", "group3");

--- a/edc-extensions/bpn-validation/bpn-validation-spi/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/spi/BusinessPartnerStore.java
+++ b/edc-extensions/bpn-validation/bpn-validation-spi/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/spi/BusinessPartnerStore.java
@@ -31,6 +31,8 @@ public interface BusinessPartnerStore {
 
     StoreResult<List<String>> resolveForBpn(String businessPartnerNumber);
 
+    StoreResult<List<String>> resolveForBpnGroup(String businessPartnerGroup);
+
     StoreResult<Void> save(String businessPartnerNumber, List<String> groups);
 
     StoreResult<Void> delete(String businessPartnerNumber);

--- a/edc-extensions/bpn-validation/business-partner-store-sql/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/store/sql/BusinessPartnerGroupStatements.java
+++ b/edc-extensions/bpn-validation/business-partner-store-sql/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/store/sql/BusinessPartnerGroupStatements.java
@@ -38,6 +38,8 @@ public interface BusinessPartnerGroupStatements {
 
     String findByBpnTemplate();
 
+    String findByBpnGroupTemplate();
+
     String insertTemplate();
 
     String deleteTemplate();

--- a/edc-extensions/bpn-validation/business-partner-store-sql/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/store/sql/PostgresBusinessPartnerGroupStatements.java
+++ b/edc-extensions/bpn-validation/business-partner-store-sql/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/store/sql/PostgresBusinessPartnerGroupStatements.java
@@ -35,7 +35,7 @@ public class PostgresBusinessPartnerGroupStatements implements BusinessPartnerGr
 
     @Override
     public String findByBpnGroupTemplate() {
-        return format("SELECT %s from %s WHERE EXISTS (SELECT 1 FROM json_array_elements_text(%s) AS group_element WHERE group_element = ?",
+        return format("SELECT %s from %s WHERE EXISTS (SELECT 1 FROM json_array_elements_text(%s) AS group_element WHERE group_element = ?)",
                 getBpnColumn(), getTable(), getGroupsColumn());
     }
 

--- a/edc-extensions/bpn-validation/business-partner-store-sql/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/store/sql/PostgresBusinessPartnerGroupStatements.java
+++ b/edc-extensions/bpn-validation/business-partner-store-sql/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/store/sql/PostgresBusinessPartnerGroupStatements.java
@@ -34,6 +34,12 @@ public class PostgresBusinessPartnerGroupStatements implements BusinessPartnerGr
     }
 
     @Override
+    public String findByBpnGroupTemplate() {
+        return format("SELECT %s from %s WHERE EXISTS (SELECT 1 FROM json_array_elements_text(%s) AS group_element WHERE group_element = ?",
+                getBpnColumn(), getTable(), getGroupsColumn());
+    }
+
+    @Override
     public String insertTemplate() {
         return format("INSERT INTO %s (%s, %s) VALUES (?, ?%s)", getTable(), getBpnColumn(), getGroupsColumn(), getFormatJsonOperator());
     }

--- a/edc-extensions/bpn-validation/business-partner-store-sql/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/store/sql/SqlBusinessPartnerStore.java
+++ b/edc-extensions/bpn-validation/business-partner-store-sql/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/store/sql/SqlBusinessPartnerStore.java
@@ -68,7 +68,7 @@ public class SqlBusinessPartnerStore extends AbstractSqlStore implements Busines
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {
                 var sql = statements.findByBpnGroupTemplate();
-                var list = queryExecutor.single(connection, true, this::mapJson, sql, businessPartnerGroup);
+                var list = queryExecutor.query(connection, true, this::mapGroup, sql, businessPartnerGroup).toList();
                 return list.isEmpty() ?
                         StoreResult.notFound(NOT_FOUND_TEMPLATE.formatted(businessPartnerGroup)) :
                         StoreResult.success(list);
@@ -134,7 +134,7 @@ public class SqlBusinessPartnerStore extends AbstractSqlStore implements Busines
         return fromJson(resultSet.getString(statements.getGroupsColumn()), LIST_OF_STRING);
     }
 
-    private String mapGroupJson(ResultSet resultSet) throws SQLException {
+    private String mapGroup(ResultSet resultSet) throws SQLException {
         return resultSet.getString(statements.getBpnColumn());
     }
 

--- a/edc-extensions/bpn-validation/business-partner-store-sql/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/store/sql/SqlBusinessPartnerStore.java
+++ b/edc-extensions/bpn-validation/business-partner-store-sql/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/store/sql/SqlBusinessPartnerStore.java
@@ -68,7 +68,7 @@ public class SqlBusinessPartnerStore extends AbstractSqlStore implements Busines
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {
                 var sql = statements.findByBpnGroupTemplate();
-                List<String> list = queryExecutor.query(connection, true, this::mapGroupJson, sql, businessPartnerGroup).toList();
+                var list = queryExecutor.single(connection, true, this::mapJson, sql, businessPartnerGroup);
                 return list.isEmpty() ?
                         StoreResult.notFound(NOT_FOUND_TEMPLATE.formatted(businessPartnerGroup)) :
                         StoreResult.success(list);

--- a/edc-extensions/bpn-validation/business-partner-store-sql/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/store/sql/SqlBusinessPartnerStore.java
+++ b/edc-extensions/bpn-validation/business-partner-store-sql/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/store/sql/SqlBusinessPartnerStore.java
@@ -68,10 +68,11 @@ public class SqlBusinessPartnerStore extends AbstractSqlStore implements Busines
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {
                 var sql = statements.findByBpnGroupTemplate();
-                var list = queryExecutor.query(connection, true, this::mapGroup, sql, businessPartnerGroup).toList();
-                return list.isEmpty() ?
+                var result = queryExecutor.query(connection, true, this::mapGroup, sql, businessPartnerGroup);
+                var bpns = result.toList();
+                return bpns.isEmpty() ?
                         StoreResult.notFound(NOT_FOUND_TEMPLATE.formatted(businessPartnerGroup)) :
-                        StoreResult.success(list);
+                        StoreResult.success(bpns);
             } catch (SQLException e) {
                 throw new EdcPersistenceException(e);
             }


### PR DESCRIPTION
## WHAT

In alignment with [this Decision Record](https://github.com/eclipse-tractusx/tractusx-edc/pull/1867), this PR adds a creation of an endpoint to expose the BPNs belonging to a BPN group given a group identifier.

## WHY

To implement the defined solution in the Decision Record. Simply, to allow a user to request all of the BPNs in a BPN group instead of retrieving the groups of all BPNs and iterate over them.

## FURTHER NOTES

Exemplified request and expected response format. 

![Screenshot 2025-04-09 at 11 44 17](https://github.com/user-attachments/assets/60a3b0c9-917c-4f8b-9275-d8bae184adc6)


Closes https://github.com/eclipse-tractusx/tractusx-edc/issues/1806
