### PR TITLE
refactor(test): improve IATP tests assertions

### DIFF
--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java
@@ -212,12 +212,10 @@ public abstract class TractusxParticipantBase extends IdentityParticipant {
                 .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
                 .add(TYPE, "CatalogRequest")
                 .add("counterPartyId", provider.id)
-                .add("counterPartyAddress", provider.federatedCatalog.get().toString())
+                .add("counterPartyAddress", provider.getProtocolUrl())
                 .add("protocol", protocol);
 
-
-        return given()
-                .baseUri(federatedCatalog.get().toString())
+        return baseManagementRequest()
                 .header("x-api-key", MANAGEMENT_API_KEY)
                 .contentType(JSON)
                 .when()

--- a/edc-tests/e2e/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/AbstractIatpConsumerPullTest.java
+++ b/edc-tests/e2e/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/AbstractIatpConsumerPullTest.java
@@ -60,7 +60,6 @@ import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.frame
 import static org.eclipse.tractusx.edc.tests.participant.TractusxParticipantBase.ASYNC_TIMEOUT;
 import static org.eclipse.tractusx.edc.tests.transfer.iatp.harness.IatpHelperFunctions.createVcBuilder;
 import static org.eclipse.tractusx.edc.tests.transfer.iatp.harness.IatpHelperFunctions.membershipSubject;
-import static org.hamcrest.Matchers.not;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -207,9 +206,9 @@ public abstract class AbstractIatpConsumerPullTest extends ConsumerPullBaseTest 
         try {
             consumer().getCatalog(provider())
                     .log().ifError()
-                    .statusCode(not(200));
+                    .statusCode(502);
         } finally {
-            // restore the original credential without credentialStatus
+            // restore the original credential
             store.update(existingCred);
         }
 
@@ -272,9 +271,9 @@ public abstract class AbstractIatpConsumerPullTest extends ConsumerPullBaseTest 
             // verify the failed catalog request
             consumer().getCatalog(provider())
                     .log().ifValidationFails()
-                    .statusCode(not(200));
+                    .statusCode(502);
         } finally {
-            // restore the original credential without credentialStatus
+            // restore the original credential
             store.update(existingCred);
         }
     }

--- a/edc-tests/e2e/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/AbstractIatpConsumerPullTest.java
+++ b/edc-tests/e2e/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/AbstractIatpConsumerPullTest.java
@@ -153,6 +153,11 @@ public abstract class AbstractIatpConsumerPullTest extends ConsumerPullBaseTest 
         var accessPolicyId = provider().createPolicyDefinition(createAccessPolicy(consumer().getBpn()));
         var contractPolicyId = provider().createPolicyDefinition(contractPolicy);
         provider().createContractDefinition(assetId, "def-1", accessPolicyId, contractPolicyId);
+
+        consumer().getCatalog(provider())
+                .log().ifValidationFails()
+                .statusCode(200);
+
         var negotiationId = consumer().initContractNegotiation(provider(), assetId);
 
         await().pollInterval(fibonacci())
@@ -199,16 +204,15 @@ public abstract class AbstractIatpConsumerPullTest extends ConsumerPullBaseTest 
                         .build())
                 .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
 
-
-        // verify the failed catalog request
         try {
             consumer().getCatalog(provider())
                     .log().ifError()
                     .statusCode(not(200));
         } finally {
-            // restore the non-expired cred
+            // restore the original credential without credentialStatus
             store.update(existingCred);
         }
+
     }
 
     @DisplayName("Expect the Catalog request to fail if a credential is revoked")

--- a/edc-tests/e2e/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/CredentialSpoofTest.java
+++ b/edc-tests/e2e/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/CredentialSpoofTest.java
@@ -52,7 +52,6 @@ import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.bnpPo
 import static org.eclipse.tractusx.edc.tests.transfer.iatp.harness.IatpHelperFunctions.configureParticipant;
 import static org.eclipse.tractusx.edc.tests.transfer.iatp.runtime.Runtimes.iatpRuntime;
 import static org.eclipse.tractusx.edc.tests.transfer.iatp.runtime.Runtimes.stsRuntime;
-import static org.hamcrest.Matchers.not;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
@@ -139,7 +138,7 @@ public class CredentialSpoofTest implements IatpParticipants {
 
         MALICIOUS_ACTOR.getCatalog(PROVIDER)
                 .log().ifError()
-                .statusCode(not(200));
+                .statusCode(502);
     }
 
     @Test
@@ -167,7 +166,7 @@ public class CredentialSpoofTest implements IatpParticipants {
 
         MALICIOUS_ACTOR.getCatalog(PROVIDER)
                 .log().ifError()
-                .statusCode(not(200));
+                .statusCode(502);
 
     }
 


### PR DESCRIPTION
## WHAT

I just discovered that the IATP tests didn't test the interaction with the catalog correctly, they were hitting the federated catalog instead of the /catalog endpoint on management api, that was responding 404 (`not(200)` was ok).

Now they make more sense

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
