### PR TITLE
docs: Create DR to retrieve all BPN Groups

### DIFF
--- a/docs/development/decision-records/2025-04-17-expose-all-bpn-groups/README.md
+++ b/docs/development/decision-records/2025-04-17-expose-all-bpn-groups/README.md
@@ -9,6 +9,8 @@ TractusX-EDC will expose an endpoint that will provide all the BPN groups with t
 Currently, listing all available BPN Groups requires [retrieving all BPNs](https://eclipse-tractusx.github.io/tractusx-edc/openapi/control-plane-api/0.9.0/#/Business%20Partner%20Group/resolveV3) in the `BusinessPartnerGroup` api and iterating through their assigned groups.
 This approach is consuming for the user and providing an endpoint to return all BPN groups with respective BPN assigned would improve usability since a single request can be performed. Using the existing BPN Group API keeps consistency.
 
+Since the response of this new endpoint includes the same information provided from the `/group/{group}` GET request and this one was not published on any release, it will be removed.
+
 ## Approach
 
 1. In `BusinessPartnerGroupApiV3` create a new POST endpoint, appending `/request`. This returns filtered BPNs (according to a particular query sent as a QuerySpec in the body of the request) each containing the list of groups it is assigned to.
@@ -35,4 +37,5 @@ The endpoint will accept a request body with the `querySpec` containing the filt
   }
 ]
 ```
+5. Delete the `/group/{group}` GET endpoint from the `BusinessPartnerGroupApiV3` interface and remove the implementation from `BusinessPartnerGroupApiControllerV3`.
 

--- a/docs/development/decision-records/2025-04-17-expose-all-bpn-groups/README.md
+++ b/docs/development/decision-records/2025-04-17-expose-all-bpn-groups/README.md
@@ -13,60 +13,26 @@ This approach is consuming for the user and providing an endpoint to return all 
 
 1. In `BusinessPartnerGroupApiV3` create a new POST endpoint, appending `/request`. This returns filtered BPNs (according to a particular query sent as a QuerySpec in the body of the request) each containing the list of groups it is assigned to.
 
-The endpoint will accept a request body with the `querySpec` like the following.
+The endpoint will accept a request body with the `querySpec` containing the filtering BPN's. If no BPN is sent as filter, the response should be all BPNs and their assigned groups.
 
-```json
-{
-  "filterExpression": [
-    {
-      "operandLeft": "BusinessPartnerNumber",
-      "operator": "IN",
-      "operandRight": ["BPN000000001", "BPN000000002", "BPN000000003"]
-    }
-  ],
-  "limit": 50,
-  "offset": 0,
-  "sortOrder": "ASC",
-  "sortField": "BusinessPartnerNumber"
-}
-```
-
-If the `operandRight` is empty, the response should be all BPNs and their assigned groups.
-
-The response for the above request will be similar to the next block.
+2. Create a query targeting the `edc_business_partner_group` table to evaluate and extract all BPNs and respective groups.
+3. Using the `BusinessPartnerStore` include a new operation that returns the BPNs and BPN groups and the change is reflected in the two existing implementations (In Memory and SQL).
+4. The response will include a list of filtered BPNs and their assigned groups and should be similar to the next block.
 
 ```json
 [
-   {
-      "@id": "BPN000000001",
-      "tx:groups": [
-         "group4",
-         "group3",
-         "group5",
-         "group2",
-         "group1"
-      ]
-   },
-   {
-      "@id": "BPN000000002",
-      "tx:groups": [
-         "group1",
-         "group2",
-         "group5"
-      ]
-   },
-   {
-      "@id": "BPN000000003",
-      "tx:groups": [
-         "group1"
-      ]
-   }
+  {
+    "bpn": "BPNL000000000001",
+    "groups": ["group1","group5","group4"]
+  },
+  {
+    "bpn": "BPNL000000000002",
+    "groups": ["group1","group5","group4"]
+  },
+  {
+    "bpn": "BPNL000000000003",
+    "groups": ["group1"]
+  }
 ]
 ```
-   
-  - The `query` object should contain the type of object to be queried and the criteria for filtering.
-  - The response should include a list of BPNs and their assigned groups.
-2. Create a query targeting the `edc_business_partner_group` table to evaluate and extract all BPNs and respective groups.
-3. Using the `BusinessPartnerStore` include a new operation that returns the BPNs and BPN groups and the change is reflected in the two existing implementations (In Memory and SQL).
-4. Response of the new endpoint is a key-value map with the key being the BPNs that meet the query constraints and the value containing the corresponding groups.
 

--- a/docs/development/decision-records/2025-04-17-expose-all-bpn-groups/README.md
+++ b/docs/development/decision-records/2025-04-17-expose-all-bpn-groups/README.md
@@ -2,16 +2,71 @@
 
 ## Decision
 
-TractusX-EDC will expose an endpoint that will provide all the BPN groups that have a BPN assigned to them.
+TractusX-EDC will expose an endpoint that will provide all the BPN groups with the BPN assigned to them.
 
 ## Rationale
 
-Currently, listing all available BPN Groups requires [retrieving all BPNs](https://eclipse-tractusx.github.io/tractusx-edc/openapi/control-plane-api/0.9.0/#/Business%20Partner%20Group/resolveV3) in the `BusinessPartnerGroup` api and iterating through their assigned groups. This approach is consuming for the user and providing an endpoint to return all BPN groups would improve usability. Using the existing BPN Group API keeps consistency.
+Currently, listing all available BPN Groups requires [retrieving all BPNs](https://eclipse-tractusx.github.io/tractusx-edc/openapi/control-plane-api/0.9.0/#/Business%20Partner%20Group/resolveV3) in the `BusinessPartnerGroup` api and iterating through their assigned groups.
+This approach is consuming for the user and providing an endpoint to return all BPN groups with respective BPN assigned would improve usability since a single request can be performed. Using the existing BPN Group API keeps consistency.
 
 ## Approach
 
-1. In `BusinessPartnerGroupApiV3` create a new POST endpoint, appending `/groups/request`, that returns all groups according to a particular query (sent as a QuerySpec in the body of the request).
-2. Create a query targeting the `edc_business_partner_group` table to evaluate and extract all BPN groups.
-3. Using the `BusinessPartnerStore` include a new operation that returns the BPN groups and the change is reflected in the two existing implementations (In Memory and SQL).
-4. Response of the new endpoint is a list containing all the groups that meet the query constraints.
+1. In `BusinessPartnerGroupApiV3` create a new POST endpoint, appending `/request`. This returns filtered BPNs (according to a particular query sent as a QuerySpec in the body of the request) each containing the list of groups it is assigned to.
+
+The endpoint will accept a request body with the `querySpec` like the following.
+
+```json
+{
+  "filterExpression": [
+    {
+      "operandLeft": "BusinessPartnerNumber",
+      "operator": "IN",
+      "operandRight": ["BPN000000001", "BPN000000002", "BPN000000003"]
+    }
+  ],
+  "limit": 50,
+  "offset": 0,
+  "sortOrder": "ASC",
+  "sortField": "BusinessPartnerNumber"
+}
+```
+
+If the `operandRight` is empty, the response should be all BPNs and their assigned groups.
+
+The response for the above request will be similar to the next block.
+
+```json
+[
+   {
+      "@id": "BPN000000001",
+      "tx:groups": [
+         "group4",
+         "group3",
+         "group5",
+         "group2",
+         "group1"
+      ]
+   },
+   {
+      "@id": "BPN000000002",
+      "tx:groups": [
+         "group1",
+         "group2",
+         "group5"
+      ]
+   },
+   {
+      "@id": "BPN000000003",
+      "tx:groups": [
+         "group1"
+      ]
+   }
+]
+```
+   
+  - The `query` object should contain the type of object to be queried and the criteria for filtering.
+  - The response should include a list of BPNs and their assigned groups.
+2. Create a query targeting the `edc_business_partner_group` table to evaluate and extract all BPNs and respective groups.
+3. Using the `BusinessPartnerStore` include a new operation that returns the BPNs and BPN groups and the change is reflected in the two existing implementations (In Memory and SQL).
+4. Response of the new endpoint is a key-value map with the key being the BPNs that meet the query constraints and the value containing the corresponding groups.
 

--- a/docs/development/decision-records/2025-04-17-expose-all-bpn-groups/README.md
+++ b/docs/development/decision-records/2025-04-17-expose-all-bpn-groups/README.md
@@ -2,31 +2,16 @@
 
 ## Decision
 
-TractusX-EDC will expose an endpoint that will provide all the BPN groups.
+TractusX-EDC will expose an endpoint that will provide all the BPN groups that have a BPN assigned to them.
 
 ## Rationale
 
-Currently, listing all available BPN Groups requires [retrieving all BPNs](https://eclipse-tractusx.github.io/tractusx-edc/openapi/control-plane-api/0.9.0/#/Business%20Partner%20Group/resolveV3) in the `BusinessPartnerGroup` api and iterating through their assigned groups. This approach is consuming for the user and providing an endpoint to return all BPN groups would improve usability.
-
-Creating a new specific endpoint that returns all BPN groups provides a simplified approach. Using the existing BPN Group API keeps consistency.
+Currently, listing all available BPN Groups requires [retrieving all BPNs](https://eclipse-tractusx.github.io/tractusx-edc/openapi/control-plane-api/0.9.0/#/Business%20Partner%20Group/resolveV3) in the `BusinessPartnerGroup` api and iterating through their assigned groups. This approach is consuming for the user and providing an endpoint to return all BPN groups would improve usability. Using the existing BPN Group API keeps consistency.
 
 ## Approach
 
-1. In `BusinessPartnerGroupApiV3` create a new GET endpoint that returns all groups, appending `/groups`.
+1. In `BusinessPartnerGroupApiV3` create a new POST endpoint, appending `/groups/request`, that returns all groups according to a particular query (sent as a QuerySpec in the body of the request).
 2. Create a query targeting the `edc_business_partner_group` table to evaluate and extract all BPN groups.
-3. Using the `BusinessPartnerStore` include a new operation that returns all the BPN groups and the change is reflected in the two existing implementations (In Memory and SQL).
-4. Response of the new endpoint should follow the format of the other read endpoints, listing all the groups, similar to the next.
-```
-{
-	"@id": "groups",
-	"tx:groups": [
-		"group4",
-		"group3",
-		"group5",
-		"group2",
-		"group1"
-	],
-	"@context": {...}
-}
-```
+3. Using the `BusinessPartnerStore` include a new operation that returns the BPN groups and the change is reflected in the two existing implementations (In Memory and SQL).
+4. Response of the new endpoint is a list containing all the groups that meet the query constraints.
 

--- a/docs/development/decision-records/2025-04-17-expose-all-bpn-groups/README.md
+++ b/docs/development/decision-records/2025-04-17-expose-all-bpn-groups/README.md
@@ -1,0 +1,32 @@
+# Expose all Business Partner Groups
+
+## Decision
+
+TractusX-EDC will expose an endpoint that will provide all the BPN groups.
+
+## Rationale
+
+Currently, listing all available BPN Groups requires [retrieving all BPNs](https://eclipse-tractusx.github.io/tractusx-edc/openapi/control-plane-api/0.9.0/#/Business%20Partner%20Group/resolveV3) in the `BusinessPartnerGroup` api and iterating through their assigned groups. This approach is consuming for the user and providing an endpoint to return all BPN groups would improve usability.
+
+Creating a new specific endpoint that returns all BPN groups provides a simplified approach. Using the existing BPN Group API keeps consistency.
+
+## Approach
+
+1. In `BusinessPartnerGroupApiV3` create a new GET endpoint that returns all groups, appending `/groups`.
+2. Create a query targeting the `edc_business_partner_group` table to evaluate and extract all BPN groups.
+3. Using the `BusinessPartnerStore` include a new operation that returns all the BPN groups and the change is reflected in the two existing implementations (In Memory and SQL).
+4. Response of the new endpoint should follow the format of the other read endpoints, listing all the groups, similar to the next.
+```
+{
+	"@id": "groups",
+	"tx:groups": [
+		"group4",
+		"group3",
+		"group5",
+		"group2",
+		"group1"
+	],
+	"@context": {...}
+}
+```
+

--- a/docs/development/decision-records/2025-04-17-expose-all-bpn-groups/README.md
+++ b/docs/development/decision-records/2025-04-17-expose-all-bpn-groups/README.md
@@ -2,40 +2,16 @@
 
 ## Decision
 
-TractusX-EDC will expose an endpoint that will provide all the BPN groups with the BPN assigned to them.
+TractusX-EDC will expose an endpoint that provides all the BPN groups that have a BPN assigned to them.
 
 ## Rationale
 
-Currently, listing all available BPN Groups requires [retrieving all BPNs](https://eclipse-tractusx.github.io/tractusx-edc/openapi/control-plane-api/0.9.0/#/Business%20Partner%20Group/resolveV3) in the `BusinessPartnerGroup` api and iterating through their assigned groups.
-This approach is consuming for the user and providing an endpoint to return all BPN groups with respective BPN assigned would improve usability since a single request can be performed. Using the existing BPN Group API keeps consistency.
-
-Since the response of this new endpoint includes the same information provided from the `/group/{group}` GET request and this one was not published on any release, it will be removed.
+Currently, listing all available BPN Groups requires [retrieving all BPNs](https://eclipse-tractusx.github.io/tractusx-edc/openapi/control-plane-api/0.9.0/#/Business%20Partner%20Group/resolveV3) in the `BusinessPartnerGroup` api and iterating through their assigned groups. This approach is consuming for the user and providing an endpoint to return all BPN groups would improve usability. Using the existing BPN Group API keeps consistency.
 
 ## Approach
 
-1. In `BusinessPartnerGroupApiV3` create a new POST endpoint, appending `/request`. This returns filtered BPNs (according to a particular query sent as a QuerySpec in the body of the request) each containing the list of groups it is assigned to.
-
-The endpoint will accept a request body with the `querySpec` containing the filtering BPN's. If no BPN is sent as filter, the response should be all BPNs and their assigned groups.
-
-2. Create a query targeting the `edc_business_partner_group` table to evaluate and extract all BPNs and respective groups.
-3. Using the `BusinessPartnerStore` include a new operation that returns the BPNs and BPN groups and the change is reflected in the two existing implementations (In Memory and SQL).
-4. The response will include a list of filtered BPNs and their assigned groups and should be similar to the next block.
-
-```json
-[
-  {
-    "bpn": "BPNL000000000001",
-    "groups": ["group1","group5","group4"]
-  },
-  {
-    "bpn": "BPNL000000000002",
-    "groups": ["group1","group5","group4"]
-  },
-  {
-    "bpn": "BPNL000000000003",
-    "groups": ["group1"]
-  }
-]
-```
-5. Delete the `/group/{group}` GET endpoint from the `BusinessPartnerGroupApiV3` interface and remove the implementation from `BusinessPartnerGroupApiControllerV3`.
+1. In `BusinessPartnerGroupApiV3` create a new GET endpoint that returns all groups, appending `/groups`.
+2. Create a query targeting the `edc_business_partner_group` table to evaluate and extract all BPN groups.
+3. Using the `BusinessPartnerStore` include a new operation that returns all the BPN groups and the change is reflected in the two existing implementations (In Memory and SQL).
+4. Response of the new endpoint is a list containing all the BPN groups.
 


### PR DESCRIPTION
## WHAT

Adds a Decision Record to expose all the BPN groups in a new endpoint.

## WHY

Right now to get all BPN groups stored the user needs to retrieve all BPNs and their related groups and iterate over them. This can be time consuming and adding a new endpoint that returns all the BPN groups would simplify API usage.

Relates to #1898 