### PR TITLE
fix(config) - added missing opentelemetry options

### DIFF
--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -334,7 +334,7 @@ controlplane:
   opentelemetry: |-
     otel.javaagent.enabled=false
     otel.javaagent.debug=false
-    # By default prometheus uses port 9464
+    # Alignment of edc /metrics port and OTEL prometheus configuration (By default OTEL is exposing prometheus metrics at 9464)
     otel.exporter.prometheus.port=9090
     otel.metrics.exporter=prometheus
 
@@ -579,7 +579,7 @@ dataplane:
   opentelemetry: |-
     otel.javaagent.enabled=false
     otel.javaagent.debug=false
-    # By default prometheus uses port 9464
+    # Alignment of edc /metrics port and OTEL prometheus configuration (By default OTEL is exposing prometheus metrics at 9464)
     otel.exporter.prometheus.port=9090
     otel.metrics.exporter=prometheus
 

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -4,6 +4,7 @@
 #  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #  Copyright (c) 2025 Schaeffler AG
+#
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.
 #

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -333,6 +333,9 @@ controlplane:
   opentelemetry: |-
     otel.javaagent.enabled=false
     otel.javaagent.debug=false
+    # By default prometheus uses port 9464
+    otel.exporter.prometheus.port=9090
+    otel.metrics.exporter=prometheus
 
 
   # -- [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to constrain pods to nodes
@@ -575,6 +578,9 @@ dataplane:
   opentelemetry: |-
     otel.javaagent.enabled=false
     otel.javaagent.debug=false
+    # By default prometheus uses port 9464
+    otel.exporter.prometheus.port=9090
+    otel.metrics.exporter=prometheus
 
 
   # -- [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to constrain pods to nodes

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -3,7 +3,7 @@
 #  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
 #  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
-#
+#  Copyright (c) 2025 Schaeffler AG
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.
 #


### PR DESCRIPTION
## WHAT
remapped port from default 9464 to 9090, and overriden exporter format

## WHY
In order to be able to scrap metrics with prometheus, when otel javaagent is enabled

## FURTHER NOTES
N/A

Closes #1905
