### PR TITLE
fix: execute the `generate-allure-report` job when the `Run-All-Tests` workflow is manually triggered by a tag.

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -159,7 +159,7 @@ jobs:
   generate-allure-report:
     runs-on: ubuntu-latest
     needs: end-to-end-tests
-    if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'bugfix/') }}
+    if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'bugfix/') || github.ref_type  == 'tag' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## WHAT

This PR updates the `verify` workflow to ensure the `generate-allure-report` job runs when the `Run-All-Tests` workflow is manually triggered by a tag.

## WHY

To enable manual regeneration of the Allure report against a specific tag.

Closes #1928 
