### PR TITLE
Add implementation for exposing all BPN groups.

### DIFF
--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3.java
@@ -59,6 +59,14 @@ public interface BusinessPartnerGroupApiV3 {
             })
     JsonObject resolveGroupV3(@Parameter(name = "group", description = "The business partner group") String group);
 
+    @Operation(description = "Resolves all BPN Groups",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "An object containing an array with the all BPN groups"),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    JsonObject resolveGroupsV3();
+
     @Operation(description = "Deletes the entry for a particular BPN",
             responses = {
                     @ApiResponse(responseCode = "204", description = "The object was successfully deleted"),

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3Controller.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3Controller.java
@@ -75,7 +75,6 @@ public class BusinessPartnerGroupApiV3Controller extends BaseBusinessPartnerGrou
     public JsonObject resolveGroupsV3() {
         return businessPartnerService.resolveForBpnGroups()
                 .map(result -> Json.createObjectBuilder()
-                        //.add(ID, "groups")
                         .add(TX_NAMESPACE + "groups", Json.createArrayBuilder(result))
                         .build())
                 .orElseThrow(failure -> new ObjectNotFoundException(List.class, failure.getFailureDetail()));

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3Controller.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3Controller.java
@@ -69,6 +69,18 @@ public class BusinessPartnerGroupApiV3Controller extends BaseBusinessPartnerGrou
                 .orElseThrow(failure -> new ObjectNotFoundException(List.class, failure.getFailureDetail()));
     }
 
+    @GET
+    @Path("/groups")
+    @Override
+    public JsonObject resolveGroupsV3() {
+        return businessPartnerService.resolveForBpnGroups()
+                .map(result -> Json.createObjectBuilder()
+                        //.add(ID, "groups")
+                        .add(TX_NAMESPACE + "groups", Json.createArrayBuilder(result))
+                        .build())
+                .orElseThrow(failure -> new ObjectNotFoundException(List.class, failure.getFailureDetail()));
+    }
+
     @DELETE
     @Path("/{bpn}")
     @Override

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/test/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3ControllerTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/test/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3ControllerTest.java
@@ -56,7 +56,7 @@ class BusinessPartnerGroupApiV3ControllerTest extends BaseBusinessPartnerGroupAp
 
     @Test
     void resolveForBpnGroups_exists() {
-        when(businessPartnerStore.resolveForBpnGroups()).thenReturn(StoreResult.success(List.of("bpn1", "bpn2")));
+        when(businessPartnerStore.resolveForBpnGroups()).thenReturn(StoreResult.success(List.of("group1", "group2")));
         baseRequest()
                 .get("/groups")
                 .then()

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/test/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3ControllerTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/test/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3ControllerTest.java
@@ -54,6 +54,25 @@ class BusinessPartnerGroupApiV3ControllerTest extends BaseBusinessPartnerGroupAp
                 .statusCode(404);
     }
 
+    @Test
+    void resolveForBpnGroups_exists() {
+        when(businessPartnerStore.resolveForBpnGroups()).thenReturn(StoreResult.success(List.of("bpn1", "bpn2")));
+        baseRequest()
+                .get("/groups")
+                .then()
+                .statusCode(200)
+                .body(notNullValue());
+    }
+
+    @Test
+    void resolveForBpnGroups_notExists_returns404() {
+        when(businessPartnerStore.resolveForBpnGroups()).thenReturn(StoreResult.notFound("test-message"));
+        baseRequest()
+                .get("/groups")
+                .then()
+                .statusCode(404);
+    }
+
     @Override
     protected Object controller() {
         return new BusinessPartnerGroupApiV3Controller(businessPartnerStore);

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/defaults/InMemoryBusinessPartnerStore.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/defaults/InMemoryBusinessPartnerStore.java
@@ -50,6 +50,15 @@ public class InMemoryBusinessPartnerStore implements BusinessPartnerStore {
     }
 
     @Override
+    public StoreResult<List<String>> resolveForBpnGroups() {
+        var groups = cache.values().stream()
+                .flatMap(List::stream)
+                .distinct()
+                .collect(Collectors.toList());
+        return StoreResult.success(groups);
+    }
+
+    @Override
     public StoreResult<Void> save(String businessPartnerNumber, List<String> groups) {
         //to maintain behavioural consistency with the SQL store
         if (cache.containsKey(businessPartnerNumber)) {

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/testFixtures/java/org/eclipse/tractusx/edc/validation/businesspartner/store/BusinessPartnerStoreTestBase.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/testFixtures/java/org/eclipse/tractusx/edc/validation/businesspartner/store/BusinessPartnerStoreTestBase.java
@@ -75,7 +75,7 @@ public abstract class BusinessPartnerStoreTestBase {
         assertThat(getStore().resolveForBpnGroups())
                 .isSucceeded()
                 .asInstanceOf(list(String.class))
-                .containsExactly("test-bpn-group", "group2", "group17", "group3");
+                .contains("group2", "test-bpn-group", "group3", "group17");
     }
 
     @Test

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/testFixtures/java/org/eclipse/tractusx/edc/validation/businesspartner/store/BusinessPartnerStoreTestBase.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/testFixtures/java/org/eclipse/tractusx/edc/validation/businesspartner/store/BusinessPartnerStoreTestBase.java
@@ -75,7 +75,7 @@ public abstract class BusinessPartnerStoreTestBase {
         assertThat(getStore().resolveForBpnGroups())
                 .isSucceeded()
                 .asInstanceOf(list(String.class))
-                .containsExactly("group2", "test-bpn-group", "group3", "group17");
+                .containsExactly("test-bpn-group", "group2", "group17", "group3");
     }
 
     @Test

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/testFixtures/java/org/eclipse/tractusx/edc/validation/businesspartner/store/BusinessPartnerStoreTestBase.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/testFixtures/java/org/eclipse/tractusx/edc/validation/businesspartner/store/BusinessPartnerStoreTestBase.java
@@ -66,6 +66,19 @@ public abstract class BusinessPartnerStoreTestBase {
     }
 
     @Test
+    void resolveForBpnGroups() {
+        getStore().save("test-bpn-0", List.of("group2"));
+        getStore().save("test-bpn-1", List.of("test-bpn-group", "group2", "group3"));
+        getStore().save("test-bpn-2", List.of("test-bpn-group"));
+        getStore().save("test-bpn-3", List.of("test-bpn-group", "group17"));
+
+        assertThat(getStore().resolveForBpnGroups())
+                .isSucceeded()
+                .asInstanceOf(list(String.class))
+                .containsExactly("group2", "test-bpn-group", "group3", "group17");
+    }
+
+    @Test
     void save() {
         getStore().save("test-bpn", List.of("group1", "group2", "group3"));
         assertThat(getStore().resolveForBpn("test-bpn").getContent()).containsExactly("group1", "group2", "group3");

--- a/edc-extensions/bpn-validation/bpn-validation-spi/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/spi/BusinessPartnerStore.java
+++ b/edc-extensions/bpn-validation/bpn-validation-spi/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/spi/BusinessPartnerStore.java
@@ -33,6 +33,8 @@ public interface BusinessPartnerStore {
 
     StoreResult<List<String>> resolveForBpnGroup(String businessPartnerGroup);
 
+    StoreResult<List<String>> resolveForBpnGroups();
+
     StoreResult<Void> save(String businessPartnerNumber, List<String> groups);
 
     StoreResult<Void> delete(String businessPartnerNumber);

--- a/edc-extensions/bpn-validation/business-partner-store-sql/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/store/sql/BusinessPartnerGroupStatements.java
+++ b/edc-extensions/bpn-validation/business-partner-store-sql/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/store/sql/BusinessPartnerGroupStatements.java
@@ -40,6 +40,8 @@ public interface BusinessPartnerGroupStatements {
 
     String findByBpnGroupTemplate();
 
+    String findByBpnGroupsTemplate();
+
     String insertTemplate();
 
     String deleteTemplate();

--- a/edc-extensions/bpn-validation/business-partner-store-sql/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/store/sql/PostgresBusinessPartnerGroupStatements.java
+++ b/edc-extensions/bpn-validation/business-partner-store-sql/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/store/sql/PostgresBusinessPartnerGroupStatements.java
@@ -40,6 +40,12 @@ public class PostgresBusinessPartnerGroupStatements implements BusinessPartnerGr
     }
 
     @Override
+    public String findByBpnGroupsTemplate() {
+        return format("SELECT DISTINCT group_element AS group_name from %s, json_array_elements_text(%s) AS group_element;",
+                getTable(), getGroupsColumn());
+    }
+
+    @Override
     public String insertTemplate() {
         return format("INSERT INTO %s (%s, %s) VALUES (?, ?%s)", getTable(), getBpnColumn(), getGroupsColumn(), getFormatJsonOperator());
     }


### PR DESCRIPTION
## WHAT

Adds a new `/groups` endpoint to resolve all BPN Groups. Implementation of [this Decision Record](https://github.com/eclipse-tractusx/tractusx-edc/pull/1908).

## WHY

To ease the listing of all BPN groups stored.

## FURTHER NOTES

As defined in the DR, this endpoint is added in the `BusinessPartnerGroupApiV3`.

Request:
GET /v3/business-partner-groups/groups

Example response:
```
{
	"tx:groups": [
		"group2",
		"group4",
		"group13",
		"group10",
		"group3",
		"group1",
		"group5"
	],
	"@context": {...}
}
```

Closes #1898 
