### PR TITLE
feat: stabilize agreements retirement api to v3

### DIFF
--- a/edc-extensions/agreements/retirement-evaluation-api/src/main/java/org/eclipse/tractusx/edc/agreements/retirement/api/v3/AgreementsRetirementApiV3Controller.java
+++ b/edc-extensions/agreements/retirement-evaluation-api/src/main/java/org/eclipse/tractusx/edc/agreements/retirement/api/v3/AgreementsRetirementApiV3Controller.java
@@ -46,7 +46,7 @@ import static org.eclipse.tractusx.edc.agreements.retirement.spi.types.Agreement
 
 @Consumes(APPLICATION_JSON)
 @Produces(APPLICATION_JSON)
-@Path("/v3.1alpha/retireagreements")
+@Path("/v3/contractagreements/retirements")
 public class AgreementsRetirementApiV3Controller implements AgreementsRetirementApiV3 {
 
     private final AgreementsRetirementService service;

--- a/edc-extensions/agreements/retirement-evaluation-api/src/test/java/org/eclipse/tractusx/edc/agreements/retirement/api/v3/AgreementsRetirementApiV3ControllerTest.java
+++ b/edc-extensions/agreements/retirement-evaluation-api/src/test/java/org/eclipse/tractusx/edc/agreements/retirement/api/v3/AgreementsRetirementApiV3ControllerTest.java
@@ -224,7 +224,7 @@ class AgreementsRetirementApiV3ControllerTest extends RestControllerTestBase {
     private RequestSpecification baseRequest() {
         return given()
                 .baseUri("http://localhost:" + port)
-                .basePath("/v3.1alpha/retireagreements")
+                .basePath("/v3/contractagreements/retire")
                 .when();
     }
 

--- a/edc-extensions/agreements/retirement-evaluation-api/src/test/java/org/eclipse/tractusx/edc/agreements/retirement/api/v3/AgreementsRetirementApiV3ControllerTest.java
+++ b/edc-extensions/agreements/retirement-evaluation-api/src/test/java/org/eclipse/tractusx/edc/agreements/retirement/api/v3/AgreementsRetirementApiV3ControllerTest.java
@@ -224,7 +224,7 @@ class AgreementsRetirementApiV3ControllerTest extends RestControllerTestBase {
     private RequestSpecification baseRequest() {
         return given()
                 .baseUri("http://localhost:" + port)
-                .basePath("/v3/contractagreements/retire")
+                .basePath("/v3/contractagreements/retirements")
                 .when();
     }
 

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java
@@ -177,7 +177,7 @@ public abstract class TractusxParticipantBase extends IdentityParticipant {
                 .contentType(JSON)
                 .body(body)
                 .when()
-                .post("/v3/contractagreements/retire")
+                .post("/v3/contractagreements/retirements")
                 .then();
     }
 

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java
@@ -177,7 +177,7 @@ public abstract class TractusxParticipantBase extends IdentityParticipant {
                 .contentType(JSON)
                 .body(body)
                 .when()
-                .post("/v3.1alpha/retireagreements")
+                .post("/v3/contractagreements/retire")
                 .then();
     }
 


### PR DESCRIPTION
## WHAT

Stabilizes the agreements retirements api to v3 (was v3.1alpha before.)

## WHY

Gained maturity.

## FURTHER NOTES

This PR also moves the API the `/contractagreements/retirements` url path, as it makes sense for such actions to be under that domain.

Closes #1851 
