### PR TITLE
fix: update the path to the correct allure-results directory

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -136,14 +136,14 @@ jobs:
 
       - name: Set sanitized artifact name
         run: |
-          SANITIZED_NAME=$(echo "${{ matrix.variant.dir }}" | tr '/' '-')
+          SANITIZED_NAME=$(echo "edc-tests/e2e/${{ matrix.dir }}" | tr '/' '-')
           echo "ARTIFACT_NAME=${SANITIZED_NAME}" >> $GITHUB_ENV
 
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4
         with:
           name: allure-results-${{ env.ARTIFACT_NAME }}
-          path: ${{ matrix.variant.dir }}/build/allure-results
+          path: edc-tests/e2e/${{ matrix.dir }}/build/allure-results
 
   postgres-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## WHAT

This PR modifies the `Verif`y workflow to correctly resolve the path to the allure-results directory.

## WHY

To enable the generation of the Allure report for end-to-end tests.

Closes #1947 
