### PR TITLE
fix: avoid using gradle cache for end-to-end tests execution

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -130,8 +130,7 @@ jobs:
       - name: Run E2E tests (${{ matrix.dir }})
         run: |
           ./gradlew compileJava compileTestJava
-          ./gradlew -p edc-tests/e2e/${{ matrix.dir }} test -DincludeTags="EndToEndTest" -PverboseTest=true \
-          --rerun-tasks --no-build-cache
+          ./gradlew -p edc-tests/e2e/${{ matrix.dir }} test -DincludeTags="EndToEndTest" -PverboseTest=true --no-build-cache
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -130,7 +130,8 @@ jobs:
       - name: Run E2E tests (${{ matrix.dir }})
         run: |
           ./gradlew compileJava compileTestJava
-          ./gradlew -p edc-tests/e2e/${{ matrix.dir }} test -DincludeTags="EndToEndTest" -PverboseTest=true
+          ./gradlew -p edc-tests/e2e/${{ matrix.dir }} test -DincludeTags="EndToEndTest" -PverboseTest=true \
+          --rerun-tasks --no-build-cache
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 


### PR DESCRIPTION
## WHAT

This PR avoid using gradle cache when executing end-to-end tests in the `Verify` workflow

## WHY

To ensure that end-to-end tests always run and allow the generation of an accurate Allure report.

Part of #1952
