### PR TITLE
fix: exclude sts client extension from controlplane-base

### DIFF
--- a/edc-controlplane/edc-controlplane-base/build.gradle.kts
+++ b/edc-controlplane/edc-controlplane-base/build.gradle.kts
@@ -26,6 +26,9 @@ plugins {
 configurations.all {
     // edr-cache-api excluded due to edr controller signature clash with tx-edr-api-v2 that provides same functionality with token auto_refresh capability
     exclude(group = "org.eclipse.edc", module = "edr-cache-api")
+
+    // identity-trust-sts-remote-client excluded because we have the tx-dcp-sts-dim that takes care to define the correct client in case of DIM
+    exclude("org.eclipse.edc", "identity-trust-sts-remote-client")
 }
 
 dependencies {

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java
@@ -118,7 +118,6 @@ public abstract class TractusxParticipantBase extends IdentityParticipant {
                 put("edc.iam.sts.oauth.token.url", "http://sts.example.com/token");
                 put("edc.iam.sts.oauth.client.id", "test-clientid");
                 put("edc.iam.sts.oauth.client.secret.alias", "test-clientid-alias");
-                put("tx.edc.iam.sts.dim.url", "http://sts.example.com");
                 put("tx.edc.iam.iatp.bdrs.server.url", "http://sts.example.com");
                 put("edc.dataplane.api.public.baseurl", "%s/v2/data".formatted(dataPlanePublic.get()));
                 put("edc.catalog.cache.execution.delay.seconds", "2");

--- a/edc-tests/runtime/iatp/runtime-memory-iatp-dim-ih/build.gradle.kts
+++ b/edc-tests/runtime/iatp/runtime-memory-iatp-dim-ih/build.gradle.kts
@@ -25,10 +25,7 @@ plugins {
 dependencies {
 
     // use basic (all in-mem) control plane
-    implementation(project(":edc-controlplane:edc-controlplane-base")) {
-        exclude("org.eclipse.edc", "identity-trust-issuers-configuration")
-        exclude("org.eclipse.edc", "identity-trust-sts-remote-client")
-    }
+    implementation(project(":edc-controlplane:edc-controlplane-base"))
     implementation(project(":core:json-ld-core"))
     implementation(project(":edc-extensions:cx-policy"))
     implementation(project(":edc-extensions:dcp:tx-dcp"))
@@ -45,7 +42,6 @@ dependencies {
     implementation(libs.edc.core.controlplane)
     implementation(libs.edc.core.did)
     implementation(libs.edc.identity.trust.transform)
-    implementation(libs.edc.identity.trust.issuers.configuration)
     implementation(libs.edc.auth.oauth2.client)
     implementation(libs.edc.ih.api.presentation)
     implementation(libs.edc.ih.keypairs)

--- a/edc-tests/runtime/iatp/runtime-memory-iatp-ih/build.gradle.kts
+++ b/edc-tests/runtime/iatp/runtime-memory-iatp-ih/build.gradle.kts
@@ -25,10 +25,7 @@ plugins {
 dependencies {
 
     // use basic (all in-mem) control plane
-    implementation(project(":edc-controlplane:edc-controlplane-base")) {
-        exclude(module = "tx-dcp-sts-dim")
-        exclude("org.eclipse.edc", "identity-trust-issuers-configuration")
-    }
+    implementation(project(":edc-controlplane:edc-controlplane-base"))
     implementation(project(":edc-extensions:cx-policy"))
     implementation(project(":core:json-ld-core"))
     implementation(project(":edc-extensions:dcp:tx-dcp"))
@@ -44,8 +41,6 @@ dependencies {
     implementation(libs.edc.core.controlplane)
     implementation(libs.edc.core.did)
     implementation(libs.edc.identity.trust.transform)
-    implementation(libs.edc.identity.trust.sts.remote.client)
-    implementation(libs.edc.identity.trust.issuers.configuration)
     implementation(libs.edc.auth.oauth2.client)
     // IH dependencies
     implementation(libs.edc.ih.api.presentation)

--- a/edc-tests/runtime/iatp/runtime-memory-sts/build.gradle.kts
+++ b/edc-tests/runtime/iatp/runtime-memory-sts/build.gradle.kts
@@ -25,10 +25,7 @@ plugins {
 dependencies {
 
     // use basic (all in-mem) control plane
-    implementation(project(":edc-controlplane:edc-controlplane-base")) {
-        exclude(module = "tx-dcp-sts-dim")
-        exclude("org.eclipse.edc", "identity-trust-issuers-configuration")
-    }
+    implementation(project(":edc-controlplane:edc-controlplane-base"))
     implementation(project(":core:json-ld-core"))
 
     implementation(libs.edc.iam.mock)

--- a/edc-tests/runtime/runtime-postgresql/build.gradle.kts
+++ b/edc-tests/runtime/runtime-postgresql/build.gradle.kts
@@ -25,7 +25,6 @@ plugins {
 
 dependencies {
     runtimeOnly(project(":edc-controlplane:edc-controlplane-postgresql-hashicorp-vault")) {
-        exclude("org.eclipse.edc", "identity-trust-issuers-configuration")
         exclude("org.eclipse.edc", "vault-hashicorp")
         exclude(module = "tx-dcp")
         exclude(module = "tx-dcp-sts-dim")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -122,7 +122,6 @@ edc-identity-vc-ldp = { module = "org.eclipse.edc:ldp-verifiable-credentials", v
 edc-identity-vc-jwt = { module = "org.eclipse.edc:jwt-verifiable-credentials", version.ref = "edc" }
 edc-identity-trust-service = { module = "org.eclipse.edc:identity-trust-service", version.ref = "edc" }
 edc-identity-trust-transform = { module = "org.eclipse.edc:identity-trust-transform", version.ref = "edc" }
-edc-identity-trust-issuers-configuration = { module = "org.eclipse.edc:identity-trust-issuers-configuration", version.ref = "edc" }
 
 # DCP for Testing
 edc-identity-trust-sts-remote-client = { module = "org.eclipse.edc:identity-trust-sts-remote-client", version.ref = "edc" }

--- a/samples/edc-dast/edc-dast-runtime/build.gradle.kts
+++ b/samples/edc-dast/edc-dast-runtime/build.gradle.kts
@@ -27,13 +27,11 @@ plugins {
 dependencies {
     runtimeOnly(project(":edc-tests:runtime:iatp:runtime-memory-iatp-ih")) {
         exclude(module = "tx-dcp-sts-dim")
-        exclude("org.eclipse.edc", "identity-trust-sts-remote-client")
 
     }
 
     runtimeOnly(project(":edc-tests:runtime:iatp:runtime-memory-sts")) {
         exclude(module = "tx-dcp-sts-dim")
-        exclude("org.eclipse.edc", "identity-trust-sts-remote-client")
         exclude(group = "org.eclipse.edc", module = "iam-mock")
         exclude(module = "bdrs-client")
 

--- a/samples/multi-tenancy/build.gradle.kts
+++ b/samples/multi-tenancy/build.gradle.kts
@@ -29,13 +29,10 @@ dependencies {
     implementation(libs.edc.iam.mock)
     implementation(project(":edc-controlplane:edc-controlplane-base")) {
         exclude(module = "auth-tokenbased")
-        // the token refresh extension is not needed
-        exclude(module = "tx-dcp-sts-dim")
         exclude(module = "tokenrefresh-handler")
         exclude(module = "edr-core")
         exclude(module = "edr-api-v2")
         exclude(module = "edr-callback")
-        exclude("org.eclipse.edc", "identity-trust-issuers-configuration")
     }
     implementation(libs.edc.core.controlplane)
     implementation(libs.jakarta.rsApi)


### PR DESCRIPTION
## WHAT

Exclude `org.eclipse.edc:identity-trust-sts-remote-client` from the controlplane-base module.

## WHY

Fix bug

## FURTHER NOTES

### Why this happened?
Using upstream BOM files ([PR](https://github.com/eclipse-tractusx/tractusx-edc/pull/1937)) we also inherited that module, that as shown in logs we received from users, it was overriding 2 services:
```
WARNING 2025-05-13T01:58:53.310725006 A service of the type org.eclipse.edc.iam.identitytrust.sts.remote.StsRemoteClientConfiguration was already registered and has now been replaced with a StsRemoteClientConfiguration instance.
WARNING 2025-05-13T01:58:53.316061488 A service of the type org.eclipse.edc.iam.identitytrust.spi.SecureTokenService was already registered and has now been replaced with a RemoteSecureTokenService instance.
```

### Why we didn't catch that before?
Unfortunately in some e2e runtimes we were actually doing exclusions instead of relying on the pure production runtimes, that's why this PR is actually moving the exclusion up to the base runtime definition 

### How to prevent that in the future?
E2E tests should be as similar as possible to the production environment, trying to avoid mocks, stubs, dummies and fakes.

Closes #1968
