### PR TITLE
build: permit release from release/* branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,8 @@ jobs:
             exit 1
           fi
 
-          if [[ "${{ github.ref_name }}" != "main" && ! "${{ github.ref_name }}" =~ ^bugfix/ ]]; then
-            echo "This workflow can only be run on the main branch or branches starting with bugfix/."
+          if [[ ! "${{ github.ref_name }}" =~ ^release/ && ! "${{ github.ref_name }}" =~ ^bugfix/ ]]; then
+            echo "This workflow can only be run on the branches starting with release/ or bugfix/."
             exit 1
           fi
           


### PR DESCRIPTION
## WHAT

At the moment it's not possible to release from `release/` branches (sounds like an oxymoron :D )

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
