### PR TITLE
fix: exclude sql target node extension

### DIFF
--- a/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/build.gradle.kts
+++ b/edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/build.gradle.kts
@@ -26,6 +26,11 @@ plugins {
     alias(libs.plugins.shadow)
 }
 
+configurations.all {
+    // target-node-directory-sql excluded because we provide our own file based target node directory implementation
+    exclude(group = "org.eclipse.edc", module = "target-node-directory-sql")
+}
+
 dependencies {
     runtimeOnly(project(":edc-controlplane:edc-controlplane-base"))
 


### PR DESCRIPTION
## WHAT

Explicitly exclude the `target-node-directory-sql` extension

## WHY

To have our file based target-node working correctly.


## FURTHER NOTES

- if no file system target-node directory is provided, federated catalog will be disabled, so we can consider this as the default behavior

Closes #1965 
