### PR TITLE
docs: DR to Dataplane return selected http status codes

### DIFF
--- a/docs/development/decision-records/2025-05-21-return-http-status-codes-in-dataplane/README.md
+++ b/docs/development/decision-records/2025-05-21-return-http-status-codes-in-dataplane/README.md
@@ -1,4 +1,4 @@
-# Expose HTTP status code
+# Dataplane to expose HTTP status code
 
 ## Decision
 
@@ -10,10 +10,8 @@ Currently, the dataplane does not return status code different from 2XX or 5XX. 
 
 To achieve it, a new `allowedStatusCodes` field will be added to the http data address in which it contains the accepted http status codes (and respective response messages) that the dataplane can return. The current behaviour will be kept as the default one.
 
-
-
 ## Approach
 
 1. Include the logic needed from `data-plane-http` and `data-plane-http-spi` (like `HttpDataSource`, `HttpRequestParams` or `HttpDataAddress`) upstream modules in the Tractus-X EDC distribution. 
-2. In the `HttpRequestParams` include the new optional parameter `allowedStatusCodes`. If empty, the default behaviour will be kept (2XX and 5XX).
+2. In the `HttpRequestParams` include the new optional parameter `allowedStatusCodes`. If empty, the default behaviour will be kept (2XX or 5XX).
 3. In the `HttpDataSource` included implementation, update the `openPartStream()` overridden method to handle the error message to allow the return of established status code and respective message, based on chosen range.

--- a/docs/development/decision-records/2025-05-21-return-http-status-codes-in-dataplane/README.md
+++ b/docs/development/decision-records/2025-05-21-return-http-status-codes-in-dataplane/README.md
@@ -1,4 +1,4 @@
-# Dataplane to expose HTTP status code
+# Dataplane to expose selected HTTP status code
 
 ## Decision
 

--- a/docs/development/decision-records/2025-05-21-return-http-status-codes-in-dataplane/README.md
+++ b/docs/development/decision-records/2025-05-21-return-http-status-codes-in-dataplane/README.md
@@ -1,0 +1,19 @@
+# Expose HTTP status code
+
+## Decision
+
+The dataplane API will expose the status codes and respective messages based on a new allowed status code range parameter. 
+
+## Rationale
+
+Currently, the dataplane does not return status code different from 2XX or 5XX. This is due to not exposing potentitally sensitive information. However, there is a need to allow the option of returning different http status codes that may reflect the real behaviour, easing troubleshooting.
+
+To achieve it, a new `allowedStatusCodes` field will be added to the http data address in which it contains the accepted http status codes (and respective response messages) that the dataplane can return. The current behaviour will be kept as the default one.
+
+
+
+## Approach
+
+1. Include the logic needed from `data-plane-http` and `data-plane-http-spi` (like `HttpDataSource`, `HttpRequestParams` or `HttpDataAddress`) upstream modules in the Tractus-X EDC distribution. 
+2. In the `HttpRequestParams` include the new optional parameter `allowedStatusCodes`. If empty, the default behaviour will be kept (2XX and 5XX).
+3. In the `HttpDataSource` included implementation, update the `openPartStream()` overridden method to handle the error message to allow the return of established status code and respective message, based on chosen range.


### PR DESCRIPTION
## WHAT

Adds a DR proposal to allow the http dataplane to return other status codes other than 2XX or 5XX.

## WHY

Some requirements in turning this optional since having a larger scope of available http status codes can ease usage. 

## FURTHER NOTES

Other considered option was to toggle at the service level, applicable to all usage (very restritive and forces the user to use this if not wanted on some asset). 

Relates to #1850 
