### PR TITLE
docs:  update links to upstream documents

### DIFF
--- a/docs/migration/Version_0.1.x_0.3.x.md
+++ b/docs/migration/Version_0.1.x_0.3.x.md
@@ -17,13 +17,13 @@ Details at the [official documentation on swaggerhub](https://app.swaggerhub.com
 
 ## Settings changes
 
-- refactored the HTTP server contexts (more details on the [related decision record](https://eclipse-edc.github.io/docs/#/submodule/Connector/docs/developer/decision-records/2022-11-09-api-refactoring/renaming)). They need to be refactored as:
+- refactored the HTTP server contexts (more details on the [related decision record](https://github.com/eclipse-edc/Connector/blob/v0.1.0/docs/developer/decision-records/2022-11-09-api-refactoring/renaming.md)). They need to be refactored as:
   - `web.http.data` becomes `web.http.management`
   - `web.http.ids` becomes `web.http.protocol`
   - `web.http.validation`, `web.http.controlplane` and `web.http.dataplane` become `web.http.control`
 - Healthcheck api now it's exposed under the `management` context.
 - Removed default value for setting `edc.transfer.proxy.token.verifier.publickey.alias` so it must be valued accordingly
-- made the state machine settings configurable so it will be possible to tune them accordingly. More details in the [related documentation entry](https://eclipse-edc.github.io/docs/#/submodule/Connector/docs/developer/performance-tuning).
+- made the state machine settings configurable so it will be possible to tune them accordingly. More details in the [related documentation entry](https://github.com/eclipse-edc/Connector/blob/v0.1.0/docs/developer/performance-tuning.md).
 - renamed `edc.receiver.http.endpoint` to `edc.receiver.http.dynamic.endpoint`
 - renamed `edc.oauth.public.key.alias` setting to `edc.oauth.certificate.alias`
 

--- a/docs/migration/Version_0.4.x_0.5.x.md
+++ b/docs/migration/Version_0.4.x_0.5.x.md
@@ -106,7 +106,7 @@ The status (`/health`, `/startup`, `/liveness`, `/readiness`) of the EDC can be 
 
 Starting from `0.5.0-rc5` which incorporates `EDC` 0.1.3, the consumer pull has been simplified in upstream, and it
 can cause some breaking changes on users usage. The change is reflected in
-this [diagram](https://github.com/eclipse-edc/Connector/blob/main/docs/developer/architecture/data-transfer/diagrams/transfer-data-plane-consumer-pull.png).
+this [diagram](https://github.com/eclipse-edc/Connector/blob/v0.1.3/docs/developer/architecture/data-transfer/diagrams/transfer-data-plane-consumer-pull.png).
 
 The main difference is that in the previous iteration of the pull flow there were two EDRs involved. One created by the
 provider while serving

--- a/docs/migration/Version_0.5.x_0.7.x.md
+++ b/docs/migration/Version_0.5.x_0.7.x.md
@@ -53,7 +53,7 @@ auto-refresh the token if it is nearing expiry.
 
 In order for Dataplane Signaling to become aligned with the Dataspace Protocol (DSP), `DataAddress` objects now conform
 to
-the `dspace` [data format](https://github.com/eclipse-edc/Connector/blob/main/docs/developer/data-plane-signaling/data-plane-signaling-token-handling.md#2-updates-to-thedataaddress-format).
+the `dspace` [data format](https://github.com/eclipse-edc/Connector/blob/v0.7.2/docs/developer/data-plane-signaling/data-plane-signaling-token-handling.md#2-updates-to-thedataaddress-format).
 
 ### 1.4 Dataplane Signaling API
 
@@ -73,9 +73,9 @@ participant's control plane and data plane.
 ### 1.6 Further references
 
 - Dataplane Signaling
-  [documentation](https://github.com/eclipse-edc/Connector/blob/main/docs/developer/data-plane-signaling/data-plane-signaling.md)
+  [documentation](https://github.com/eclipse-edc/Connector/blob/v0.7.2/docs/developer/data-plane-signaling/data-plane-signaling.md)
   and [token
-  handling](https://github.com/eclipse-edc/Connector/blob/main/docs/developer/data-plane-signaling/data-plane-signaling-token-handling.md)
+  handling](https://github.com/eclipse-edc/Connector/blob/v0.7.2/docs/developer/data-plane-signaling/data-plane-signaling-token-handling.md)
 - [Tractus-X Specification for Token
   Renewal](https://github.com/eclipse-tractusx/tractusx-profiles/blob/main/tx/refresh/refresh.token.grant.profile.md)
 - [Tractus-X EDC Implementation
@@ -91,7 +91,7 @@ Likewise, the option to dynamically register a consumer-side HTTP-callback via `
 
 The main reason is that EDC/Tractus-X-EDC switched to Dataplane Signaling for handling transfers and the EDR format
 specified in
-DPS [spec](https://github.com/eclipse-edc/Connector/blob/main/docs/developer/data-plane-signaling/data-plane-signaling-token-handling.md)
+DPS [spec](https://github.com/eclipse-edc/Connector/blob/v0.7.2/docs/developer/data-plane-signaling/data-plane-signaling-token-handling.md)
 was not handled properly by the receiver extension.
 
 Now all the EDRs are automatically stored by the consumer's EDR cache and made available via the new
@@ -138,7 +138,7 @@ EDC_CALLBACK_CB1_EVENTS="transfer.process.started"
 
 - [OpenAPI Spec](https://app.swaggerhub.com/apis/eclipse-tractusx-bot/tractusx-edc/0.7.0), "Control Plane EDR Api"
 - More info
-  about [callbacks](https://github.com/eclipse-edc/Connector/tree/main/docs/developer/decision-records/2023-02-28-processing-callbacks)
+  about [callbacks](https://github.com/eclipse-edc/Connector/tree/v0.7.2/docs/developer/decision-records/2023-02-28-processing-callbacks)
 
 ## 3. Identity And Trust Protocols (IATP)
 
@@ -318,7 +318,7 @@ the [EDR API documentation](https://github.com/eclipse-tractusx/tractusx-edc/blo
 - The `consumerId` and `providerId` were replaced by the ODRL `assignee `and `assigner`, respectively. The latter also
   has to be injected in the ContractRequest Message.
 - A transfer process has now a new transfer type property that should adhere to the following
-  mapping: https://github.com/eclipse-edc/Connector/blob/main/docs/developer/data-plane-signaling/data-plane-signaling-mapping.md
+  mapping: https://github.com/eclipse-edc/Connector/blob/v0.7.2/docs/developer/data-plane-signaling/data-plane-signaling-mapping.md
 - The EDR API changed, and it's no longer possible to query for EDRs by contract agreement directly. A `QuerySpec` with
   a filter has to be used for this.
 - The AWS S3 Extension also has been improved and now enables the user to specify S3 object prefixes in the data

--- a/docs/usage/management-api-walkthrough/02_policies.md
+++ b/docs/usage/management-api-walkthrough/02_policies.md
@@ -117,7 +117,7 @@ policies.
    authorized to pass the constraint or define a group of BPNs that may pass and can be extended at runtime.
 3. **Checks for temporal validity**: If a usage policy is defined against a HTTP-based asset accessible via EDR-tokens,
    the Data Provider can prohibit issuance of new tokens by defining a specific constraint based on the
-   [contract validity check extension](https://github.com/eclipse-edc/Connector/blob/main/docs/developer/contract-duration/contract-validity-check.md)
+   [contract validity check extension](https://eclipse-edc.github.io/documentation/for-adopters/control-plane/policy-engine/#in-force-policy)
 
 ### Access & Usage Policies
 

--- a/docs/usage/management-api-walkthrough/05_contractnegotiations.md
+++ b/docs/usage/management-api-walkthrough/05_contractnegotiations.md
@@ -140,7 +140,7 @@ The Contract Negotiation was successful when `edc:state == FINALIZED`.
 As shown in the example above, state transitions can also be subscribed to by adding a `callbackAddress`. A typical
 callback message will hold the relevant information in the `type` property. The value of the `type` property will always
 hold a string following the schema `ContractNegotiation` appended by the new state like `Verified` yielding `ContractNegotiationVerified`
-The state-machine for the Contract Negotiation process is [visualized in the documentation](https://eclipse-edc.github.io/docs/#/submodule/Connector/docs/developer/contracts?id=state-machine)
+The state-machine for the Contract Negotiation process is [visualized in the documentation](https://eclipse-edc.github.io/documentation/for-contributors/control-plane/entities/#4-contract-negotiations)
 of the eclipse-edc/connector. The diagram only visualizes the transitions while the callbacks are fired when such a
 transition is done yielding a new state.
 

--- a/docs/usage/management-api-walkthrough/06_transferprocesses.md
+++ b/docs/usage/management-api-walkthrough/06_transferprocesses.md
@@ -5,7 +5,7 @@ the consumer access to a `Dataset` under the terms negotiated the in [Contract N
 
 The processes are handled in the state machine of the Control Planes, but the real data transfer (if necessary)
 happens in the provider Data Plane. 
-TractusX 0.7.0 follows the spec of [DPS](https://github.com/eclipse-edc/Connector/blob/main/docs/developer/data-plane-signaling/data-plane-signaling.md) (Data plane signaling) for Control Plane -> Data Plane communication
+TractusX 0.7.0 follows the spec of [DPS](https://eclipse-edc.github.io/documentation/for-contributors/data-plane/data-plane-signaling/) (Data plane signaling) for Control Plane -> Data Plane communication
 
 Currently, transfer processes are divided in two modes:
 
@@ -155,7 +155,7 @@ yielding
 }
 ```
 Note that the property `errorDetails` will only be returned in certain states and may contain hints to where the communication
-between the Data Planes failed. The state-machine for the Transfer Process is [documented here](https://eclipse-edc.github.io/docs/#/submodule/Connector/docs/developer/data-transfer?id=transfer-process-state-machine).
+between the Data Planes failed. The state-machine for the Transfer Process is [documented here](https://eclipse-edc.github.io/documentation/for-contributors/control-plane/entities/#7-transfer-processes).
 
 ### Callbacks
 

--- a/docs/usage/management-api-walkthrough/07_edrs.md
+++ b/docs/usage/management-api-walkthrough/07_edrs.md
@@ -11,7 +11,7 @@ Previously TractusX-EDC provided a set extensions for caching EDRs on Consumer s
 The renewal was handled proactively by firing another transfer process with the same contract agreement near expiry and caching
 the newly transmitted EDR.
 
-Starting from TractusX-EDC 0.7.0, the high level concepts are the same, but with the advent of [DPS](https://github.com/eclipse-edc/Connector/blob/main/docs/developer/data-plane-signaling/data-plane-signaling.md) (Data plane signaling)
+Starting from TractusX-EDC 0.7.0, the high level concepts are the same, but with the advent of [DPS](https://eclipse-edc.github.io/documentation/for-contributors/data-plane/data-plane-signaling/) (Data plane signaling)
 the way EDRs are managed and renewed has been changed.
 
 Since the default implementation of DPS does not support token refresh, the TractusX-EDC project extends it by introducing refresh capabilities. More info [here](https://github.com/eclipse-tractusx/tractusx-edc/blob/main/docs/development/dataplane-signaling/tx-signaling.extensions.md)

--- a/docs/usage/management-api-walkthrough/README.md
+++ b/docs/usage/management-api-walkthrough/README.md
@@ -93,16 +93,14 @@ given they are not part of the following list:
       the ["Connect" section of the E2E-Tutorial](https://eclipse-tractusx.github.io/docs/tutorials/e2e/connect/prepareInfrastructure)
       for first steps. It provides an easy-to-start preconfigured deployment of critical Catena-X infrastructure
       components.
-    - The [MXD documentation](https://eclipse-edc.github.io/docs/#/submodule/MinimumViableDataspace/docs/developer/continuous-deployment/continuous_deployment) has a similar section on its setup.
+    - The [MXD documentation](https://github.com/eclipse-tractusx/tutorial-resources/blob/main/mxd/README.md#1-prerequisites) has a similar section on its setup.
     - To deploy and configure the Tractus-X EDC, check
       its [documentation](https://github.com/eclipse-tractusx/tractusx-edc/blob/main/README.md).
 - Exchanging data via two EDCs:
     - Via API: ["Boost" section of the E2E-Tutorial](https://eclipse-tractusx.github.io/docs/tutorials/e2e/boost/). It
       is
       exemplary and non-comprehensive.
-    - Via
-      Frontend: [The MXD-Documentation ](https://eclipse-edc.github.io/docs/#/submodule/MinimumViableDataspace/docs/developer/?id=scenarios-covered)
-      explains how to use the open-source web-view.
+    - Via the [MXD](https://github.com/eclipse-tractusx/tutorial-resources/blob/main/mxd/README.md#27-use-postman-collections-to-communicate-with-your-services).
 - [Eclipse-EDC Samples](https://github.com/eclipse-edc/Samples): This repo includes a wide variety of setups - many of
   which
   go beyond this Kit in scope but not in detail.

--- a/edc-extensions/bpn-validation/README.md
+++ b/edc-extensions/bpn-validation/README.md
@@ -13,7 +13,7 @@ This extension is used to introduce the capability to a connector to evaluate tw
 
 Technically, both these policies and their evaluation functions can be used in several circumstances, which in EDC are
 called *scopes*. More information on how to bind policy functions to scopes can be found in
-the [official documentation](https://github.com/eclipse-edc/Connector/blob/main/docs/developer/policy-engine.md).
+the [official documentation](https://eclipse-edc.github.io/documentation/for-adopters/control-plane/policy-engine/).
 
 Both previously mentioned evaluation functions are bound to the following scopes:
 


### PR DESCRIPTION
## WHAT

This PR update links to upstream documentation that is outdated.

## WHY

To have actual documentation.

Closes #2005 
