### PR TITLE
fix: restored copyright to all eclipse contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Catena-X
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/charts/tractusx-connector-memory/LICENSE
+++ b/charts/tractusx-connector-memory/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Catena-X
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/charts/tractusx-connector/LICENSE
+++ b/charts/tractusx-connector/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Catena-X
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## WHAT

- Removed Catena-X Copyright and substituted with empty copyright owner

## WHY

As specified in this issue #2029 the Licenses used are pointing to Catena-X and that is not true anymore since the consortia died. Or you add the Catena-X Automotive Network e.V.  Association or you remove it so it valid for all the eclipse contributors.

I am not sure if it should be the eclipse foundation.

I am removing it so it would be valid for everyone like in other repos.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #2029
