### PR TITLE
feat: add hardcoded default scopes

### DIFF
--- a/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientImpl.java
+++ b/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientImpl.java
@@ -154,7 +154,7 @@ class BdrsClientImpl implements BdrsClient {
                 SUBJECT, ownDid,
                 AUDIENCE, ownDid
         );
-        var scope = TxIatpConstants.DEFAULT_MEMBERSHIP_SCOPE;
+        var scope = TxIatpConstants.MEMBERSHIP_SCOPE;
 
         return secureTokenService.createToken(claims, scope)
                 .compose(sit -> credentialServiceClient.requestPresentation(ownCredentialServiceUrl.get(), sit.getToken(), List.of(scope)))

--- a/spi/core-spi/src/main/java/org/eclipse/tractusx/edc/TxIatpConstants.java
+++ b/spi/core-spi/src/main/java/org/eclipse/tractusx/edc/TxIatpConstants.java
@@ -26,9 +26,13 @@ import static java.lang.String.format;
 public interface TxIatpConstants {
 
     String CREDENTIAL_TYPE_NAMESPACE = "org.eclipse.tractusx.vc.type";
-    String DEFAULT_CREDENTIAL = "MembershipCredential";
+    String MEMBERSHIP_CREDENTIAL = "MembershipCredential";
+    String DATA_EXCHANGE_GOVERNANCE_CREDENTIAL = "DataExchangeGovernanceCredential";
+    String BPN_CREDENTIAL = "BpnCredential";
     String READ_OPERATION = "read";
-    String DEFAULT_MEMBERSHIP_SCOPE = format("%s:%s:%s", CREDENTIAL_TYPE_NAMESPACE, DEFAULT_CREDENTIAL, READ_OPERATION);
-    Set<String> DEFAULT_SCOPES = Set.of(DEFAULT_MEMBERSHIP_SCOPE);
+    String MEMBERSHIP_SCOPE = format("%s:%s:%s", CREDENTIAL_TYPE_NAMESPACE, MEMBERSHIP_CREDENTIAL, READ_OPERATION);
+    String DATA_EXCHANGE_GOVERNANCE_SCOPE = format("%s:%s:%s", CREDENTIAL_TYPE_NAMESPACE, DATA_EXCHANGE_GOVERNANCE_CREDENTIAL, READ_OPERATION);
+    String BPN_SCOPE = format("%s:%s:%s", CREDENTIAL_TYPE_NAMESPACE, BPN_CREDENTIAL, READ_OPERATION);
+    Set<String> DEFAULT_SCOPES = Set.of(MEMBERSHIP_SCOPE, DATA_EXCHANGE_GOVERNANCE_SCOPE, BPN_SCOPE);
 
 }


### PR DESCRIPTION
## WHAT

The TX EDC should contain two more scopes.

## WHY

It should be possible to evaulate the DataExchangeGovernance credential during the catalog request.

Closes #1996