### PR TITLE
feat: non finite provider push

### DIFF
--- a/edc-dataplane/edc-dataplane-base/build.gradle.kts
+++ b/edc-dataplane/edc-dataplane-base/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
     runtimeOnly(project(":edc-extensions:dcp:tx-dcp-sts-dim"))
     runtimeOnly(project(":edc-extensions:tokenrefresh-handler"))
 
+    runtimeOnly(project(":edc-extensions:non-finite-provider-push:non-finite-provider-push-core"))
+
     runtimeOnly(libs.bundles.edc.monitoring)
     runtimeOnly(libs.edc.aws.validator.data.address.s3)
     runtimeOnly(libs.edc.core.did) // for the DID Public Key Resolver

--- a/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/build.gradle.kts
+++ b/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/build.gradle.kts
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+dependencies {
+    api(project(":edc-extensions:non-finite-provider-push:non-finite-provider-push-spi"))
+
+    implementation(libs.edc.spi.core)
+    implementation(libs.edc.spi.dataplane.dataplane)
+    implementation(libs.opentelemetry.instrumentation.annotations)
+
+    testImplementation(libs.edc.junit)
+    testImplementation(libs.assertj)
+}

--- a/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/main/java/org/eclipse/edc/tractusx/non/finite/provider/push/core/evaluator/FinitenessEvaluatorExtension.java
+++ b/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/main/java/org/eclipse/edc/tractusx/non/finite/provider/push/core/evaluator/FinitenessEvaluatorExtension.java
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.edc.tractusx.non.finite.provider.push.core.evaluator;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.tractusx.non.finite.provider.push.spi.FinitenessEvaluator;
+
+@Extension(FinitenessEvaluatorExtension.NAME)
+public class FinitenessEvaluatorExtension implements ServiceExtension {
+
+    public static final String NAME = "Finiteness Evaluator";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider(isDefault = true)
+    public FinitenessEvaluator finitenessEvaluator() {
+        return new FinitenessEvaluatorImpl();
+    }
+
+}

--- a/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/main/java/org/eclipse/edc/tractusx/non/finite/provider/push/core/evaluator/FinitenessEvaluatorImpl.java
+++ b/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/main/java/org/eclipse/edc/tractusx/non/finite/provider/push/core/evaluator/FinitenessEvaluatorImpl.java
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (c) 2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.edc.tractusx.non.finite.provider.push.core.evaluator;
+
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.edc.tractusx.non.finite.provider.push.spi.FinitenessEvaluator;
+
+import static java.lang.Boolean.parseBoolean;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
+public class FinitenessEvaluatorImpl implements FinitenessEvaluator {
+
+    private static final String IS_NON_FINITE_PROP = EDC_NAMESPACE + "isNonFinite";
+
+    @Override
+    public boolean isNonFinite(DataFlow dataflow) {
+        return containsNonFiniteProperty(dataflow.getSource());
+    }
+
+    @Override
+    public boolean isNonFinite(DataFlowStartMessage message) {
+        return containsNonFiniteProperty(message.getSourceDataAddress());
+    }
+
+    private boolean containsNonFiniteProperty(DataAddress address) {
+        return parseBoolean(address.getStringProperty(IS_NON_FINITE_PROP));
+    }
+}

--- a/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/main/java/org/eclipse/edc/tractusx/non/finite/provider/push/core/pipeline/NonFiniteCapablePipelineService.java
+++ b/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/main/java/org/eclipse/edc/tractusx/non/finite/provider/push/core/pipeline/NonFiniteCapablePipelineService.java
@@ -1,0 +1,220 @@
+/********************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.edc.tractusx.non.finite.provider.push.core.pipeline;
+
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSink;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSinkFactory;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSourceFactory;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.edc.tractusx.non.finite.provider.push.spi.FinitenessEvaluator;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.lang.String.format;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.stream.Collectors.toSet;
+
+/**
+ * Pipeline service implementation to handle
+ * finite and non-finite data transfers
+ */
+public class NonFiniteCapablePipelineService implements PipelineService {
+
+    private final List<DataSourceFactory> sourceFactories = new ArrayList<>();
+    private final List<DataSinkFactory> sinkFactories = new ArrayList<>();
+    private final Map<String, DataSource> sources = new ConcurrentHashMap<>();
+
+    private final Monitor monitor;
+    private final FinitenessEvaluator finitenessEvaluator;
+
+    public NonFiniteCapablePipelineService(Monitor monitor, FinitenessEvaluator finitenessEvaluator) {
+        this.monitor = monitor;
+        this.finitenessEvaluator = finitenessEvaluator;
+    }
+
+    @Override
+    public boolean canHandle(DataFlowStartMessage request) {
+        return getSourceFactory(request) != null && getSinkFactory(request) != null;
+    }
+
+    @Override
+    public Result<Void> validate(DataFlowStartMessage request) {
+        var sourceFactory = getSourceFactory(request);
+        if (sourceFactory == null) {
+            // NB: do not include the source type as that can possibly leak internal
+            // information
+            return Result.failure("Data source not supported for: " + request.getId());
+        }
+
+        var sourceValidation = sourceFactory.validateRequest(request);
+        if (sourceValidation.failed()) {
+            return Result.failure(sourceValidation.getFailureMessages());
+        }
+
+        var sinkFactory = getSinkFactory(request);
+        if (sinkFactory == null) {
+            // NB: do not include the target type as that can possibly leak internal
+            // information
+            return Result.failure("Data sink not supported for: " + request.getId());
+        }
+
+        var sinkValidation = sinkFactory.validateRequest(request);
+        if (sinkValidation.failed()) {
+            return Result.failure(sinkValidation.getFailureMessages());
+        }
+
+        return Result.success();
+    }
+
+    @WithSpan
+    @Override
+    public CompletableFuture<StreamResult<Object>> transfer(DataFlowStartMessage request) {
+        var sinkFactory = getSinkFactory(request);
+        if (sinkFactory == null) {
+            return noSinkFactory(request);
+        }
+
+        var sink = sinkFactory.createSink(request);
+
+        return transfer(request, sink);
+    }
+
+    @WithSpan
+    @Override
+    public CompletableFuture<StreamResult<Object>> transfer(DataFlowStartMessage request, DataSink sink) {
+        var sourceFactory = getSourceFactory(request);
+        if (sourceFactory == null) {
+            return noSourceFactory(request);
+        }
+        var source = sourceFactory.createSource(request);
+
+        sources.put(request.getProcessId(), source);
+        monitor.debug(() -> format("Transferring from %s to %s for flow id: %s.",
+                request.getSourceDataAddress().getType(), request.getDestinationDataAddress().getType(),
+                request.getProcessId()));
+
+        var futureResult = sink.transfer(source)
+                .thenApply(result -> {
+                    terminate(request.getProcessId());
+                    return result;
+                });
+
+        if (!finitenessEvaluator.isNonFinite(request)) {
+            return futureResult;
+        }
+
+        // Complete transfer only if transfer result failed for non-finite data
+        var returnedFuture = new CompletableFuture<StreamResult<Object>>();
+        futureResult.thenAccept(result -> {
+            if (result.failed()) {
+                returnedFuture.complete(result);
+            }
+        });
+        return returnedFuture;
+    }
+
+    @Override
+    public StreamResult<Void> terminate(DataFlow dataFlow) {
+        return terminate(dataFlow.getId());
+    }
+
+    @Override
+    public void closeAll() {
+        sources.forEach((processId, source) -> terminate(processId));
+    }
+
+    @Override
+    public void registerFactory(DataSourceFactory factory) {
+        sourceFactories.add(factory);
+    }
+
+    @Override
+    public void registerFactory(DataSinkFactory factory) {
+        sinkFactories.add(factory);
+    }
+
+    @Override
+    public Set<String> supportedSourceTypes() {
+        return sourceFactories.stream().map(DataSourceFactory::supportedType).collect(toSet());
+    }
+
+    @Override
+    public Set<String> supportedSinkTypes() {
+        return sinkFactories.stream().map(DataSinkFactory::supportedType).collect(toSet());
+    }
+
+    @Nullable
+    private DataSourceFactory getSourceFactory(DataFlowStartMessage request) {
+        return sourceFactories.stream()
+                .filter(s -> Objects.equals(s.supportedType(), request.getSourceDataAddress().getType()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Nullable
+    private DataSinkFactory getSinkFactory(DataFlowStartMessage request) {
+        return sinkFactories.stream()
+                .filter(s -> Objects.equals(s.supportedType(), request.getDestinationDataAddress().getType()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private StreamResult<Void> terminate(String dataFlowId) {
+        var source = sources.remove(dataFlowId);
+        if (source == null) {
+            return StreamResult.notFound();
+        } else {
+            try {
+                source.close();
+                return StreamResult.success();
+            } catch (Exception e) {
+                return StreamResult.error("Cannot terminate DataFlow %s: %s".formatted(dataFlowId, e.getMessage()));
+            }
+        }
+    }
+
+    @NotNull
+    private CompletableFuture<StreamResult<Object>> noSourceFactory(DataFlowStartMessage request) {
+        return completedFuture(StreamResult.error("Unknown data source type %s for flow id: %s.".formatted(
+                request.getSourceDataAddress().getType(), request.getProcessId())));
+    }
+
+    @NotNull
+    private CompletableFuture<StreamResult<Object>> noSinkFactory(DataFlowStartMessage request) {
+        return completedFuture(StreamResult.error("Unknown data sink type %s for flow id: %s.".formatted(
+                request.getDestinationDataAddress().getType(), request.getProcessId())));
+    }
+
+}

--- a/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/main/java/org/eclipse/edc/tractusx/non/finite/provider/push/core/pipeline/NonFiniteCapablePipelineServiceExtension.java
+++ b/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/main/java/org/eclipse/edc/tractusx/non/finite/provider/push/core/pipeline/NonFiniteCapablePipelineServiceExtension.java
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.edc.tractusx.non.finite.provider.push.core.pipeline;
+
+import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.tractusx.non.finite.provider.push.spi.FinitenessEvaluator;
+
+@Extension(NonFiniteCapablePipelineServiceExtension.NAME)
+public class NonFiniteCapablePipelineServiceExtension implements ServiceExtension {
+
+    public static final String NAME = "Non Finite Capable Pipeline Service";
+
+    @Inject
+    private Monitor monitor;
+
+    @Inject
+    private FinitenessEvaluator finitenessEvaluator;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider
+    public PipelineService pipelineService() {
+        return new NonFiniteCapablePipelineService(monitor, finitenessEvaluator);
+    }
+
+}
+

--- a/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -18,3 +18,4 @@
 #################################################################################
 
 org.eclipse.edc.tractusx.non.finite.provider.push.core.evaluator.FinitenessEvaluatorExtension
+org.eclipse.edc.tractusx.non.finite.provider.push.core.pipeline.NonFiniteCapablePipelineServiceExtension

--- a/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,20 @@
+#################################################################################
+#  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+org.eclipse.edc.tractusx.non.finite.provider.push.core.evaluator.FinitenessEvaluatorExtension

--- a/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/test/java/org/eclipse/edc/tractusx/non/finite/provider/push/core/evaluator/FinitenessEvaluatorImplTest.java
+++ b/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/test/java/org/eclipse/edc/tractusx/non/finite/provider/push/core/evaluator/FinitenessEvaluatorImplTest.java
@@ -1,0 +1,75 @@
+/********************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.edc.tractusx.non.finite.provider.push.core.evaluator;
+
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FinitenessEvaluatorImplTest {
+
+    private FinitenessEvaluatorImpl finitenessEvaluator;
+
+    @BeforeEach
+    public void setup() {
+        finitenessEvaluator = new FinitenessEvaluatorImpl();
+    }
+
+    private DataFlow createFiniteDataFlow() {
+        return DataFlow.Builder.newInstance()
+                .source(DataAddress.Builder.newInstance().type("smt").build())
+                .build();
+    }
+
+    private DataFlow createNonFiniteDataFlow() {
+        return DataFlow.Builder.newInstance()
+                .source(DataAddress.Builder.newInstance()
+                        .type("smt")
+                        .property(EDC_NAMESPACE + "isNonFinite", "true")
+                        .build())
+                .build();
+    }
+
+    @Test
+    public void isNonFinite_shouldReturnFalse_whenDataFlowIsFinite() {
+        assertFalse(finitenessEvaluator.isNonFinite(createFiniteDataFlow()));
+    }
+
+    @Test
+    public void isNonFinite_shouldReturnTrue_whenDataFlowIsNonFinite() {
+        assertTrue(finitenessEvaluator.isNonFinite(createNonFiniteDataFlow()));
+    }
+
+    @Test
+    public void isNonFinite_shouldReturnFalse_whenDataFlowStartMessageIsFinite() {
+        assertFalse(finitenessEvaluator.isNonFinite(createFiniteDataFlow().toRequest()));
+    }
+
+    @Test
+    public void isNonFinite_shouldReturnTrue_whenDataFlowStartMessageIsNonFinite() {
+        assertTrue(finitenessEvaluator.isNonFinite(createNonFiniteDataFlow().toRequest()));
+    }
+
+}

--- a/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/test/java/org/eclipse/edc/tractusx/non/finite/provider/push/core/pipeline/NonFiniteCapablePipelineServiceIntegrationTest.java
+++ b/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/test/java/org/eclipse/edc/tractusx/non/finite/provider/push/core/pipeline/NonFiniteCapablePipelineServiceIntegrationTest.java
@@ -1,0 +1,181 @@
+/********************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.edc.tractusx.non.finite.provider.push.core.pipeline;
+
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSink;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSinkFactory;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSourceFactory;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.InputStreamDataSource;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.edc.tractusx.non.finite.provider.push.spi.FinitenessEvaluator;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult.failure;
+import static org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult.success;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.util.async.AsyncUtils.asyncAllOf;
+import static org.mockito.Mockito.mock;
+
+class NonFiniteCapablePipelineServiceIntegrationTest {
+
+    private final Monitor monitor = mock();
+    private final FinitenessEvaluator finitenessEvaluator = mock();
+    private final NonFiniteCapablePipelineService pipelineService = new NonFiniteCapablePipelineService(monitor, finitenessEvaluator);
+
+    private static class InputStreamDataSourceFactory implements DataSourceFactory {
+
+        private static final List<String> DATA = List.of("foo", "bar", "baz");
+
+        private int count = 0;
+
+        @Override
+        public String supportedType() {
+            return "any";
+        }
+
+        @Override
+        public DataSource createSource(DataFlowStartMessage request) {
+            var bytes = DATA.get(count).getBytes();
+            count++;
+            return new InputStreamDataSource("test", new ByteArrayInputStream(bytes));
+        }
+
+        @Override
+        public @NotNull Result<Void> validateRequest(DataFlowStartMessage request) {
+            return Result.success();
+        }
+
+    }
+
+    private static class MemorySink implements DataSink {
+
+        private final ByteArrayOutputStream bos;
+
+        MemorySink() {
+            bos = new ByteArrayOutputStream();
+        }
+
+        @Override
+        public CompletableFuture<StreamResult<Object>> transfer(DataSource source) {
+            var streamResult = source.openPartStream();
+            if (streamResult.failed()) {
+                return completedFuture(failure(streamResult.getFailure()));
+            }
+            var partStream = streamResult.getContent();
+            return partStream
+                    .map(part -> supplyAsync(() -> transferTo(part, bos)))
+                    .collect(asyncAllOf())
+                    .thenApply(longs -> success(bos.toByteArray()));
+        }
+
+        private long transferTo(DataSource.Part part, OutputStream stream) {
+            try {
+                return part.openStream().transferTo(stream);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+
+    private static class MemorySinkFactory implements DataSinkFactory {
+
+        @Override
+        public String supportedType() {
+            return "any";
+        }
+
+        @Override
+        public DataSink createSink(DataFlowStartMessage request) {
+            return new MemorySink();
+        }
+
+        @Override
+        public @NotNull Result<Void> validateRequest(DataFlowStartMessage request) {
+            return Result.success();
+        }
+    }
+
+    private DataFlowStartMessage createRequest() {
+        return DataFlowStartMessage.Builder.newInstance()
+                .id("1")
+                .processId("1")
+                .sourceDataAddress(DataAddress.Builder.newInstance().type("any").build())
+                .destinationDataAddress(DataAddress.Builder.newInstance().type("any").build())
+                .build();
+    }
+
+    @Test
+    void transferData() {
+        pipelineService.registerFactory(new InputStreamDataSourceFactory());
+        pipelineService.registerFactory(new MemorySinkFactory());
+
+        var future = pipelineService.transfer(createRequest());
+
+        assertThat(future).succeedsWithin(5, SECONDS)
+                .satisfies(result -> assertThat(result).isSucceeded()
+                        .isEqualTo(InputStreamDataSourceFactory.DATA.get(0).getBytes()));
+    }
+
+    @Test
+    void transferData_withCustomSink() {
+        pipelineService.registerFactory(new InputStreamDataSourceFactory());
+
+        var future = pipelineService.transfer(createRequest(), new MemorySink());
+
+        assertThat(future).succeedsWithin(5, SECONDS).satisfies(result -> {
+            assertThat(result).isSucceeded().isInstanceOf(byte[].class);
+            var bytes = (byte[]) result.getContent();
+            assertThat(bytes).isEqualTo(InputStreamDataSourceFactory.DATA.get(0).getBytes());
+        });
+    }
+
+    @Test
+    void transferNonFiniteData() {
+        pipelineService.registerFactory(new InputStreamDataSourceFactory());
+        pipelineService.registerFactory(new MemorySinkFactory());
+
+        for (var data : InputStreamDataSourceFactory.DATA) {
+            var future = pipelineService.transfer(createRequest());
+
+            assertThat(future).succeedsWithin(5, SECONDS)
+                    .satisfies(StreamResult::succeeded)
+                    .satisfies(result -> result.getContent().equals(data));
+        }
+    }
+
+}

--- a/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/test/java/org/eclipse/edc/tractusx/non/finite/provider/push/core/pipeline/NonFiniteCapablePipelineServiceTest.java
+++ b/edc-extensions/non-finite-provider-push/non-finite-provider-push-core/src/test/java/org/eclipse/edc/tractusx/non/finite/provider/push/core/pipeline/NonFiniteCapablePipelineServiceTest.java
@@ -1,0 +1,331 @@
+/********************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.edc.tractusx.non.finite.provider.push.core.pipeline;
+
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSink;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSinkFactory;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSourceFactory;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamFailure;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.edc.tractusx.non.finite.provider.push.spi.FinitenessEvaluator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.dataplane.spi.pipeline.StreamFailure.Reason.GENERAL_ERROR;
+import static org.eclipse.edc.connector.dataplane.spi.pipeline.StreamFailure.Reason.NOT_FOUND;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class NonFiniteCapablePipelineServiceTest {
+
+    private static final String PROCESS_ID = "1";
+    private static final String SUPPORTED_SOURCE_TYPE = "source";
+    private static final String SUPPORTED_DESTINATION_TYPE = "destination";
+
+    private final DataSourceFactory sourceFactory = mock();
+    private final DataSinkFactory sinkFactory = mock();
+    private final DataSource source = mock();
+    private final DataSink sink = mock();
+
+    private final Monitor monitor = mock();
+    private final FinitenessEvaluator finitenessEvaluator = mock();
+    private final NonFiniteCapablePipelineService service = new NonFiniteCapablePipelineService(monitor, finitenessEvaluator);
+
+    @BeforeEach
+    void setUp() {
+        service.registerFactory(sourceFactory);
+        service.registerFactory(sinkFactory);
+    }
+
+    private DataFlow dataFlow(String sourceType, String destinationType) {
+        return DataFlow.Builder.newInstance()
+                .id(PROCESS_ID)
+                .source(DataAddress.Builder.newInstance().type(sourceType).build())
+                .destination(DataAddress.Builder.newInstance().type(destinationType).build())
+                .build();
+    }
+
+    private static class CanHandleArguments implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
+            return Stream.of(
+                    arguments(SUPPORTED_SOURCE_TYPE, SUPPORTED_DESTINATION_TYPE, true),
+                    arguments("unsupported_source", SUPPORTED_DESTINATION_TYPE, false),
+                    arguments(SUPPORTED_SOURCE_TYPE, "unsupported_destination", false),
+                    arguments("unsupported_source", "unsupported_destination", false));
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(CanHandleArguments.class)
+    void canHandle_shouldReturnTrue_whenSourceAndDestinationCanBeHandled(
+            String source,
+            String destination,
+            boolean expected) {
+        when(sourceFactory.supportedType()).thenReturn(SUPPORTED_SOURCE_TYPE);
+        when(sinkFactory.supportedType()).thenReturn(SUPPORTED_DESTINATION_TYPE);
+
+        boolean result = service.canHandle(dataFlow(source, destination).toRequest());
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Nested
+    class Transfer {
+
+        @Test
+        void transfer_shouldFail_withUnknownSink() {
+            var flowRequest = dataFlow(SUPPORTED_SOURCE_TYPE, "custom-destination").toRequest();
+            var expectedErrorMessage = format(
+                    "GENERAL_ERROR: Unknown data sink type custom-destination for flow id: %s.",
+                    PROCESS_ID);
+
+            var future = service.transfer(flowRequest);
+
+            assertThat(future).succeedsWithin(5, SECONDS)
+                    .satisfies(res -> assertThat(res).isFailed())
+                    .satisfies(res -> assertThat(res.getFailure().getMessages()).hasSize(1))
+                    .satisfies(res -> assertThat(res.getFailureDetail()).isEqualTo(expectedErrorMessage));
+            verify(sinkFactory).supportedType();
+        }
+
+        @Test
+        void transfer_shouldFail_withUnknownSource() {
+            var flowRequest = dataFlow("wrong-source", SUPPORTED_DESTINATION_TYPE).toRequest();
+            var expectedErrorMessage = format(
+                    "GENERAL_ERROR: Unknown data source type wrong-source for flow id: %s.",
+                    PROCESS_ID);
+
+            when(sinkFactory.supportedType()).thenReturn(SUPPORTED_DESTINATION_TYPE);
+            when(sinkFactory.createSink(any())).thenReturn(sink);
+
+            var future = service.transfer(flowRequest);
+
+            assertThat(future).succeedsWithin(5, SECONDS)
+                    .satisfies(res -> assertThat(res).isFailed())
+                    .satisfies(res -> assertThat(res.getFailure().getMessages()).hasSize(1))
+                    .satisfies(res -> assertThat(res.getFailureDetail()).isEqualTo(expectedErrorMessage));
+            verify(sourceFactory).supportedType();
+        }
+
+        @Test
+        void transfer_shouldSucceed_withDefaultSink() throws Exception {
+            var flowRequest = dataFlow(SUPPORTED_SOURCE_TYPE, SUPPORTED_DESTINATION_TYPE).toRequest();
+
+            when(sourceFactory.supportedType()).thenReturn(SUPPORTED_SOURCE_TYPE);
+            when(sourceFactory.createSource(any())).thenReturn(source);
+            when(sinkFactory.supportedType()).thenReturn(SUPPORTED_DESTINATION_TYPE);
+            when(sinkFactory.createSink(any())).thenReturn(sink);
+            when(sink.transfer(any())).thenReturn(completedFuture(StreamResult.success()));
+            when(finitenessEvaluator.isNonFinite(any(DataFlowStartMessage.class))).thenReturn(false);
+
+            var future = service.transfer(flowRequest);
+
+            assertThat(future).succeedsWithin(5, SECONDS)
+                    .satisfies(res -> assertThat(res).isSucceeded());
+            verify(sinkFactory).createSink(flowRequest);
+            verify(sourceFactory).createSource(flowRequest);
+            verify(sink).transfer(source);
+            verify(source).close();
+        }
+
+        @Test
+        void transfer_shouldSucceed_withCustomSink() throws Exception {
+            var flowRequest = dataFlow(SUPPORTED_SOURCE_TYPE, "custom-destination").toRequest();
+
+            when(sourceFactory.supportedType()).thenReturn(SUPPORTED_SOURCE_TYPE);
+            when(sourceFactory.createSource(any())).thenReturn(source);
+            when(sink.transfer(any())).thenReturn(completedFuture(StreamResult.success()));
+            when(finitenessEvaluator.isNonFinite(any(DataFlowStartMessage.class))).thenReturn(false);
+
+            var customSink = new DataSink() {
+                @Override
+                public CompletableFuture<StreamResult<Object>> transfer(DataSource source) {
+                    return CompletableFuture.completedFuture(StreamResult.success("test-response"));
+                }
+            };
+            var future = service.transfer(flowRequest, customSink);
+
+            assertThat(future).succeedsWithin(5, SECONDS)
+                    .satisfies(res -> assertThat(res).isSucceeded()
+                            .satisfies(obj -> assertThat(obj).isEqualTo("test-response")));
+            verifyNoInteractions(sinkFactory);
+            verify(sourceFactory).createSource(flowRequest);
+            verify(source).close();
+        }
+
+        @Test
+        void transfer_shouldReturnIncompleteFuture_whenNonFinite() throws Exception {
+            var flowRequest = dataFlow(SUPPORTED_SOURCE_TYPE, SUPPORTED_DESTINATION_TYPE).toRequest();
+
+            when(sourceFactory.supportedType()).thenReturn(SUPPORTED_SOURCE_TYPE);
+            when(sourceFactory.createSource(any())).thenReturn(source);
+            when(sinkFactory.supportedType()).thenReturn(SUPPORTED_DESTINATION_TYPE);
+            when(sinkFactory.createSink(any())).thenReturn(sink);
+            when(sink.transfer(any())).thenReturn(completedFuture(StreamResult.success()));
+            when(finitenessEvaluator.isNonFinite(any(DataFlowStartMessage.class))).thenReturn(true);
+
+            var future = service.transfer(flowRequest);
+
+            assertThat(future).isNotCompleted();
+        }
+
+        @Test
+        void transfer_shouldFail_whenNonFiniteAndTransferFailed() throws Exception {
+            var flowRequest = dataFlow(SUPPORTED_SOURCE_TYPE, SUPPORTED_DESTINATION_TYPE).toRequest();
+
+            when(sourceFactory.supportedType()).thenReturn(SUPPORTED_SOURCE_TYPE);
+            when(sourceFactory.createSource(any())).thenReturn(source);
+            when(sinkFactory.supportedType()).thenReturn(SUPPORTED_DESTINATION_TYPE);
+            when(sinkFactory.createSink(any())).thenReturn(sink);
+            when(sink.transfer(any())).thenReturn(
+                    completedFuture(StreamResult.failure(new StreamFailure(List.of("error"), GENERAL_ERROR))));
+            when(finitenessEvaluator.isNonFinite(any(DataFlowStartMessage.class))).thenReturn(true);
+
+            var future = service.transfer(flowRequest);
+
+            assertThat(future).succeedsWithin(5, SECONDS)
+                    .satisfies(res -> assertThat(res).isFailed())
+                    .satisfies(res -> res.getFailureDetail().equals("error"));
+        }
+
+        @Nested
+        class Terminate {
+
+            @Test
+            void terminate_shouldCloseDataSource() throws Exception {
+                var dataFlow = dataFlow(SUPPORTED_SOURCE_TYPE, SUPPORTED_DESTINATION_TYPE);
+
+                when(sourceFactory.supportedType()).thenReturn(SUPPORTED_SOURCE_TYPE);
+                when(sourceFactory.createSource(any())).thenReturn(source);
+                when(sinkFactory.supportedType()).thenReturn(SUPPORTED_DESTINATION_TYPE);
+                when(sinkFactory.createSink(any())).thenReturn(sink);
+                when(sink.transfer(any())).thenReturn(new CompletableFuture<>());
+                when(finitenessEvaluator.isNonFinite(any(DataFlowStartMessage.class))).thenReturn(false);
+
+                service.transfer(dataFlow.toRequest());
+                var result = service.terminate(dataFlow);
+
+                assertThat(result).isSucceeded();
+                verify(source).close();
+            }
+
+            @Test
+            void terminate_shouldFail_whenSourceClosureFails() throws Exception {
+                var dataFlow = dataFlow(SUPPORTED_SOURCE_TYPE, SUPPORTED_DESTINATION_TYPE);
+
+                when(sourceFactory.supportedType()).thenReturn(SUPPORTED_SOURCE_TYPE);
+                when(sourceFactory.createSource(any())).thenReturn(source);
+                when(sinkFactory.supportedType()).thenReturn(SUPPORTED_DESTINATION_TYPE);
+                when(sinkFactory.createSink(any())).thenReturn(sink);
+                when(sink.transfer(any())).thenReturn(new CompletableFuture<>());
+                when(finitenessEvaluator.isNonFinite(any(DataFlowStartMessage.class))).thenReturn(false);
+                doThrow(IOException.class).when(source).close();
+
+                service.transfer(dataFlow.toRequest());
+                var result = service.terminate(dataFlow);
+
+                assertThat(result).isFailed().extracting(StreamFailure::getReason).isEqualTo(GENERAL_ERROR);
+                verify(source).close();
+            }
+
+            @Test
+            void terminate_shouldFail_whenTransferDoesNotExist() {
+                var dataFlow = dataFlow(SUPPORTED_SOURCE_TYPE, SUPPORTED_DESTINATION_TYPE);
+
+                var result = service.terminate(dataFlow);
+
+                assertThat(result).isFailed().extracting(StreamFailure::getReason).isEqualTo(NOT_FOUND);
+                verifyNoInteractions(source);
+            }
+        }
+
+        @Nested
+        class CloseAll {
+
+            @Test
+            void closeAll_shouldCloseAllOngoingDataFlows() throws Exception {
+                when(sourceFactory.supportedType()).thenReturn(SUPPORTED_SOURCE_TYPE);
+                when(sourceFactory.createSource(any())).thenReturn(source);
+                when(sinkFactory.supportedType()).thenReturn(SUPPORTED_DESTINATION_TYPE);
+                when(sinkFactory.createSink(any())).thenReturn(sink);
+                when(sink.transfer(any())).thenReturn(new CompletableFuture<>());
+
+                service.transfer(dataFlow(SUPPORTED_SOURCE_TYPE, SUPPORTED_DESTINATION_TYPE).toRequest());
+                service.closeAll();
+
+                verify(source).close();
+            }
+        }
+
+        @Nested
+        class SupportedTypes {
+
+            @Test
+            void supportedSourceTypes_shouldReturnSourceTypesFromFactories() {
+                when(sourceFactory.supportedType()).thenReturn(SUPPORTED_SOURCE_TYPE);
+
+                var result = service.supportedSourceTypes();
+
+                assertThat(result).containsOnly(SUPPORTED_SOURCE_TYPE);
+                verifyNoInteractions(sinkFactory);
+            }
+
+            @Test
+            void supportedSinkTypes_shouldReturnSinkTypesFromFactories() {
+                when(sinkFactory.supportedType()).thenReturn(SUPPORTED_DESTINATION_TYPE);
+
+                var result = service.supportedSinkTypes();
+
+                assertThat(result).containsOnly(SUPPORTED_DESTINATION_TYPE);
+                verifyNoInteractions(sourceFactory);
+            }
+
+        }
+
+    }
+
+}

--- a/edc-extensions/non-finite-provider-push/non-finite-provider-push-spi/build.gradle.kts
+++ b/edc-extensions/non-finite-provider-push/non-finite-provider-push-spi/build.gradle.kts
@@ -1,0 +1,28 @@
+/********************************************************************************
+ * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+dependencies {
+    implementation(libs.edc.spi.core)
+    implementation(libs.edc.spi.dataplane.dataplane)
+}

--- a/edc-extensions/non-finite-provider-push/non-finite-provider-push-spi/src/main/java/org/eclipse/edc/tractusx/non/finite/provider/push/spi/FinitenessEvaluator.java
+++ b/edc-extensions/non-finite-provider-push/non-finite-provider-push-spi/src/main/java/org/eclipse/edc/tractusx/non/finite/provider/push/spi/FinitenessEvaluator.java
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (c) 2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.edc.tractusx.non.finite.provider.push.spi;
+
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+
+/**
+ * Determines the finiteness of a data transfer
+ */
+public interface FinitenessEvaluator {
+
+    /**
+     * Evaluates if a {@link DataFlow} is non-finite
+     *
+     * @param dataflow dataflow to be evaluated
+     * @return true if it is non-finite, false otherwise
+     */
+    boolean isNonFinite(DataFlow dataflow);
+
+    /**
+     * Evaluates if a {@link DataFlowStartMessage} represents a non-finite dataflow
+     *
+     * @param message dataflow start message to be evaluated
+     * @return true if it is non-finite, false otherwise
+     */
+    boolean isNonFinite(DataFlowStartMessage message);
+}

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/runtimes/ParticipantRuntimeExtension.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/runtimes/ParticipantRuntimeExtension.java
@@ -28,7 +28,6 @@ import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
 import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.security.token.jwt.DefaultJwsSignerProvider;
-import org.eclipse.edc.spi.iam.AudienceResolver;
 import org.eclipse.edc.spi.iam.TokenParameters;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.security.Vault;
@@ -37,7 +36,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.token.JwtGenerationService;
 import org.eclipse.edc.token.spi.KeyIdDecorator;
 import org.eclipse.edc.token.spi.TokenDecorator;
-import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ format.version = "1.1"
 [versions]
 edc = "0.13.0"
 allure = "2.29.1"
+assertj = "3.27.3"
 awaitility = "4.3.0"
 aws = "2.31.68"
 azure-storage-blob = "12.30.1"
@@ -14,6 +15,7 @@ jakarta-json = "2.0.1"
 nimbus = "10.3"
 netty-mockserver = "5.15.0"
 opentelemetry = "2.17.0"
+opentelemetry-instrumentation = "2.16.0"
 postgres = "42.7.7"
 restAssured = "5.5.5"
 rsApi = "4.0.0"
@@ -162,6 +164,7 @@ edc-micrometer-jetty = { module = "org.eclipse.edc:jetty-micrometer", version.re
 
 # other deps
 allure-junit5 = { module = "io.qameta.allure:allure-junit5", version.ref = "allure" }
+assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
 aws-s3 = { module = "software.amazon.awssdk:s3", version.ref = "aws" }
 aws-s3transfer = { module = "software.amazon.awssdk:s3-transfer-manager", version.ref = "aws" }
@@ -173,6 +176,7 @@ jakarta-rsApi = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version.ref = "rsA
 jakartaJson = { module = "org.glassfish:jakarta.json", version.ref = "jakarta-json" }
 nimbus-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbus" }
 opentelemetry-javaagent = { module = "io.opentelemetry.javaagent:opentelemetry-javaagent", version.ref = "opentelemetry" }
+opentelemetry-instrumentation-annotations = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations", version.ref = "opentelemetry-instrumentation" }
 netty-mockserver = { module = "org.mock-server:mockserver-netty", version.ref = "netty-mockserver" }
 postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
 restAssured = { module = "io.rest-assured:rest-assured", version.ref = "restAssured" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -67,6 +67,8 @@ include(":edc-extensions:dataplane:dataplane-token-refresh:token-refresh-core")
 include(":edc-extensions:dataplane:dataplane-token-refresh:token-refresh-api")
 include(":edc-extensions:dataplane:dataplane-proxy:dataplane-public-api-v2")
 
+include(":edc-extensions:non-finite-provider-push:non-finite-provider-push-spi")
+
 // test modules
 include(":edc-tests:e2e-fixtures")
 include(":edc-tests:e2e:agreement-retirement-tests")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -68,6 +68,7 @@ include(":edc-extensions:dataplane:dataplane-token-refresh:token-refresh-api")
 include(":edc-extensions:dataplane:dataplane-proxy:dataplane-public-api-v2")
 
 include(":edc-extensions:non-finite-provider-push:non-finite-provider-push-spi")
+include(":edc-extensions:non-finite-provider-push:non-finite-provider-push-core")
 
 // test modules
 include(":edc-tests:e2e-fixtures")


### PR DESCRIPTION
## WHAT

Implement support to identify and handle non-finite data.

## WHY

Enable non-finite data transfers using the Provider-PUSH flow.

## FURTHER NOTES

Implementation follows this [DR](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/docs/development/decision-records/2025-06-04-non-finite-provider-push).

Adds two new Gradle subprojects:
- non-finite-provider-push-spi, to define extendable interfaces.
- non-finite-provider-push-core, to provide implementations

Removes unused imports in `ParticipantRuntimeExtension` to comply with checkstyle linting.

Explicitly adds `assertj` and `opentelemetry-instrumentation-annotations` as dependencies.

Links to: https://github.com/eclipse-tractusx/sig-release/issues/1150
