### PR TITLE
chore: remove ndr-brt from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Identify the committers responsible for the repository as standard reviewers
 
-* @rafaelmag110 @ndr-brt @lgblaumeiser
+* @rafaelmag110 @lgblaumeiser @bmg13


### PR DESCRIPTION
## WHAT

I took the freedom to remove my account from the CODEOWNERS and to add @bmg13 , as he's a committer now

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
