### PR TITLE
doc: add decision record for logging and metrics framework

### DIFF
--- a/docs/development/decision-records/2025-07-09-logging_and_metrics_framework/README.md
+++ b/docs/development/decision-records/2025-07-09-logging_and_metrics_framework/README.md
@@ -1,0 +1,36 @@
+# Logging/Eventing/Metrics Framework
+
+The purpose of this decision record is to agree on the general strategy concerning how log information and domain
+event information is processed in the connector and in background services that take the information and process
+it further.
+
+## Decision
+
+1. The connector provides log information in a structured way in the form of json objects.
+2. The technology to provide execution information towards background services is OpenTelemetry.
+3. OpenTelemetry is added as direct dependency. The target is that the usage of the java agent is abandonned.
+4. The connector will not calculate domain metrics. Instead it will provide relevant domain events that are forwarded
+   using OpenTelemetry as well.
+5. An OpenTelemetry collector is the recommended way to catch and forward the provided information into a background
+   operations stack that is then capable to process the information, generate metrics out of it and present them
+   adequately for the different user groups.
+
+## Rationale
+
+There is a large and basically individual number of metrics that are of interest for a company operating a connector.
+In addition, the calculation of metrics requires infrastructure that is already provided by typical operation stacks.
+As a consequence, it makes sense to just provide the information out of the connector to keep complexity out of the
+connector and to provide flexibility for an operator to manage the connector according to the local requirements.
+
+To allow easy processing of the information, a structured output allows to use the data directly without the need
+for reengineering the meaning of the information.
+
+There was an agreement by the involved parties, that OpenTelemetry is the right technology to provide information
+out of the connector to background services that manage operations. But the usage of the java agent is consuming a
+high number of resources, that is why the SDK approach of using OpenTelemetry was preferred.
+
+## Approach
+
+The concrete changes required to meet the requirements of this decision record are part of further records looking
+into single changes needed to meet the goals described by this decision record. The goal here is to bring the
+different changes into an overall context.

--- a/docs/development/decision-records/2025-07-09-logging_and_metrics_strategy/README.md
+++ b/docs/development/decision-records/2025-07-09-logging_and_metrics_strategy/README.md
@@ -1,4 +1,4 @@
-# Logging/Eventing/Metrics Framework
+# Logging/Eventing/Metrics Strategy
 
 The purpose of this decision record is to agree on the general strategy concerning how log information and domain
 event information is processed in the connector and in background services that take the information and process
@@ -19,18 +19,18 @@ it further.
 
 There is a large and basically individual number of metrics that are of interest for a company operating a connector.
 In addition, the calculation of metrics requires infrastructure that is already provided by typical operation stacks.
-As a consequence, it makes sense to just provide the information out of the connector to keep complexity out of the
-connector and to provide flexibility for an operator to manage the connector according to the local requirements.
+As a consequence, it makes sense to just provide the incident information to external services in order to keep
+complexity out of the connector and to provide flexibility for an operator to manage the connector according to
+the local requirements.
 
 To allow easy processing of the information, a structured output allows to use the data directly without the need
 for reengineering the meaning of the information.
 
-There was an agreement by the involved parties, that OpenTelemetry is the right technology to provide information
-out of the connector to background services that manage operations. But the usage of the java agent is consuming a
-high number of resources, that is why the SDK approach of using OpenTelemetry was preferred.
+There was an agreement by the involved parties, that OpenTelemetry is the right technology to provide incident
+information to background services that manage operations. But the usage of the java agent is consuming a
+high amount of resources, that is why the SDK approach of using OpenTelemetry was preferred.
 
 ## Approach
 
 The concrete changes required to meet the requirements of this decision record are part of further records looking
-into single changes needed to meet the goals described by this decision record. The goal here is to bring the
-different changes into an overall context.
+into single changes needed. The goal here is to bring the different changes into an overall context.


### PR DESCRIPTION
## WHAT

A decision record that describes the overall decision concerning how logging information and further events are handled by the connector and the approach to compute metrics for better operations of a connector.

## WHY

The framework described allows a more standardized and streamlined operation of connectors. Major information is made available in a way, that is easily processable and which allows to get an overview over current activities within a connector on a technical level as well as on a domain level.

Fixes #1745
