### PR TITLE
feat(constraints): add validation for data constraints

### DIFF
--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/CxPolicyExtension.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/CxPolicyExtension.java
@@ -22,24 +22,35 @@ package org.eclipse.tractusx.edc.policy.cx;
 import org.eclipse.edc.connector.controlplane.catalog.spi.policy.CatalogPolicyContext;
 import org.eclipse.edc.connector.controlplane.contract.spi.policy.ContractNegotiationPolicyContext;
 import org.eclipse.edc.connector.controlplane.contract.spi.policy.TransferProcessPolicyContext;
+import org.eclipse.edc.policy.engine.spi.AtomicConstraintRuleFunction;
+import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.policy.engine.spi.RuleBindingRegistry;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.policy.model.Prohibition;
+import org.eclipse.edc.policy.model.Rule;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.tractusx.edc.policy.cx.affiliates.AffiliatesBpnlPermissionConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.affiliates.AffiliatesBpnlProhibitionConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.affiliates.AffiliatesRegionPermissionConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.affiliates.AffiliatesRegionProhibitionConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.contractreference.ContractReferenceConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.dismantler.DismantlerCredentialConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.framework.FrameworkAgreementCredentialConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.membership.MembershipCredentialConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.usage.UsagePurposeConstraintFunction;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
+import static org.eclipse.tractusx.edc.policy.cx.affiliates.AffiliatesBpnlProhibitionConstraintFunction.AFFILIATES_BPNL;
+import static org.eclipse.tractusx.edc.policy.cx.affiliates.AffiliatesRegionProhibitionConstraintFunction.AFFILIATES_REGION;
 import static org.eclipse.tractusx.edc.policy.cx.common.PolicyScopes.CATALOG_REQUEST_SCOPE;
 import static org.eclipse.tractusx.edc.policy.cx.common.PolicyScopes.CATALOG_SCOPE;
 import static org.eclipse.tractusx.edc.policy.cx.common.PolicyScopes.NEGOTIATION_REQUEST_SCOPE;
@@ -70,6 +81,27 @@ public class CxPolicyExtension implements ServiceExtension {
     private RuleBindingRegistry bindingRegistry;
 
     public static void registerFunctions(PolicyEngine engine) {
+
+        // Usage Prohibition Validators
+        registerForContexts(
+                ContractNegotiationPolicyContext.class,
+                Prohibition.class,
+                engine,
+                Map.of(
+                        CX_POLICY_NS + AFFILIATES_BPNL, new AffiliatesBpnlProhibitionConstraintFunction<>(),
+                        CX_POLICY_NS + AFFILIATES_REGION, new AffiliatesRegionProhibitionConstraintFunction<>())
+        );
+
+        registerForContexts(
+                TransferProcessPolicyContext.class,
+                Prohibition.class,
+                engine,
+                Map.of(
+                        CX_POLICY_NS + AFFILIATES_BPNL, new AffiliatesBpnlProhibitionConstraintFunction<>(),
+                        CX_POLICY_NS + AFFILIATES_REGION, new AffiliatesRegionProhibitionConstraintFunction<>())
+        );
+
+        // Access and Usage Permission Validators
         engine.registerFunction(CatalogPolicyContext.class, Permission.class, new DismantlerCredentialConstraintFunction<>());
         engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, new DismantlerCredentialConstraintFunction<>());
         engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, new DismantlerCredentialConstraintFunction<>());
@@ -82,13 +114,18 @@ public class CxPolicyExtension implements ServiceExtension {
         engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, new MembershipCredentialConstraintFunction<>());
         engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, new MembershipCredentialConstraintFunction<>());
 
-        engine.registerFunction(CatalogPolicyContext.class, Permission.class, CX_POLICY_NS + USAGE_PURPOSE, new UsagePurposeConstraintFunction<>());
-        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + USAGE_PURPOSE, new UsagePurposeConstraintFunction<>());
-        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + USAGE_PURPOSE, new UsagePurposeConstraintFunction<>());
+        // Usage Permission Validators
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + AFFILIATES_BPNL, new AffiliatesBpnlPermissionConstraintFunction<>());
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + AFFILIATES_BPNL, new AffiliatesBpnlPermissionConstraintFunction<>());
 
-        engine.registerFunction(CatalogPolicyContext.class, Permission.class, CX_POLICY_NS + CONTRACT_REFERENCE, new ContractReferenceConstraintFunction<>());
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + AFFILIATES_REGION, new AffiliatesRegionPermissionConstraintFunction<>());
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + AFFILIATES_REGION, new AffiliatesRegionPermissionConstraintFunction<>());
+
         engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + CONTRACT_REFERENCE, new ContractReferenceConstraintFunction<>());
         engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + CONTRACT_REFERENCE, new ContractReferenceConstraintFunction<>());
+
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + USAGE_PURPOSE, new UsagePurposeConstraintFunction<>());
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + USAGE_PURPOSE, new UsagePurposeConstraintFunction<>());
     }
 
     public static void registerBindings(RuleBindingRegistry registry) {
@@ -102,14 +139,32 @@ public class CxPolicyExtension implements ServiceExtension {
         registry.bind(ODRL_SCHEMA + "use", CATALOG_SCOPE);
         registry.bind(ODRL_SCHEMA + "use", NEGOTIATION_SCOPE);
         registry.bind(ODRL_SCHEMA + "use", TRANSFER_PROCESS_SCOPE);
-        
-        registry.bind(CX_POLICY_NS + USAGE_PURPOSE, CATALOG_SCOPE);
-        registry.bind(CX_POLICY_NS + USAGE_PURPOSE, NEGOTIATION_SCOPE);
-        registry.bind(CX_POLICY_NS + USAGE_PURPOSE, TRANSFER_PROCESS_SCOPE);
 
-        registry.bind(CX_POLICY_NS + CONTRACT_REFERENCE, CATALOG_SCOPE);
-        registry.bind(CX_POLICY_NS + CONTRACT_REFERENCE, NEGOTIATION_SCOPE);
-        registry.bind(CX_POLICY_NS + CONTRACT_REFERENCE, TRANSFER_PROCESS_SCOPE);
+        registerBindingSets(
+                registry,
+                Set.of(CX_POLICY_NS + USAGE_PURPOSE, CX_POLICY_NS + CONTRACT_REFERENCE),
+                Set.of(CATALOG_SCOPE, NEGOTIATION_SCOPE, TRANSFER_PROCESS_SCOPE));
+
+        // Usage Prohibition Validators
+        registerBindingSets(
+                registry,
+                Set.of(CX_POLICY_NS + AFFILIATES_BPNL, CX_POLICY_NS + AFFILIATES_REGION),
+                Set.of(NEGOTIATION_SCOPE, TRANSFER_PROCESS_SCOPE));
+
+        // Usage Permission Validators
+        registerBindingSets(
+                registry,
+                Set.of(
+                        CX_POLICY_NS + AFFILIATES_BPNL,
+                        CX_POLICY_NS + AFFILIATES_REGION,
+                        CX_POLICY_NS + CONTRACT_REFERENCE,
+                        CX_POLICY_NS + USAGE_PURPOSE),
+                Set.of(NEGOTIATION_SCOPE, TRANSFER_PROCESS_SCOPE));
+
+    }
+
+    private static void registerBindingSets(RuleBindingRegistry registry, Set<String> names, Set<String> scopes) {
+        scopes.forEach(scope -> names.forEach(name -> registry.bind(name, scope)));
     }
 
     @Override
@@ -121,5 +176,11 @@ public class CxPolicyExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         registerFunctions(policyEngine);
         registerBindings(bindingRegistry);
+    }
+
+    private static <R extends Rule, C extends PolicyContext> void registerForContexts(Class<C> context, Class<R> type, PolicyEngine engine, Map<String, AtomicConstraintRuleFunction<R, C>> constraints) {
+        constraints.forEach((functionId, constraintFunction) ->
+                engine.registerFunction(context, type, functionId, constraintFunction)
+        );
     }
 }

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/CxPolicyExtension.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/CxPolicyExtension.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.policy.engine.spi.AtomicConstraintRuleFunction;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.policy.engine.spi.RuleBindingRegistry;
+import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Prohibition;
 import org.eclipse.edc.policy.model.Rule;
@@ -38,6 +39,12 @@ import org.eclipse.tractusx.edc.policy.cx.affiliates.AffiliatesBpnlProhibitionCo
 import org.eclipse.tractusx.edc.policy.cx.affiliates.AffiliatesRegionPermissionConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.affiliates.AffiliatesRegionProhibitionConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.contractreference.ContractReferenceConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.datafrequency.DataFrequencyConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.dataprovisioning.DataProvisioningEndDateConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.dataprovisioning.DataProvisioningEndDurationDaysConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.datausage.DataUsageEndDateConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.datausage.DataUsageEndDefinitionConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.datausage.DataUsageEndDurationDaysConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.dismantler.DismantlerCredentialConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.framework.FrameworkAgreementCredentialConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.membership.MembershipCredentialConstraintFunction;
@@ -58,6 +65,12 @@ import static org.eclipse.tractusx.edc.policy.cx.common.PolicyScopes.NEGOTIATION
 import static org.eclipse.tractusx.edc.policy.cx.common.PolicyScopes.TRANSFER_PROCESS_REQUEST_SCOPE;
 import static org.eclipse.tractusx.edc.policy.cx.common.PolicyScopes.TRANSFER_PROCESS_SCOPE;
 import static org.eclipse.tractusx.edc.policy.cx.contractreference.ContractReferenceConstraintFunction.CONTRACT_REFERENCE;
+import static org.eclipse.tractusx.edc.policy.cx.datafrequency.DataFrequencyConstraintFunction.DATA_FREQUENCY;
+import static org.eclipse.tractusx.edc.policy.cx.dataprovisioning.DataProvisioningEndDateConstraintFunction.DATA_PROVISIONING_END_DATE;
+import static org.eclipse.tractusx.edc.policy.cx.dataprovisioning.DataProvisioningEndDurationDaysConstraintFunction.DATA_PROVISIONING_END_DURATION_DAYS;
+import static org.eclipse.tractusx.edc.policy.cx.datausage.DataUsageEndDateConstraintFunction.DATA_USAGE_END_DATE;
+import static org.eclipse.tractusx.edc.policy.cx.datausage.DataUsageEndDefinitionConstraintFunction.DATA_USAGE_END_DEFINITION;
+import static org.eclipse.tractusx.edc.policy.cx.datausage.DataUsageEndDurationDaysConstraintFunction.DATA_USAGE_END_DURATION_DAYS;
 import static org.eclipse.tractusx.edc.policy.cx.dismantler.DismantlerCredentialConstraintFunction.DISMANTLER_LITERAL;
 import static org.eclipse.tractusx.edc.policy.cx.framework.FrameworkAgreementCredentialConstraintFunction.FRAMEWORK_AGREEMENT_LITERAL;
 import static org.eclipse.tractusx.edc.policy.cx.membership.MembershipCredentialConstraintFunction.MEMBERSHIP_LITERAL;
@@ -81,6 +94,24 @@ public class CxPolicyExtension implements ServiceExtension {
     private RuleBindingRegistry bindingRegistry;
 
     public static void registerFunctions(PolicyEngine engine) {
+
+        // Usage Duty Validators
+        registerForContexts(
+                ContractNegotiationPolicyContext.class,
+                Duty.class,
+                engine,
+                Map.of(
+                        CX_POLICY_NS + DATA_PROVISIONING_END_DURATION_DAYS, new DataProvisioningEndDurationDaysConstraintFunction<>(),
+                        CX_POLICY_NS + DATA_PROVISIONING_END_DATE, new DataProvisioningEndDateConstraintFunction<>())
+        );
+        registerForContexts(
+                TransferProcessPolicyContext.class,
+                Duty.class,
+                engine,
+                Map.of(
+                        CX_POLICY_NS + DATA_PROVISIONING_END_DURATION_DAYS, new DataProvisioningEndDurationDaysConstraintFunction<>(),
+                        CX_POLICY_NS + DATA_PROVISIONING_END_DATE, new DataProvisioningEndDateConstraintFunction<>())
+        );
 
         // Usage Prohibition Validators
         registerForContexts(
@@ -124,6 +155,18 @@ public class CxPolicyExtension implements ServiceExtension {
         engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + CONTRACT_REFERENCE, new ContractReferenceConstraintFunction<>());
         engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + CONTRACT_REFERENCE, new ContractReferenceConstraintFunction<>());
 
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + DATA_FREQUENCY, new DataFrequencyConstraintFunction<>());
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + DATA_FREQUENCY, new DataFrequencyConstraintFunction<>());
+
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + DATA_USAGE_END_DATE, new DataUsageEndDateConstraintFunction<>());
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + DATA_USAGE_END_DATE, new DataUsageEndDateConstraintFunction<>());
+
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + DATA_USAGE_END_DEFINITION, new DataUsageEndDefinitionConstraintFunction<>());
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + DATA_USAGE_END_DEFINITION, new DataUsageEndDefinitionConstraintFunction<>());
+
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + DATA_USAGE_END_DURATION_DAYS, new DataUsageEndDurationDaysConstraintFunction<>());
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + DATA_USAGE_END_DURATION_DAYS, new DataUsageEndDurationDaysConstraintFunction<>());
+
         engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + USAGE_PURPOSE, new UsagePurposeConstraintFunction<>());
         engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + USAGE_PURPOSE, new UsagePurposeConstraintFunction<>());
     }
@@ -145,6 +188,12 @@ public class CxPolicyExtension implements ServiceExtension {
                 Set.of(CX_POLICY_NS + USAGE_PURPOSE, CX_POLICY_NS + CONTRACT_REFERENCE),
                 Set.of(CATALOG_SCOPE, NEGOTIATION_SCOPE, TRANSFER_PROCESS_SCOPE));
 
+        // Usage Duty Validators
+        registerBindingSets(
+                registry,
+                Set.of(CX_POLICY_NS + DATA_PROVISIONING_END_DURATION_DAYS, CX_POLICY_NS + DATA_PROVISIONING_END_DATE),
+                Set.of(NEGOTIATION_SCOPE, TRANSFER_PROCESS_SCOPE));
+
         // Usage Prohibition Validators
         registerBindingSets(
                 registry,
@@ -158,6 +207,10 @@ public class CxPolicyExtension implements ServiceExtension {
                         CX_POLICY_NS + AFFILIATES_BPNL,
                         CX_POLICY_NS + AFFILIATES_REGION,
                         CX_POLICY_NS + CONTRACT_REFERENCE,
+                        CX_POLICY_NS + DATA_FREQUENCY,
+                        CX_POLICY_NS + DATA_USAGE_END_DATE,
+                        CX_POLICY_NS + DATA_USAGE_END_DEFINITION,
+                        CX_POLICY_NS + DATA_USAGE_END_DURATION_DAYS,
                         CX_POLICY_NS + USAGE_PURPOSE),
                 Set.of(NEGOTIATION_SCOPE, TRANSFER_PROCESS_SCOPE));
 

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesBpnlBaseConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesBpnlBaseConstraintFunction.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.affiliates;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Rule;
+import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for AffiliatesBpnl. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class AffiliatesBpnlBaseConstraintFunction<T extends Rule, C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<T, C> {
+    public static final String AFFILIATES_BPNL = "AffiliatesBpnl";
+
+    public AffiliatesBpnlBaseConstraintFunction() {
+        super(
+                Set.of(Operator.IS_ANY_OF),
+                "^BPNL[0-9A-Z]{12}$",
+                true
+        );
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesBpnlPermissionConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesBpnlPermissionConstraintFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.affiliates;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Permission;
+
+/**
+ * This is a placeholder constraint function for AffiliatesBpnl. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class AffiliatesBpnlPermissionConstraintFunction<C extends ParticipantAgentPolicyContext> extends AffiliatesBpnlBaseConstraintFunction<Permission, C> {
+    public AffiliatesBpnlPermissionConstraintFunction() {
+        super();
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesBpnlProhibitionConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesBpnlProhibitionConstraintFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.affiliates;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Prohibition;
+
+/**
+ * This is a placeholder constraint function for AffiliatesBpnl. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class AffiliatesBpnlProhibitionConstraintFunction<C extends ParticipantAgentPolicyContext> extends AffiliatesBpnlBaseConstraintFunction<Prohibition, C> {
+    public AffiliatesBpnlProhibitionConstraintFunction() {
+        super();
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesRegionBaseConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesRegionBaseConstraintFunction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.affiliates;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Rule;
+import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for AffiliatesRegion. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class AffiliatesRegionBaseConstraintFunction<T extends Rule, C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<T, C> {
+    public static final String AFFILIATES_REGION = "AffiliatesRegion";
+
+    public AffiliatesRegionBaseConstraintFunction() {
+        super(
+                Set.of(Operator.IS_ANY_OF),
+                Set.of(
+                        "cx.region.all:1",
+                        "cx.region.europe:1",
+                        "cx.region.northAmerica:1",
+                        "cx.region.southAmerica:1",
+                        "cx.region.africa:1",
+                        "cx.region.asia:1",
+                        "cx.region.oceania:1",
+                        "cx.region.antarctica:1"
+                ),
+                true
+        );
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesRegionPermissionConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesRegionPermissionConstraintFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.affiliates;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Permission;
+
+/**
+ * This is a placeholder constraint function for AffiliatesRegion. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class AffiliatesRegionPermissionConstraintFunction<C extends ParticipantAgentPolicyContext> extends AffiliatesRegionBaseConstraintFunction<Permission, C> {
+    public AffiliatesRegionPermissionConstraintFunction() {
+        super();
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesRegionProhibitionConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesRegionProhibitionConstraintFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.affiliates;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Prohibition;
+
+/**
+ * This is a placeholder constraint function for AffiliatesRegion. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class AffiliatesRegionProhibitionConstraintFunction<C extends ParticipantAgentPolicyContext> extends AffiliatesRegionBaseConstraintFunction<Prohibition, C> {
+    public AffiliatesRegionProhibitionConstraintFunction() {
+        super();
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/BaseConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/BaseConstraintFunction.java
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.policy.cx.common;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.engine.spi.AtomicConstraintRuleFunction;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Rule;
+import org.eclipse.edc.spi.result.Result;
+
+import java.util.Set;
+
+public abstract class BaseConstraintFunction<T extends Rule, C extends ParticipantAgentPolicyContext> implements AtomicConstraintRuleFunction<T, C> {
+    private final Set<Operator> allowedOperators;
+
+    protected BaseConstraintFunction(Set<Operator> allowedOperators) {
+        this.allowedOperators = allowedOperators;
+    }
+
+    @Override
+    public boolean evaluate(Operator operator, Object rightOperand, T rule, C c) {
+        return true;
+    }
+
+    @Override
+    public Result<Void> validate(Operator operator, Object rightValue, T rule) {
+        if (!allowedOperators.contains(operator)) {
+            return Result.failure("Invalid operator: this constraint only allows the following operators: %s, but received '%s'."
+                    .formatted(allowedOperators, operator));
+        }
+        return validateRightOperand(rightValue);
+    }
+
+    protected abstract Result<Void> validateRightOperand(Object rightValue);
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/ValueValidatingConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/ValueValidatingConstraintFunction.java
@@ -1,0 +1,123 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.policy.cx.common;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Rule;
+import org.eclipse.edc.spi.result.Result;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public abstract class ValueValidatingConstraintFunction<T extends Rule, C extends ParticipantAgentPolicyContext> extends BaseConstraintFunction<T, C> {
+    private final Set<String> allowedValues;
+    private final String pattern;
+    private final boolean validateList;
+
+    protected ValueValidatingConstraintFunction(Set<Operator> allowedOperators, String pattern) {
+        this(allowedOperators, Set.of(), pattern, false);
+    }
+
+    protected ValueValidatingConstraintFunction(Set<Operator> allowedOperators, Set<String> validValues) {
+        this(allowedOperators, validValues, "[\\s\\S]+", false);
+    }
+
+    protected ValueValidatingConstraintFunction(Set<Operator> allowedOperators, String pattern, boolean validateList) {
+        this(allowedOperators, Set.of(), pattern, validateList);
+    }
+
+    protected ValueValidatingConstraintFunction(Set<Operator> allowedOperators, Set<String> validValues, boolean validateList) {
+        this(allowedOperators, validValues, "[\\s\\S]+", validateList);
+    }
+
+    protected ValueValidatingConstraintFunction(Set<Operator> allowedOperators,
+                                                Set<String> validValues,
+                                                String pattern,
+                                                boolean validateList) {
+        super(allowedOperators);
+        this.allowedValues = validValues;
+        this.pattern = pattern;
+        this.validateList = validateList;
+    }
+
+    @Override
+    protected Result<Void> validateRightOperand(Object rightValue) {
+        return validateList ? validateList(rightValue) : validateSingleValue(rightValue);
+    }
+
+    private Result<Void> validateSingleValue(Object rightValue) {
+        if (allowedValues != null && !allowedValues.isEmpty()) {
+            return rightValue instanceof String && allowedValues.contains(rightValue.toString().toLowerCase())
+                    ? Result.success()
+                    : Result.failure("Invalid right-operand: this constraint only allows the following right-operands: %s, but received '%s'."
+                    .formatted(String.join(", ", allowedValues), rightValue));
+        }
+
+        var compiledPattern = Pattern.compile(pattern);
+        return rightValue instanceof String s && compiledPattern.matcher(s).matches()
+                ? Result.success()
+                : Result.failure("Invalid right-operand: right operand must match pattern '%s'".formatted(pattern));
+    }
+
+    private Result<Void> validateList(Object rightValue) {
+        List<?> list = List.of();
+        if (rightValue instanceof String s) {
+            list = s.contains(",") ?
+                    Arrays.stream(s.split(","))
+                            .map(String::trim)
+                            .toList() :
+                    List.of(s.trim());
+        }
+        if (rightValue instanceof List<?> rightValuelist) {
+            list = rightValuelist;
+        }
+
+        if (list.isEmpty()) {
+            return Result.failure("Invalid right-operand: must be a list and contain at least 1 value");
+        }
+
+        if (allowedValues != null && !allowedValues.isEmpty()) {
+            var invalidValues = list.stream()
+                    .filter(String.class::isInstance)
+                    .map(String.class::cast)
+                    .filter(value -> !allowedValues.contains(value))
+                    .toList();
+
+            return invalidValues.isEmpty()
+                    ? Result.success()
+                    : Result.failure("Invalid right-operand: the following values are not allowed: %s".formatted(invalidValues));
+        }
+
+        var compiledPattern = Pattern.compile(pattern);
+        var distinctValues = list.stream()
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .filter(s -> compiledPattern.matcher(s).matches())
+                .distinct()
+                .count();
+
+        return distinctValues == list.size()
+                ? Result.success()
+                : Result.failure("Invalid right-operand: list must contain only unique values matching pattern: %s".formatted(pattern));
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/datafrequency/DataFrequencyConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/datafrequency/DataFrequencyConstraintFunction.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.datafrequency;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for DataFrequency. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class DataFrequencyConstraintFunction<C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<Permission, C> {
+    public static final String DATA_FREQUENCY = "DataFrequency";
+
+    public DataFrequencyConstraintFunction() {
+        super(
+                Set.of(Operator.EQ),
+                Set.of(
+                        "cx.datafrequency.once:1",
+                        "cx.datafrequency.unlimited:1"
+                )
+        );
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/dataprovisioning/DataProvisioningEndDateConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/dataprovisioning/DataProvisioningEndDateConstraintFunction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.dataprovisioning;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Duty;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for DataProvisioningEndDate. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class DataProvisioningEndDateConstraintFunction<C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<Duty, C> {
+    public static final String DATA_PROVISIONING_END_DATE = "DataProvisioningEndDate";
+
+    public DataProvisioningEndDateConstraintFunction() {
+        super(
+                Set.of(Operator.EQ),
+                "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|[+-]\\d{2}:\\d{2}))$"
+        );
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/dataprovisioning/DataProvisioningEndDurationDaysConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/dataprovisioning/DataProvisioningEndDurationDaysConstraintFunction.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.dataprovisioning;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.engine.spi.AtomicConstraintRuleFunction;
+import org.eclipse.edc.policy.model.Duty;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.spi.result.Result;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for DataProvisioningEndDurationDays. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class DataProvisioningEndDurationDaysConstraintFunction<C extends ParticipantAgentPolicyContext> implements AtomicConstraintRuleFunction<Duty, C> {
+    public static final String DATA_PROVISIONING_END_DURATION_DAYS = "DataProvisioningEndDurationDays";
+    private static final Set<Operator> ALLOWED_OPERATORS = Set.of(
+            Operator.EQ
+    );
+
+    @Override
+    public boolean evaluate(Operator operator, Object rightOperand, Duty permission, C c) {
+        return true;
+    }
+
+    @Override
+    public Result<Void> validate(Operator operator, Object rightValue, Duty rule) {
+        if (!ALLOWED_OPERATORS.contains(operator)) {
+            return Result.failure("Invalid operator: this constraint only allows the following operators: %s, but received '%s'.".formatted(ALLOWED_OPERATORS, operator));
+        }
+
+        return rightValue instanceof Integer ?
+                Result.success() :
+                Result.failure("Invalid right-operand: right operand must be an integer value");
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDateConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDateConstraintFunction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.datausage;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for DataUsageEndDate. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class DataUsageEndDateConstraintFunction<C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<Permission, C> {
+    public static final String DATA_USAGE_END_DATE = "DataUsageEndDate";
+
+    public DataUsageEndDateConstraintFunction() {
+        super(
+                Set.of(Operator.EQ),
+                "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|[+-]\\d{2}:\\d{2}))$"
+        );
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDefinitionConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDefinitionConstraintFunction.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.datausage;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for DataUsageEndDate. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class DataUsageEndDefinitionConstraintFunction<C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<Permission, C> {
+    public static final String DATA_USAGE_END_DEFINITION = "DataUsageEndDefinition";
+
+    public DataUsageEndDefinitionConstraintFunction() {
+        super(
+                Set.of(Operator.EQ),
+                Set.of(
+                        "cx.datausageend.unlimited:1"
+                )
+        );
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDurationDaysConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDurationDaysConstraintFunction.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.datausage;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.engine.spi.AtomicConstraintRuleFunction;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.result.Result;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for DataUsageEndDurationDays. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class DataUsageEndDurationDaysConstraintFunction<C extends ParticipantAgentPolicyContext> implements AtomicConstraintRuleFunction<Permission, C> {
+    public static final String DATA_USAGE_END_DURATION_DAYS = "DataUsageEndDurationDays";
+    private static final Set<Operator> ALLOWED_OPERATORS = Set.of(
+            Operator.EQ
+    );
+
+    @Override
+    public boolean evaluate(Operator operator, Object rightOperand, Permission permission, C c) {
+        return true;
+    }
+
+    @Override
+    public Result<Void> validate(Operator operator, Object rightValue, Permission rule) {
+        if (!ALLOWED_OPERATORS.contains(operator)) {
+            return Result.failure("Invalid operator: this constraint only allows the following operators: %s, but received '%s'.".formatted(ALLOWED_OPERATORS, operator));
+        }
+
+        if (rightValue instanceof Integer) {
+            return Result.success();
+        }
+
+        if (rightValue instanceof String stringValue) {
+            try {
+                Integer.parseInt(stringValue);
+                return Result.success();
+            } catch (NumberFormatException e) {
+                return Result.failure("Invalid right-operand: String value must be a valid integer, but got '%s'.".formatted(stringValue));
+            }
+        }
+
+        return Result.failure("Invalid right-operand: this constraint only allows integer values or strings representing integers, but got '%s'."
+                .formatted(rightValue != null ? rightValue.getClass().getName() : "null"));
+    }
+}

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesBpnlConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesBpnlConstraintFunctionTest.java
@@ -1,0 +1,80 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.policy.cx.affiliates;
+
+import org.eclipse.edc.participant.spi.ParticipantAgent;
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class AffiliatesBpnlConstraintFunctionTest {
+
+    private final ParticipantAgent participantAgent = mock();
+    private final AffiliatesBpnlProhibitionConstraintFunction<ParticipantAgentPolicyContext> function = new AffiliatesBpnlProhibitionConstraintFunction<>();
+    private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
+
+    @Test
+    void evaluate() {
+        assertThat(function.evaluate(Operator.EQ, "BPNL00000000001A", null, context)).isTrue();
+    }
+
+    @Test
+    void validate_whenValidOperatorAndRightValueArePassed_thenSuccess() {
+        var rightValue = List.of("BPNL00000000001A", "BPNL00000000002B");
+        var result = function.validate(Operator.IS_ANY_OF, rightValue, null);
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenValidOperatorAndOneRightValueIsPassed_thenSuccess() {
+        var rightValue = List.of("BPNL00000000001A");
+        var result = function.validate(Operator.IS_ANY_OF, rightValue, null);
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenInvalidOperator_thenFailure() {
+        var rightValue = List.of("BPNL00000000001A");
+        var result = function.validate(Operator.EQ, rightValue, null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Invalid operator");
+    }
+
+    @Test
+    void validate_whenInvalidRightValueType_thenFailure() {
+        var result = function.validate(Operator.IS_ANY_OF, "BPNL000000001A", null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("list must contain only unique values matching pattern");
+    }
+
+    @Test
+    void validate_whenInvalidBpnlFormat_thenFailure() {
+        var rightValue = List.of("invalid-bpnl");
+        var result = function.validate(Operator.IS_ANY_OF, rightValue, null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("matching pattern");
+    }
+}

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesRegionConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesRegionConstraintFunctionTest.java
@@ -1,0 +1,72 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.policy.cx.affiliates;
+
+import org.eclipse.edc.participant.spi.ParticipantAgent;
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class AffiliatesRegionConstraintFunctionTest {
+
+    private final ParticipantAgent participantAgent = mock();
+    private final AffiliatesRegionProhibitionConstraintFunction<ParticipantAgentPolicyContext> function = new AffiliatesRegionProhibitionConstraintFunction<>();
+    private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
+
+    @Test
+    void evaluate() {
+        assertThat(function.evaluate(Operator.IS_ANY_OF, "BPNL00000000001A", null, context)).isTrue();
+    }
+
+    @Test
+    void validate_whenValidOperatorAndRightValueArePassed_thenSuccess() {
+        var rightValue = List.of("cx.region.europe:1", "cx.region.northAmerica:1");
+        var result = function.validate(Operator.IS_ANY_OF, rightValue, null);
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenValidOperatorAndOneRightValueIsPassed_thenSuccess() {
+        var rightValue = List.of("cx.region.all:1");
+        var result = function.validate(Operator.IS_ANY_OF, rightValue, null);
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenInvalidOperator_thenFailure() {
+        var rightValue = List.of("cx.region.all:1");
+        var result = function.validate(Operator.EQ, rightValue, null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Invalid operator");
+    }
+
+    @Test
+    void validate_whenInvalidRightValueType_thenFailure() {
+        var result = function.validate(Operator.IS_ANY_OF, "invalid_value", null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("the following values are not allowed");
+    }
+}

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/datafrequency/DataFrequencyConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/datafrequency/DataFrequencyConstraintFunctionTest.java
@@ -1,0 +1,61 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.policy.cx.datafrequency;
+
+import org.eclipse.edc.participant.spi.ParticipantAgent;
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class DataFrequencyConstraintFunctionTest {
+
+    private final ParticipantAgent participantAgent = mock();
+    private final DataFrequencyConstraintFunction<ParticipantAgentPolicyContext> function = new DataFrequencyConstraintFunction<>();
+    private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
+
+    @Test
+    void evaluate() {
+        assertThat(function.evaluate(Operator.EQ, "cx.dataFrequency.once:1", null, context)).isTrue();
+    }
+
+    @Test
+    void validate_whenOperatorAndRightOperandAreValid_thenSuccess() {
+        var result = function.validate(Operator.EQ, "cx.dataFrequency.once:1", null);
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenInvalidOperator_thenFailure() {
+        var result = function.validate(Operator.IS_ANY_OF, "cx.dataFrequency.once:1", null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Invalid operator");
+    }
+
+    @Test
+    void validate_whenInvalidValue_thenFailure() {
+        var result = function.validate(Operator.EQ, "invalid-test", null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Invalid right-operand: ");
+    }
+}

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/dataprovisioning/DataProvisioningEndDateConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/dataprovisioning/DataProvisioningEndDateConstraintFunctionTest.java
@@ -1,0 +1,61 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.policy.cx.dataprovisioning;
+
+import org.eclipse.edc.participant.spi.ParticipantAgent;
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class DataProvisioningEndDateConstraintFunctionTest {
+
+    private final ParticipantAgent participantAgent = mock();
+    private final DataProvisioningEndDateConstraintFunction<ParticipantAgentPolicyContext> function = new DataProvisioningEndDateConstraintFunction<>();
+    private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
+
+    @Test
+    void evaluate() {
+        assertThat(function.evaluate(Operator.EQ, "2025-06-30T14:30:00Z", null, context)).isTrue();
+    }
+
+    @Test
+    void validate_whenOperatorAndRightOperandAreValid_thenSuccess() {
+        var result = function.validate(Operator.EQ, "2025-06-30T14:30:00Z", null);
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenInvalidOperator_thenFailure() {
+        var result = function.validate(Operator.IS_ANY_OF, "2025-06-30T14:30:00+01:00", null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Invalid operator");
+    }
+
+    @Test
+    void validate_whenInvalidValue_thenFailure() {
+        var result = function.validate(Operator.EQ, "invalid-test", null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Invalid right-operand: ");
+    }
+}

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/dataprovisioning/DataProvisioningEndDurationDaysConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/dataprovisioning/DataProvisioningEndDurationDaysConstraintFunctionTest.java
@@ -1,0 +1,61 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.policy.cx.dataprovisioning;
+
+import org.eclipse.edc.participant.spi.ParticipantAgent;
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class DataProvisioningEndDurationDaysConstraintFunctionTest {
+
+    private final ParticipantAgent participantAgent = mock();
+    private final DataProvisioningEndDurationDaysConstraintFunction<ParticipantAgentPolicyContext> function = new DataProvisioningEndDurationDaysConstraintFunction<>();
+    private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
+
+    @Test
+    void evaluate() {
+        assertThat(function.evaluate(Operator.EQ, 1, null, context)).isTrue();
+    }
+
+    @Test
+    void validate_whenOperatorAndRightOperandAreValid_thenSuccess() {
+        var result = function.validate(Operator.EQ, 1, null);
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenInvalidOperator_thenFailure() {
+        var result = function.validate(Operator.IS_ANY_OF, 1, null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Invalid operator");
+    }
+
+    @Test
+    void validate_whenInvalidValue_thenFailure() {
+        var result = function.validate(Operator.EQ, "invalid-test", null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Invalid right-operand: ");
+    }
+}

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDateConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDateConstraintFunctionTest.java
@@ -1,0 +1,61 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.policy.cx.datausage;
+
+import org.eclipse.edc.participant.spi.ParticipantAgent;
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class DataUsageEndDateConstraintFunctionTest {
+
+    private final ParticipantAgent participantAgent = mock();
+    private final DataUsageEndDateConstraintFunction<ParticipantAgentPolicyContext> function = new DataUsageEndDateConstraintFunction<>();
+    private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
+
+    @Test
+    void evaluate() {
+        assertThat(function.evaluate(Operator.EQ, "2025-06-30T14:30:00Z", null, context)).isTrue();
+    }
+
+    @Test
+    void validate_whenOperatorAndRightOperandAreValid_thenSuccess() {
+        var result = function.validate(Operator.EQ, "2025-06-30T14:30:00Z", null);
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenInvalidOperator_thenFailure() {
+        var result = function.validate(Operator.IS_ANY_OF, "2025-06-30T14:30:00+01:00", null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Invalid operator");
+    }
+
+    @Test
+    void validate_whenInvalidValue_thenFailure() {
+        var result = function.validate(Operator.EQ, "invalid-test", null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Invalid right-operand: ");
+    }
+}

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDefinitionConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDefinitionConstraintFunctionTest.java
@@ -1,0 +1,61 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.policy.cx.datausage;
+
+import org.eclipse.edc.participant.spi.ParticipantAgent;
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class DataUsageEndDefinitionConstraintFunctionTest {
+
+    private final ParticipantAgent participantAgent = mock();
+    private final DataUsageEndDefinitionConstraintFunction<ParticipantAgentPolicyContext> function = new DataUsageEndDefinitionConstraintFunction<>();
+    private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
+
+    @Test
+    void evaluate() {
+        assertThat(function.evaluate(Operator.EQ, "cx.dataUsageEnd.unlimited:1", null, context)).isTrue();
+    }
+
+    @Test
+    void validate_whenOperatorAndRightOperandAreValid_thenSuccess() {
+        var result = function.validate(Operator.EQ, "cx.dataUsageEnd.unlimited:1", null);
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenInvalidOperator_thenFailure() {
+        var result = function.validate(Operator.IS_ANY_OF, "cx.dataUsageEnd.unlimited:1", null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Invalid operator");
+    }
+
+    @Test
+    void validate_whenInvalidValue_thenFailure() {
+        var result = function.validate(Operator.EQ, "invalid-test", null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Invalid right-operand: ");
+    }
+}

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDurationDaysConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDurationDaysConstraintFunctionTest.java
@@ -1,0 +1,61 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.policy.cx.datausage;
+
+import org.eclipse.edc.participant.spi.ParticipantAgent;
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class DataUsageEndDurationDaysConstraintFunctionTest {
+
+    private final ParticipantAgent participantAgent = mock();
+    private final DataUsageEndDurationDaysConstraintFunction<ParticipantAgentPolicyContext> function = new DataUsageEndDurationDaysConstraintFunction<>();
+    private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
+
+    @Test
+    void evaluate() {
+        assertThat(function.evaluate(Operator.EQ, 1, null, context)).isTrue();
+    }
+
+    @Test
+    void validate_whenOperatorAndRightOperandAreValid_thenSuccess() {
+        var result = function.validate(Operator.EQ, 1, null);
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenInvalidOperator_thenFailure() {
+        var result = function.validate(Operator.IS_ANY_OF, 1, null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Invalid operator");
+    }
+
+    @Test
+    void validate_whenInvalidValue_thenFailure() {
+        var result = function.validate(Operator.EQ, "invalid-test", null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Invalid right-operand: ");
+    }
+}

--- a/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
+++ b/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
@@ -107,9 +107,12 @@ public class PolicyDefinitionEndToEndTest {
                     Arguments.of(frameworkPolicy(namespace + "Dismantler.allowedBrands", Operator.EQ, List.of("Moskvich", "Lada")), "Dismantler allowedBrands (EQ, exact match)"),
                     Arguments.of(frameworkPolicy(namespace + "Dismantler.allowedBrands", Operator.IS_NONE_OF, List.of("Yugo", "Tatra")), "Dismantler allowedBrands (IS_NONE_OF, no intersect)"),
                     Arguments.of(frameworkPolicy(namespace + "Dismantler.allowedBrands", Operator.IN, List.of("Moskvich", "Tatra", "Yugo", "Lada")), "Dismantler allowedBrands (IN, fully contained)"),
-                    Arguments.of(frameworkPolicy(Map.of(namespace + "UsagePurpose", "cx.core.industrycore:1")), "Usage Purpose"),
-                    Arguments.of(frameworkPolicy(Map.of(namespace + "ContractReference", "contractReference")), "Contract reference"),
-                    Arguments.of(frameworkPolicy(namespace + "AffiliatesRegion", Operator.IS_ANY_OF, List.of("cx.region.all:1", "cx.region.europe:1", "cx.region.northAmerica:1"), true), "Affiliates Region")
+                    Arguments.of(frameworkPolicy(namespace + "AffiliatesRegion", Operator.IS_ANY_OF, List.of("cx.region.all:1", "cx.region.europe:1", "cx.region.northAmerica:1"), true), "Affiliates Region"),
+                    Arguments.of(frameworkPolicy(namespace + "DataFrequency", Operator.EQ, "cx.datafrequency.once:1"), "Data Frequency"),
+                    Arguments.of(frameworkPolicy(namespace + "DataUsageEndDate", Operator.EQ, "2025-06-30T14:30:00Z"), "Data Usage End Date"),
+                    Arguments.of(frameworkPolicy(namespace + "DataUsageEndDefinition", Operator.EQ, "cx.datausageend.unlimited:1"), "Data Usage End Date Definition"),
+                    Arguments.of(frameworkPolicy(namespace + "DataUsageEndDurationDays", Operator.EQ, 3), "Data Usage End Duration Days"),
+                    Arguments.of(frameworkPolicy(namespace + "UsagePurpose", Operator.IS_ALL_OF,  List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), true), "Usage Purpose")
             );
         }
     }

--- a/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
+++ b/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
@@ -108,7 +108,8 @@ public class PolicyDefinitionEndToEndTest {
                     Arguments.of(frameworkPolicy(namespace + "Dismantler.allowedBrands", Operator.IS_NONE_OF, List.of("Yugo", "Tatra")), "Dismantler allowedBrands (IS_NONE_OF, no intersect)"),
                     Arguments.of(frameworkPolicy(namespace + "Dismantler.allowedBrands", Operator.IN, List.of("Moskvich", "Tatra", "Yugo", "Lada")), "Dismantler allowedBrands (IN, fully contained)"),
                     Arguments.of(frameworkPolicy(Map.of(namespace + "UsagePurpose", "cx.core.industrycore:1")), "Usage Purpose"),
-                    Arguments.of(frameworkPolicy(Map.of(namespace + "ContractReference", "contractReference")), "Contract reference")
+                    Arguments.of(frameworkPolicy(Map.of(namespace + "ContractReference", "contractReference")), "Contract reference"),
+                    Arguments.of(frameworkPolicy(namespace + "AffiliatesRegion", Operator.IS_ANY_OF, List.of("cx.region.all:1", "cx.region.europe:1", "cx.region.northAmerica:1"), true), "Affiliates Region")
             );
         }
     }


### PR DESCRIPTION
## WHAT

* add validation for the new data constraints which were introduced in the [cx-odrl-profile](https://github.com/catenax-eV/cx-odrl-profile/tree/main/schema/constraint)
* add validation for DataFrequencyConstraint
* add validation for DataProvisioningEndDateConstraint
* add validation for DataProvisioningEndDurationDaysConstraint
* add validation for DataUsageEndDateConstraint
* add validation for DataUsageEndDefinitionConstraint
* add validation for DataUsageEndDurationDaysConstraint

## WHY

To ensure that policies are valid

## FURTHER NOTES

* tests are added to validate that the changes work correctly
* manual testing has been done

This PR is based on #2086 and should best be reviewed after the base PR is merged

## Issue

Refs: #2083