### PR TITLE
feat(constraints): add validation for new constraints

### DIFF
--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/CxPolicyExtension.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/CxPolicyExtension.java
@@ -22,24 +22,35 @@ package org.eclipse.tractusx.edc.policy.cx;
 import org.eclipse.edc.connector.controlplane.catalog.spi.policy.CatalogPolicyContext;
 import org.eclipse.edc.connector.controlplane.contract.spi.policy.ContractNegotiationPolicyContext;
 import org.eclipse.edc.connector.controlplane.contract.spi.policy.TransferProcessPolicyContext;
+import org.eclipse.edc.policy.engine.spi.AtomicConstraintRuleFunction;
+import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.policy.engine.spi.RuleBindingRegistry;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.policy.model.Prohibition;
+import org.eclipse.edc.policy.model.Rule;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.tractusx.edc.policy.cx.affiliates.AffiliatesBpnlPermissionConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.affiliates.AffiliatesBpnlProhibitionConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.affiliates.AffiliatesRegionPermissionConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.affiliates.AffiliatesRegionProhibitionConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.contractreference.ContractReferenceConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.dismantler.DismantlerCredentialConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.framework.FrameworkAgreementCredentialConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.membership.MembershipCredentialConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.usage.UsagePurposeConstraintFunction;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
+import static org.eclipse.tractusx.edc.policy.cx.affiliates.AffiliatesBpnlProhibitionConstraintFunction.AFFILIATES_BPNL;
+import static org.eclipse.tractusx.edc.policy.cx.affiliates.AffiliatesRegionProhibitionConstraintFunction.AFFILIATES_REGION;
 import static org.eclipse.tractusx.edc.policy.cx.common.PolicyScopes.CATALOG_REQUEST_SCOPE;
 import static org.eclipse.tractusx.edc.policy.cx.common.PolicyScopes.CATALOG_SCOPE;
 import static org.eclipse.tractusx.edc.policy.cx.common.PolicyScopes.NEGOTIATION_REQUEST_SCOPE;
@@ -70,6 +81,27 @@ public class CxPolicyExtension implements ServiceExtension {
     private RuleBindingRegistry bindingRegistry;
 
     public static void registerFunctions(PolicyEngine engine) {
+
+        // Usage Prohibition Validators
+        registerForContexts(
+                ContractNegotiationPolicyContext.class,
+                Prohibition.class,
+                engine,
+                Map.of(
+                        CX_POLICY_NS + AFFILIATES_BPNL, new AffiliatesBpnlProhibitionConstraintFunction<>(),
+                        CX_POLICY_NS + AFFILIATES_REGION, new AffiliatesRegionProhibitionConstraintFunction<>())
+        );
+
+        registerForContexts(
+                TransferProcessPolicyContext.class,
+                Prohibition.class,
+                engine,
+                Map.of(
+                        CX_POLICY_NS + AFFILIATES_BPNL, new AffiliatesBpnlProhibitionConstraintFunction<>(),
+                        CX_POLICY_NS + AFFILIATES_REGION, new AffiliatesRegionProhibitionConstraintFunction<>())
+        );
+
+        // Access and Usage Permission Validators
         engine.registerFunction(CatalogPolicyContext.class, Permission.class, new DismantlerCredentialConstraintFunction<>());
         engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, new DismantlerCredentialConstraintFunction<>());
         engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, new DismantlerCredentialConstraintFunction<>());
@@ -82,13 +114,18 @@ public class CxPolicyExtension implements ServiceExtension {
         engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, new MembershipCredentialConstraintFunction<>());
         engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, new MembershipCredentialConstraintFunction<>());
 
-        engine.registerFunction(CatalogPolicyContext.class, Permission.class, CX_POLICY_NS + USAGE_PURPOSE, new UsagePurposeConstraintFunction<>());
-        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + USAGE_PURPOSE, new UsagePurposeConstraintFunction<>());
-        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + USAGE_PURPOSE, new UsagePurposeConstraintFunction<>());
+        // Usage Permission Validators
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + AFFILIATES_BPNL, new AffiliatesBpnlPermissionConstraintFunction<>());
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + AFFILIATES_BPNL, new AffiliatesBpnlPermissionConstraintFunction<>());
 
-        engine.registerFunction(CatalogPolicyContext.class, Permission.class, CX_POLICY_NS + CONTRACT_REFERENCE, new ContractReferenceConstraintFunction<>());
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + AFFILIATES_REGION, new AffiliatesRegionPermissionConstraintFunction<>());
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + AFFILIATES_REGION, new AffiliatesRegionPermissionConstraintFunction<>());
+
         engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + CONTRACT_REFERENCE, new ContractReferenceConstraintFunction<>());
         engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + CONTRACT_REFERENCE, new ContractReferenceConstraintFunction<>());
+
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + USAGE_PURPOSE, new UsagePurposeConstraintFunction<>());
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + USAGE_PURPOSE, new UsagePurposeConstraintFunction<>());
     }
 
     public static void registerBindings(RuleBindingRegistry registry) {
@@ -102,14 +139,32 @@ public class CxPolicyExtension implements ServiceExtension {
         registry.bind(ODRL_SCHEMA + "use", CATALOG_SCOPE);
         registry.bind(ODRL_SCHEMA + "use", NEGOTIATION_SCOPE);
         registry.bind(ODRL_SCHEMA + "use", TRANSFER_PROCESS_SCOPE);
-        
-        registry.bind(CX_POLICY_NS + USAGE_PURPOSE, CATALOG_SCOPE);
-        registry.bind(CX_POLICY_NS + USAGE_PURPOSE, NEGOTIATION_SCOPE);
-        registry.bind(CX_POLICY_NS + USAGE_PURPOSE, TRANSFER_PROCESS_SCOPE);
 
-        registry.bind(CX_POLICY_NS + CONTRACT_REFERENCE, CATALOG_SCOPE);
-        registry.bind(CX_POLICY_NS + CONTRACT_REFERENCE, NEGOTIATION_SCOPE);
-        registry.bind(CX_POLICY_NS + CONTRACT_REFERENCE, TRANSFER_PROCESS_SCOPE);
+        registerBindingSets(
+                registry,
+                Set.of(CX_POLICY_NS + USAGE_PURPOSE, CX_POLICY_NS + CONTRACT_REFERENCE),
+                Set.of(CATALOG_SCOPE, NEGOTIATION_SCOPE, TRANSFER_PROCESS_SCOPE));
+
+        // Usage Prohibition Validators
+        registerBindingSets(
+                registry,
+                Set.of(CX_POLICY_NS + AFFILIATES_BPNL, CX_POLICY_NS + AFFILIATES_REGION),
+                Set.of(NEGOTIATION_SCOPE, TRANSFER_PROCESS_SCOPE));
+
+        // Usage Permission Validators
+        registerBindingSets(
+                registry,
+                Set.of(
+                        CX_POLICY_NS + AFFILIATES_BPNL,
+                        CX_POLICY_NS + AFFILIATES_REGION,
+                        CX_POLICY_NS + CONTRACT_REFERENCE,
+                        CX_POLICY_NS + USAGE_PURPOSE),
+                Set.of(NEGOTIATION_SCOPE, TRANSFER_PROCESS_SCOPE));
+
+    }
+
+    private static void registerBindingSets(RuleBindingRegistry registry, Set<String> names, Set<String> scopes) {
+        scopes.forEach(scope -> names.forEach(name -> registry.bind(name, scope)));
     }
 
     @Override
@@ -121,5 +176,11 @@ public class CxPolicyExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         registerFunctions(policyEngine);
         registerBindings(bindingRegistry);
+    }
+
+    private static <R extends Rule, C extends PolicyContext> void registerForContexts(Class<C> context, Class<R> type, PolicyEngine engine, Map<String, AtomicConstraintRuleFunction<R, C>> constraints) {
+        constraints.forEach((functionId, constraintFunction) ->
+                engine.registerFunction(context, type, functionId, constraintFunction)
+        );
     }
 }

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/CxPolicyExtension.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/CxPolicyExtension.java
@@ -41,7 +41,14 @@ import org.eclipse.tractusx.edc.policy.cx.contractreference.ContractReferenceCon
 import org.eclipse.tractusx.edc.policy.cx.dismantler.DismantlerCredentialConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.framework.FrameworkAgreementCredentialConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.membership.MembershipCredentialConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.precedence.PrecedenceConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.usage.ExcludingUsageConstraintFunction;
 import org.eclipse.tractusx.edc.policy.cx.usage.UsagePurposeConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.usage.UsageRestrictionConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.versionchange.VersionChangesConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.warrenty.WarrantyConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.warrenty.WarrantyDefinitionConstraintFunction;
+import org.eclipse.tractusx.edc.policy.cx.warrenty.WarrantyDurationMonthsConstraintFunction;
 
 import java.util.Map;
 import java.util.Set;
@@ -61,7 +68,14 @@ import static org.eclipse.tractusx.edc.policy.cx.contractreference.ContractRefer
 import static org.eclipse.tractusx.edc.policy.cx.dismantler.DismantlerCredentialConstraintFunction.DISMANTLER_LITERAL;
 import static org.eclipse.tractusx.edc.policy.cx.framework.FrameworkAgreementCredentialConstraintFunction.FRAMEWORK_AGREEMENT_LITERAL;
 import static org.eclipse.tractusx.edc.policy.cx.membership.MembershipCredentialConstraintFunction.MEMBERSHIP_LITERAL;
+import static org.eclipse.tractusx.edc.policy.cx.precedence.PrecedenceConstraintFunction.PRECEDENCE;
+import static org.eclipse.tractusx.edc.policy.cx.usage.ExcludingUsageConstraintFunction.EXCLUSIVE_USAGE;
 import static org.eclipse.tractusx.edc.policy.cx.usage.UsagePurposeConstraintFunction.USAGE_PURPOSE;
+import static org.eclipse.tractusx.edc.policy.cx.usage.UsageRestrictionConstraintFunction.USAGE_RESTRICTION;
+import static org.eclipse.tractusx.edc.policy.cx.versionchange.VersionChangesConstraintFunction.VERSION_CHANGES;
+import static org.eclipse.tractusx.edc.policy.cx.warrenty.WarrantyConstraintFunction.WARRANTY;
+import static org.eclipse.tractusx.edc.policy.cx.warrenty.WarrantyDefinitionConstraintFunction.WARRANTY_DEFINITION;
+import static org.eclipse.tractusx.edc.policy.cx.warrenty.WarrantyDurationMonthsConstraintFunction.WARRANTY_DURATION_MONTHS;
 
 
 /**
@@ -81,7 +95,6 @@ public class CxPolicyExtension implements ServiceExtension {
     private RuleBindingRegistry bindingRegistry;
 
     public static void registerFunctions(PolicyEngine engine) {
-
         // Usage Prohibition Validators
         registerForContexts(
                 ContractNegotiationPolicyContext.class,
@@ -89,7 +102,8 @@ public class CxPolicyExtension implements ServiceExtension {
                 engine,
                 Map.of(
                         CX_POLICY_NS + AFFILIATES_BPNL, new AffiliatesBpnlProhibitionConstraintFunction<>(),
-                        CX_POLICY_NS + AFFILIATES_REGION, new AffiliatesRegionProhibitionConstraintFunction<>())
+                        CX_POLICY_NS + AFFILIATES_REGION, new AffiliatesRegionProhibitionConstraintFunction<>(),
+                        CX_POLICY_NS + USAGE_RESTRICTION, new UsageRestrictionConstraintFunction<>())
         );
 
         registerForContexts(
@@ -98,7 +112,8 @@ public class CxPolicyExtension implements ServiceExtension {
                 engine,
                 Map.of(
                         CX_POLICY_NS + AFFILIATES_BPNL, new AffiliatesBpnlProhibitionConstraintFunction<>(),
-                        CX_POLICY_NS + AFFILIATES_REGION, new AffiliatesRegionProhibitionConstraintFunction<>())
+                        CX_POLICY_NS + AFFILIATES_REGION, new AffiliatesRegionProhibitionConstraintFunction<>(),
+                        CX_POLICY_NS + USAGE_RESTRICTION, new UsageRestrictionConstraintFunction<>())
         );
 
         // Access and Usage Permission Validators
@@ -124,8 +139,26 @@ public class CxPolicyExtension implements ServiceExtension {
         engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + CONTRACT_REFERENCE, new ContractReferenceConstraintFunction<>());
         engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + CONTRACT_REFERENCE, new ContractReferenceConstraintFunction<>());
 
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + EXCLUSIVE_USAGE, new ExcludingUsageConstraintFunction<>());
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + EXCLUSIVE_USAGE, new ExcludingUsageConstraintFunction<>());
+
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + PRECEDENCE, new PrecedenceConstraintFunction<>());
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + PRECEDENCE, new PrecedenceConstraintFunction<>());
+
         engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + USAGE_PURPOSE, new UsagePurposeConstraintFunction<>());
         engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + USAGE_PURPOSE, new UsagePurposeConstraintFunction<>());
+
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + VERSION_CHANGES, new VersionChangesConstraintFunction<>());
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + VERSION_CHANGES, new VersionChangesConstraintFunction<>());
+
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + WARRANTY, new WarrantyConstraintFunction<>());
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + WARRANTY, new WarrantyConstraintFunction<>());
+
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + WARRANTY_DEFINITION, new WarrantyDefinitionConstraintFunction<>());
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + WARRANTY_DEFINITION, new WarrantyDefinitionConstraintFunction<>());
+
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + WARRANTY_DURATION_MONTHS, new WarrantyDurationMonthsConstraintFunction<>());
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + WARRANTY_DURATION_MONTHS, new WarrantyDurationMonthsConstraintFunction<>());
     }
 
     public static void registerBindings(RuleBindingRegistry registry) {
@@ -148,7 +181,7 @@ public class CxPolicyExtension implements ServiceExtension {
         // Usage Prohibition Validators
         registerBindingSets(
                 registry,
-                Set.of(CX_POLICY_NS + AFFILIATES_BPNL, CX_POLICY_NS + AFFILIATES_REGION),
+                Set.of(CX_POLICY_NS + AFFILIATES_BPNL, CX_POLICY_NS + AFFILIATES_REGION, CX_POLICY_NS + USAGE_RESTRICTION),
                 Set.of(NEGOTIATION_SCOPE, TRANSFER_PROCESS_SCOPE));
 
         // Usage Permission Validators
@@ -158,7 +191,13 @@ public class CxPolicyExtension implements ServiceExtension {
                         CX_POLICY_NS + AFFILIATES_BPNL,
                         CX_POLICY_NS + AFFILIATES_REGION,
                         CX_POLICY_NS + CONTRACT_REFERENCE,
-                        CX_POLICY_NS + USAGE_PURPOSE),
+                        CX_POLICY_NS + EXCLUSIVE_USAGE,
+                        CX_POLICY_NS + PRECEDENCE,
+                        CX_POLICY_NS + USAGE_PURPOSE,
+                        CX_POLICY_NS + VERSION_CHANGES,
+                        CX_POLICY_NS + WARRANTY,
+                        CX_POLICY_NS + WARRANTY_DEFINITION,
+                        CX_POLICY_NS + WARRANTY_DURATION_MONTHS),
                 Set.of(NEGOTIATION_SCOPE, TRANSFER_PROCESS_SCOPE));
 
     }

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesBpnlBaseConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesBpnlBaseConstraintFunction.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.affiliates;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Rule;
+import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for AffiliatesBpnl. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class AffiliatesBpnlBaseConstraintFunction<T extends Rule, C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<T, C> {
+    public static final String AFFILIATES_BPNL = "AffiliatesBpnl";
+
+    public AffiliatesBpnlBaseConstraintFunction() {
+        super(
+                Set.of(Operator.IS_ANY_OF),
+                "^BPNL[0-9A-Z]{12}$",
+                true
+        );
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesBpnlPermissionConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesBpnlPermissionConstraintFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.affiliates;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Permission;
+
+/**
+ * This is a placeholder constraint function for AffiliatesBpnl. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class AffiliatesBpnlPermissionConstraintFunction<C extends ParticipantAgentPolicyContext> extends AffiliatesBpnlBaseConstraintFunction<Permission, C> {
+    public AffiliatesBpnlPermissionConstraintFunction() {
+        super();
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesBpnlProhibitionConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesBpnlProhibitionConstraintFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.affiliates;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Prohibition;
+
+/**
+ * This is a placeholder constraint function for AffiliatesBpnl. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class AffiliatesBpnlProhibitionConstraintFunction<C extends ParticipantAgentPolicyContext> extends AffiliatesBpnlBaseConstraintFunction<Prohibition, C> {
+    public AffiliatesBpnlProhibitionConstraintFunction() {
+        super();
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesRegionBaseConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesRegionBaseConstraintFunction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.affiliates;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Rule;
+import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for AffiliatesRegion. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class AffiliatesRegionBaseConstraintFunction<T extends Rule, C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<T, C> {
+    public static final String AFFILIATES_REGION = "AffiliatesRegion";
+
+    public AffiliatesRegionBaseConstraintFunction() {
+        super(
+                Set.of(Operator.IS_ANY_OF),
+                Set.of(
+                        "cx.region.all:1",
+                        "cx.region.europe:1",
+                        "cx.region.northAmerica:1",
+                        "cx.region.southAmerica:1",
+                        "cx.region.africa:1",
+                        "cx.region.asia:1",
+                        "cx.region.oceania:1",
+                        "cx.region.antarctica:1"
+                ),
+                true
+        );
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesRegionPermissionConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesRegionPermissionConstraintFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.affiliates;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Permission;
+
+/**
+ * This is a placeholder constraint function for AffiliatesRegion. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class AffiliatesRegionPermissionConstraintFunction<C extends ParticipantAgentPolicyContext> extends AffiliatesRegionBaseConstraintFunction<Permission, C> {
+    public AffiliatesRegionPermissionConstraintFunction() {
+        super();
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesRegionProhibitionConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesRegionProhibitionConstraintFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.affiliates;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Prohibition;
+
+/**
+ * This is a placeholder constraint function for AffiliatesRegion. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class AffiliatesRegionProhibitionConstraintFunction<C extends ParticipantAgentPolicyContext> extends AffiliatesRegionBaseConstraintFunction<Prohibition, C> {
+    public AffiliatesRegionProhibitionConstraintFunction() {
+        super();
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/BaseConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/BaseConstraintFunction.java
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.policy.cx.common;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.engine.spi.AtomicConstraintRuleFunction;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Rule;
+import org.eclipse.edc.spi.result.Result;
+
+import java.util.Set;
+
+public abstract class BaseConstraintFunction<T extends Rule, C extends ParticipantAgentPolicyContext> implements AtomicConstraintRuleFunction<T, C> {
+    private final Set<Operator> allowedOperators;
+
+    protected BaseConstraintFunction(Set<Operator> allowedOperators) {
+        this.allowedOperators = allowedOperators;
+    }
+
+    @Override
+    public boolean evaluate(Operator operator, Object rightOperand, T rule, C c) {
+        return true;
+    }
+
+    @Override
+    public Result<Void> validate(Operator operator, Object rightValue, T rule) {
+        if (!allowedOperators.contains(operator)) {
+            return Result.failure("Invalid operator: this constraint only allows the following operators: %s, but received '%s'."
+                    .formatted(allowedOperators, operator));
+        }
+        return validateRightOperand(rightValue);
+    }
+
+    protected abstract Result<Void> validateRightOperand(Object rightValue);
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/ValueValidatingConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/ValueValidatingConstraintFunction.java
@@ -1,0 +1,123 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.policy.cx.common;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Rule;
+import org.eclipse.edc.spi.result.Result;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public abstract class ValueValidatingConstraintFunction<T extends Rule, C extends ParticipantAgentPolicyContext> extends BaseConstraintFunction<T, C> {
+    private final Set<String> allowedValues;
+    private final String pattern;
+    private final boolean validateList;
+
+    protected ValueValidatingConstraintFunction(Set<Operator> allowedOperators, String pattern) {
+        this(allowedOperators, Set.of(), pattern, false);
+    }
+
+    protected ValueValidatingConstraintFunction(Set<Operator> allowedOperators, Set<String> validValues) {
+        this(allowedOperators, validValues, "[\\s\\S]+", false);
+    }
+
+    protected ValueValidatingConstraintFunction(Set<Operator> allowedOperators, String pattern, boolean validateList) {
+        this(allowedOperators, Set.of(), pattern, validateList);
+    }
+
+    protected ValueValidatingConstraintFunction(Set<Operator> allowedOperators, Set<String> validValues, boolean validateList) {
+        this(allowedOperators, validValues, "[\\s\\S]+", validateList);
+    }
+
+    protected ValueValidatingConstraintFunction(Set<Operator> allowedOperators,
+                                                Set<String> validValues,
+                                                String pattern,
+                                                boolean validateList) {
+        super(allowedOperators);
+        this.allowedValues = validValues;
+        this.pattern = pattern;
+        this.validateList = validateList;
+    }
+
+    @Override
+    protected Result<Void> validateRightOperand(Object rightValue) {
+        return validateList ? validateList(rightValue) : validateSingleValue(rightValue);
+    }
+
+    private Result<Void> validateSingleValue(Object rightValue) {
+        if (allowedValues != null && !allowedValues.isEmpty()) {
+            return rightValue instanceof String && allowedValues.contains(rightValue.toString().toLowerCase())
+                    ? Result.success()
+                    : Result.failure("Invalid right-operand: this constraint only allows the following right-operands: %s, but received '%s'."
+                    .formatted(String.join(", ", allowedValues), rightValue));
+        }
+
+        var compiledPattern = Pattern.compile(pattern);
+        return rightValue instanceof String s && compiledPattern.matcher(s).matches()
+                ? Result.success()
+                : Result.failure("Invalid right-operand: right operand must match pattern '%s'".formatted(pattern));
+    }
+
+    private Result<Void> validateList(Object rightValue) {
+        List<?> list = List.of();
+        if (rightValue instanceof String s) {
+            list = s.contains(",") ?
+                    Arrays.stream(s.split(","))
+                            .map(String::trim)
+                            .toList() :
+                    List.of(s.trim());
+        }
+        if (rightValue instanceof List<?> rightValuelist) {
+            list = rightValuelist;
+        }
+
+        if (list.isEmpty()) {
+            return Result.failure("Invalid right-operand: must be a list and contain at least 1 value");
+        }
+
+        if (allowedValues != null && !allowedValues.isEmpty()) {
+            var invalidValues = list.stream()
+                    .filter(String.class::isInstance)
+                    .map(String.class::cast)
+                    .filter(value -> !allowedValues.contains(value))
+                    .toList();
+
+            return invalidValues.isEmpty()
+                    ? Result.success()
+                    : Result.failure("Invalid right-operand: the following values are not allowed: %s".formatted(invalidValues));
+        }
+
+        var compiledPattern = Pattern.compile(pattern);
+        var distinctValues = list.stream()
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .filter(s -> compiledPattern.matcher(s).matches())
+                .distinct()
+                .count();
+
+        return distinctValues == list.size()
+                ? Result.success()
+                : Result.failure("Invalid right-operand: list must contain only unique values matching pattern: %s".formatted(pattern));
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/precedence/PrecedenceConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/precedence/PrecedenceConstraintFunction.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.precedence;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for Precedence. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class PrecedenceConstraintFunction<C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<Permission, C> {
+    public static final String PRECEDENCE = "Precedence";
+
+    public PrecedenceConstraintFunction() {
+        super(
+                Set.of(Operator.EQ),
+                Set.of(
+                        "cx.precedence.contractreference:1",
+                        "cx.precedence.rcagreement:1"
+                )
+        );
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/usage/ExcludingUsageConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/usage/ExcludingUsageConstraintFunction.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.usage;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for ExclusiveUsage. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class ExcludingUsageConstraintFunction<C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<Permission, C> {
+    public static final String EXCLUSIVE_USAGE = "ExclusiveUsage";
+
+    public ExcludingUsageConstraintFunction() {
+        super(
+                Set.of(Operator.EQ),
+                Set.of(
+                        "x.exclusiveusage.dataconsumer:1"
+                )
+        );
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/usage/UsagePurposeConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/usage/UsagePurposeConstraintFunction.java
@@ -20,20 +20,54 @@
 package org.eclipse.tractusx.edc.policy.cx.usage;
 
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
-import org.eclipse.edc.policy.engine.spi.AtomicConstraintRuleFunction;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
 
+import java.util.Set;
 
 /**
  * This is a placeholder constraint function for UsagePurpose. It always returns true but allows
  * the validation of policies to be strictly enforced.
  */
-public class UsagePurposeConstraintFunction<C extends ParticipantAgentPolicyContext> implements AtomicConstraintRuleFunction<Permission, C> {
+public class UsagePurposeConstraintFunction<C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<Permission, C> {
     public static final String USAGE_PURPOSE = "UsagePurpose";
 
-    @Override
-    public boolean evaluate(Operator operator, Object rightOperand, Permission permission, C c) {
-        return true;
+    public UsagePurposeConstraintFunction() {
+        super(
+                Set.of(Operator.IS_ALL_OF),
+                Set.of(
+                        "cx.core.legalrequirementforthirdparty:1",
+                        "cx.core.industrycore:1",
+                        "cx.core.qualitynotifications:1",
+                        "cx.core.digitaltwinregistry:1",
+                        "cx.pcf.base:1",
+                        "cx.quality.base:1",
+                        "cx.dcm.base:1",
+                        "cx.puris.base:1",
+                        "cx.circular.dpp:1",
+                        "cx.circular.smc:1",
+                        "cx.circular.marketplace:1",
+                        "cx.circular.materialaccounting:1",
+                        "cx.bpdm.gate.upload:1",
+                        "cx.bpdm.gate.download:1",
+                        "cx.bpdm.pool:1",
+                        "cx.bpdm.vas.countryrisk:1",
+                        "cx.bpdm.vas.dataquality.upload:1",
+                        "cx.bpdm.vas.dataquality.download:1",
+                        "cx.bpdm.vas.bdv.upload:1",
+                        "cx.bpdm.vas.bdv.download:1",
+                        "cx.bpdm.vas.fpd.upload:1",
+                        "cx.bpdm.vas.fpd.download:1",
+                        "cx.bpdm.vas.swd.upload:1",
+                        "cx.bpdm.vas.swd.download:1",
+                        "cx.bpdm.vas.nps.upload:1",
+                        "cx.bpdm.vas.nps.download:1",
+                        "cx.ccm.base:1",
+                        "cx.bpdm.poolAll:1",
+                        "cx.logistics.base:1"
+                ),
+                true
+        );
     }
 }

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/usage/UsageRestrictionConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/usage/UsageRestrictionConstraintFunction.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.usage;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Prohibition;
+import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for UsageRestriction. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class UsageRestrictionConstraintFunction<C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<Prohibition, C> {
+    public static final String USAGE_RESTRICTION = "UsageRestriction";
+
+    public UsageRestrictionConstraintFunction() {
+        super(
+                Set.of(Operator.IS_ALL_OF),
+                Set.of(
+                        "cx.thirdparty.forbidden:1",
+                        "cx.manipulation.forbidden:1",
+                        "cx.derivations.forbidden:1",
+                        "cx.extraordinaryanalytics.forbidden:1",
+                        "cx.dataProviderremoval.forbidden:1"
+                ),
+                true
+        );
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/versionchange/VersionChangesConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/versionchange/VersionChangesConstraintFunction.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.versionchange;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for VersionChanges. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class VersionChangesConstraintFunction<C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<Permission, C> {
+    public static final String VERSION_CHANGES = "VersionChanges";
+
+    public VersionChangesConstraintFunction() {
+        super(
+                Set.of(Operator.EQ),
+                Set.of(
+                        "cx.versionchanges.minor:1",
+                        "cx.versionchanges.major:1"
+                )
+        );
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/warrenty/WarrantyConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/warrenty/WarrantyConstraintFunction.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.warrenty;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for Warranty. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class WarrantyConstraintFunction<C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<Permission, C> {
+    public static final String WARRANTY = "Warranty";
+
+    public WarrantyConstraintFunction() {
+        super(
+                Set.of(Operator.EQ),
+                Set.of(
+                        "cx.warranty.none:1",
+                        "cx.warranty.contractReference:1",
+                        "cx.warranty.dataQualityIssues:1"
+                )
+        );
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/warrenty/WarrantyDefinitionConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/warrenty/WarrantyDefinitionConstraintFunction.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.warrenty;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for ContractReference. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class WarrantyDefinitionConstraintFunction<C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<Permission, C> {
+    public static final String WARRANTY_DEFINITION = "WarrantyDefinition";
+
+    public WarrantyDefinitionConstraintFunction() {
+        super(
+                Set.of(Operator.EQ),
+                Set.of(
+                        "cx.warranty.contractenddate:1"
+                )
+        );
+    }
+}

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/warrenty/WarrantyDurationMonthsConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/warrenty/WarrantyDurationMonthsConstraintFunction.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.policy.cx.warrenty;
+
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.engine.spi.AtomicConstraintRuleFunction;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.result.Result;
+
+import java.util.Set;
+
+/**
+ * This is a placeholder constraint function for ContractReference. It always returns true but allows
+ * the validation of policies to be strictly enforced.
+ */
+public class WarrantyDurationMonthsConstraintFunction<C extends ParticipantAgentPolicyContext> implements AtomicConstraintRuleFunction<Permission, C> {
+    public static final String WARRANTY_DURATION_MONTHS = "WarrantyDurationMonths";
+    private static final Set<Operator> ALLOWED_OPERATORS = Set.of(
+            Operator.EQ
+    );
+
+    @Override
+    public boolean evaluate(Operator operator, Object rightOperand, Permission permission, C c) {
+        return true;
+    }
+
+    @Override
+    public Result<Void> validate(Operator operator, Object rightValue, Permission rule) {
+        if (!ALLOWED_OPERATORS.contains(operator)) {
+            return Result.failure("Invalid operator: this constraint only allows the following operators: %s, but received '%s'.".formatted(ALLOWED_OPERATORS, operator));
+        }
+
+        if (rightValue instanceof Integer) {
+            return Result.success();
+        }
+
+        if (rightValue instanceof String stringValue) {
+            try {
+                Integer.parseInt(stringValue);
+                return Result.success();
+            } catch (NumberFormatException e) {
+                return Result.failure("Invalid right-operand: String value must be a valid integer, but got '%s'.".formatted(stringValue));
+            }
+        }
+
+        return Result.failure("Invalid right-operand: this constraint only allows integer values or strings representing integers, but got '%s'."
+                .formatted(rightValue != null ? rightValue.getClass().getName() : "null"));
+    }
+}

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesBpnlConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesBpnlConstraintFunctionTest.java
@@ -1,0 +1,80 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.policy.cx.affiliates;
+
+import org.eclipse.edc.participant.spi.ParticipantAgent;
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class AffiliatesBpnlConstraintFunctionTest {
+
+    private final ParticipantAgent participantAgent = mock();
+    private final AffiliatesBpnlProhibitionConstraintFunction<ParticipantAgentPolicyContext> function = new AffiliatesBpnlProhibitionConstraintFunction<>();
+    private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
+
+    @Test
+    void evaluate() {
+        assertThat(function.evaluate(Operator.EQ, "BPNL00000000001A", null, context)).isTrue();
+    }
+
+    @Test
+    void validate_whenValidOperatorAndRightValueArePassed_thenSuccess() {
+        var rightValue = List.of("BPNL00000000001A", "BPNL00000000002B");
+        var result = function.validate(Operator.IS_ANY_OF, rightValue, null);
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenValidOperatorAndOneRightValueIsPassed_thenSuccess() {
+        var rightValue = List.of("BPNL00000000001A");
+        var result = function.validate(Operator.IS_ANY_OF, rightValue, null);
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenInvalidOperator_thenFailure() {
+        var rightValue = List.of("BPNL00000000001A");
+        var result = function.validate(Operator.EQ, rightValue, null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Invalid operator");
+    }
+
+    @Test
+    void validate_whenInvalidRightValueType_thenFailure() {
+        var result = function.validate(Operator.IS_ANY_OF, "BPNL000000001A", null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("list must contain only unique values matching pattern");
+    }
+
+    @Test
+    void validate_whenInvalidBpnlFormat_thenFailure() {
+        var rightValue = List.of("invalid-bpnl");
+        var result = function.validate(Operator.IS_ANY_OF, rightValue, null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("matching pattern");
+    }
+}

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesRegionConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/affiliates/AffiliatesRegionConstraintFunctionTest.java
@@ -1,0 +1,72 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.policy.cx.affiliates;
+
+import org.eclipse.edc.participant.spi.ParticipantAgent;
+import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class AffiliatesRegionConstraintFunctionTest {
+
+    private final ParticipantAgent participantAgent = mock();
+    private final AffiliatesRegionProhibitionConstraintFunction<ParticipantAgentPolicyContext> function = new AffiliatesRegionProhibitionConstraintFunction<>();
+    private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
+
+    @Test
+    void evaluate() {
+        assertThat(function.evaluate(Operator.IS_ANY_OF, "BPNL00000000001A", null, context)).isTrue();
+    }
+
+    @Test
+    void validate_whenValidOperatorAndRightValueArePassed_thenSuccess() {
+        var rightValue = List.of("cx.region.europe:1", "cx.region.northAmerica:1");
+        var result = function.validate(Operator.IS_ANY_OF, rightValue, null);
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenValidOperatorAndOneRightValueIsPassed_thenSuccess() {
+        var rightValue = List.of("cx.region.all:1");
+        var result = function.validate(Operator.IS_ANY_OF, rightValue, null);
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    @Test
+    void validate_whenInvalidOperator_thenFailure() {
+        var rightValue = List.of("cx.region.all:1");
+        var result = function.validate(Operator.EQ, rightValue, null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Invalid operator");
+    }
+
+    @Test
+    void validate_whenInvalidRightValueType_thenFailure() {
+        var result = function.validate(Operator.IS_ANY_OF, "invalid_value", null);
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("the following values are not allowed");
+    }
+}

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/precedence/PrecedenceConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/precedence/PrecedenceConstraintFunctionTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-package org.eclipse.tractusx.edc.policy.cx.usage;
+package org.eclipse.tractusx.edc.policy.cx.precedence;
 
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
@@ -30,33 +30,33 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-class UsagePurposeConstraintFunctionTest {
+class PrecedenceConstraintFunctionTest {
 
     private final ParticipantAgent participantAgent = mock();
-    private final UsagePurposeConstraintFunction<ParticipantAgentPolicyContext> function = new UsagePurposeConstraintFunction<>();
+    private final PrecedenceConstraintFunction<ParticipantAgentPolicyContext> function = new PrecedenceConstraintFunction<>();
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
 
     @Test
     void evaluate() {
-        assertThat(function.evaluate(Operator.IS_ALL_OF, List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), null, context)).isTrue();
+        assertThat(function.evaluate(Operator.EQ, "cx.precedence.contractReference:1", null, context)).isTrue();
     }
 
     @Test
     void validate_whenOperatorAndRightOperandAreValid_thenSuccess() {
-        var result = function.validate(Operator.IS_ALL_OF, List.of("cx.core.legalrequirementforthirdparty:1", "cx.core.industrycore:1"), null);
+        var result = function.validate(Operator.EQ, "cx.precedence.contractReference:1", null);
         assertThat(result.succeeded()).isTrue();
     }
 
     @Test
     void validate_whenInvalidOperator_thenFailure() {
-        var result = function.validate(Operator.EQ, List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), null);
+        var result = function.validate(Operator.IS_ANY_OF, "cx.precedence.contractReference:1", null);
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureDetail()).contains("Invalid operator");
     }
 
     @Test
     void validate_whenInvalidValue_thenFailure() {
-        var result = function.validate(Operator.IS_ALL_OF, List.of("BPNL00000000001A"), null);
+        var result = function.validate(Operator.EQ, List.of("BPNL00000000001A"), null);
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureDetail()).contains("Invalid right-operand: ");
     }

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/usage/ExcludingUsageConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/usage/ExcludingUsageConstraintFunctionTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -30,33 +30,33 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-class UsagePurposeConstraintFunctionTest {
+class ExcludingUsageConstraintFunctionTest {
 
     private final ParticipantAgent participantAgent = mock();
-    private final UsagePurposeConstraintFunction<ParticipantAgentPolicyContext> function = new UsagePurposeConstraintFunction<>();
+    private final ExcludingUsageConstraintFunction<ParticipantAgentPolicyContext> function = new ExcludingUsageConstraintFunction<>();
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
 
     @Test
     void evaluate() {
-        assertThat(function.evaluate(Operator.IS_ALL_OF, List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), null, context)).isTrue();
+        assertThat(function.evaluate(Operator.EQ, "x.exclusiveUsage.dataConsumer:1", null, context)).isTrue();
     }
 
     @Test
     void validate_whenOperatorAndRightOperandAreValid_thenSuccess() {
-        var result = function.validate(Operator.IS_ALL_OF, List.of("cx.core.legalrequirementforthirdparty:1", "cx.core.industrycore:1"), null);
+        var result = function.validate(Operator.EQ, "x.exclusiveUsage.dataConsumer:1", null);
         assertThat(result.succeeded()).isTrue();
     }
 
     @Test
     void validate_whenInvalidOperator_thenFailure() {
-        var result = function.validate(Operator.EQ, List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), null);
+        var result = function.validate(Operator.IS_ANY_OF, "x.exclusiveUsage.dataConsumer:1", null);
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureDetail()).contains("Invalid operator");
     }
 
     @Test
     void validate_whenInvalidValue_thenFailure() {
-        var result = function.validate(Operator.IS_ALL_OF, List.of("BPNL00000000001A"), null);
+        var result = function.validate(Operator.EQ, List.of("BPNL00000000001A"), null);
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureDetail()).contains("Invalid right-operand: ");
     }

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/usage/UsageRestrictionConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/usage/UsageRestrictionConstraintFunctionTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -30,26 +30,26 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-class UsagePurposeConstraintFunctionTest {
+class UsageRestrictionConstraintFunctionTest {
 
     private final ParticipantAgent participantAgent = mock();
-    private final UsagePurposeConstraintFunction<ParticipantAgentPolicyContext> function = new UsagePurposeConstraintFunction<>();
+    private final UsageRestrictionConstraintFunction<ParticipantAgentPolicyContext> function = new UsageRestrictionConstraintFunction<>();
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
 
     @Test
     void evaluate() {
-        assertThat(function.evaluate(Operator.IS_ALL_OF, List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), null, context)).isTrue();
+        assertThat(function.evaluate(Operator.IS_ALL_OF, "cx.thirdparty.forbidden:1", null, context)).isTrue();
     }
 
     @Test
     void validate_whenOperatorAndRightOperandAreValid_thenSuccess() {
-        var result = function.validate(Operator.IS_ALL_OF, List.of("cx.core.legalrequirementforthirdparty:1", "cx.core.industrycore:1"), null);
+        var result = function.validate(Operator.IS_ALL_OF, List.of("cx.thirdparty.forbidden:1"), null);
         assertThat(result.succeeded()).isTrue();
     }
 
     @Test
     void validate_whenInvalidOperator_thenFailure() {
-        var result = function.validate(Operator.EQ, List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), null);
+        var result = function.validate(Operator.EQ, List.of("cx.thirdparty.forbidden:1"), null);
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureDetail()).contains("Invalid operator");
     }

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/versionchange/VersionChangesConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/versionchange/VersionChangesConstraintFunctionTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-package org.eclipse.tractusx.edc.policy.cx.usage;
+package org.eclipse.tractusx.edc.policy.cx.versionchange;
 
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
@@ -30,33 +30,33 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-class UsagePurposeConstraintFunctionTest {
+class VersionChangesConstraintFunctionTest {
 
     private final ParticipantAgent participantAgent = mock();
-    private final UsagePurposeConstraintFunction<ParticipantAgentPolicyContext> function = new UsagePurposeConstraintFunction<>();
+    private final VersionChangesConstraintFunction<ParticipantAgentPolicyContext> function = new VersionChangesConstraintFunction<>();
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
 
     @Test
     void evaluate() {
-        assertThat(function.evaluate(Operator.IS_ALL_OF, List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), null, context)).isTrue();
+        assertThat(function.evaluate(Operator.EQ, "cx.versionchanges.minor:1", null, context)).isTrue();
     }
 
     @Test
     void validate_whenOperatorAndRightOperandAreValid_thenSuccess() {
-        var result = function.validate(Operator.IS_ALL_OF, List.of("cx.core.legalrequirementforthirdparty:1", "cx.core.industrycore:1"), null);
+        var result = function.validate(Operator.EQ, "cx.versionchanges.minor:1", null);
         assertThat(result.succeeded()).isTrue();
     }
 
     @Test
     void validate_whenInvalidOperator_thenFailure() {
-        var result = function.validate(Operator.EQ, List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), null);
+        var result = function.validate(Operator.IS_ANY_OF, "cx.versionchanges.minor:1", null);
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureDetail()).contains("Invalid operator");
     }
 
     @Test
     void validate_whenInvalidValue_thenFailure() {
-        var result = function.validate(Operator.IS_ALL_OF, List.of("BPNL00000000001A"), null);
+        var result = function.validate(Operator.EQ, List.of("invalid"), null);
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureDetail()).contains("Invalid right-operand: ");
     }

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/warrenty/WarrantyConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/warrenty/WarrantyConstraintFunctionTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-package org.eclipse.tractusx.edc.policy.cx.usage;
+package org.eclipse.tractusx.edc.policy.cx.warrenty;
 
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
@@ -25,38 +25,36 @@ import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-class UsagePurposeConstraintFunctionTest {
+class WarrantyConstraintFunctionTest {
 
     private final ParticipantAgent participantAgent = mock();
-    private final UsagePurposeConstraintFunction<ParticipantAgentPolicyContext> function = new UsagePurposeConstraintFunction<>();
+    private final WarrantyConstraintFunction<ParticipantAgentPolicyContext> function = new WarrantyConstraintFunction<>();
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
 
     @Test
     void evaluate() {
-        assertThat(function.evaluate(Operator.IS_ALL_OF, List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), null, context)).isTrue();
+        assertThat(function.evaluate(Operator.EQ, "cx.warranty.none:1", null, context)).isTrue();
     }
 
     @Test
     void validate_whenOperatorAndRightOperandAreValid_thenSuccess() {
-        var result = function.validate(Operator.IS_ALL_OF, List.of("cx.core.legalrequirementforthirdparty:1", "cx.core.industrycore:1"), null);
+        var result = function.validate(Operator.EQ, "cx.warranty.none:1", null);
         assertThat(result.succeeded()).isTrue();
     }
 
     @Test
     void validate_whenInvalidOperator_thenFailure() {
-        var result = function.validate(Operator.EQ, List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), null);
+        var result = function.validate(Operator.IS_ANY_OF, "cx.warranty.none:1", null);
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureDetail()).contains("Invalid operator");
     }
 
     @Test
     void validate_whenInvalidValue_thenFailure() {
-        var result = function.validate(Operator.IS_ALL_OF, List.of("BPNL00000000001A"), null);
+        var result = function.validate(Operator.EQ, "invalid", null);
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureDetail()).contains("Invalid right-operand: ");
     }

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/warrenty/WarrantyDefinitionConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/warrenty/WarrantyDefinitionConstraintFunctionTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-package org.eclipse.tractusx.edc.policy.cx.usage;
+package org.eclipse.tractusx.edc.policy.cx.warrenty;
 
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
@@ -25,38 +25,36 @@ import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-class UsagePurposeConstraintFunctionTest {
+class WarrantyDefinitionConstraintFunctionTest {
 
     private final ParticipantAgent participantAgent = mock();
-    private final UsagePurposeConstraintFunction<ParticipantAgentPolicyContext> function = new UsagePurposeConstraintFunction<>();
+    private final WarrantyDefinitionConstraintFunction<ParticipantAgentPolicyContext> function = new WarrantyDefinitionConstraintFunction<>();
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
 
     @Test
     void evaluate() {
-        assertThat(function.evaluate(Operator.IS_ALL_OF, List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), null, context)).isTrue();
+        assertThat(function.evaluate(Operator.EQ,  "cx.warranty.contractEndDate:1", null, context)).isTrue();
     }
 
     @Test
     void validate_whenOperatorAndRightOperandAreValid_thenSuccess() {
-        var result = function.validate(Operator.IS_ALL_OF, List.of("cx.core.legalrequirementforthirdparty:1", "cx.core.industrycore:1"), null);
+        var result = function.validate(Operator.EQ,  "cx.warranty.contractEndDate:1", null);
         assertThat(result.succeeded()).isTrue();
     }
 
     @Test
     void validate_whenInvalidOperator_thenFailure() {
-        var result = function.validate(Operator.EQ, List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), null);
+        var result = function.validate(Operator.IS_ANY_OF, "cx.warranty.contractEndDate:1", null);
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureDetail()).contains("Invalid operator");
     }
 
     @Test
     void validate_whenInvalidValue_thenFailure() {
-        var result = function.validate(Operator.IS_ALL_OF, List.of("BPNL00000000001A"), null);
+        var result = function.validate(Operator.EQ, "invalid", null);
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureDetail()).contains("Invalid right-operand: ");
     }

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/warrenty/WarrantyDurationMonthsConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/warrenty/WarrantyDurationMonthsConstraintFunctionTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-package org.eclipse.tractusx.edc.policy.cx.usage;
+package org.eclipse.tractusx.edc.policy.cx.warrenty;
 
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
@@ -25,38 +25,36 @@ import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-class UsagePurposeConstraintFunctionTest {
+class WarrantyDurationMonthsConstraintFunctionTest {
 
     private final ParticipantAgent participantAgent = mock();
-    private final UsagePurposeConstraintFunction<ParticipantAgentPolicyContext> function = new UsagePurposeConstraintFunction<>();
+    private final WarrantyDurationMonthsConstraintFunction<ParticipantAgentPolicyContext> function = new WarrantyDurationMonthsConstraintFunction<>();
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
 
     @Test
     void evaluate() {
-        assertThat(function.evaluate(Operator.IS_ALL_OF, List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), null, context)).isTrue();
+        assertThat(function.evaluate(Operator.EQ,  1, null, context)).isTrue();
     }
 
     @Test
     void validate_whenOperatorAndRightOperandAreValid_thenSuccess() {
-        var result = function.validate(Operator.IS_ALL_OF, List.of("cx.core.legalrequirementforthirdparty:1", "cx.core.industrycore:1"), null);
+        var result = function.validate(Operator.EQ,  1, null);
         assertThat(result.succeeded()).isTrue();
     }
 
     @Test
     void validate_whenInvalidOperator_thenFailure() {
-        var result = function.validate(Operator.EQ, List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), null);
+        var result = function.validate(Operator.IS_ANY_OF, 1, null);
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureDetail()).contains("Invalid operator");
     }
 
     @Test
     void validate_whenInvalidValue_thenFailure() {
-        var result = function.validate(Operator.IS_ALL_OF, List.of("BPNL00000000001A"), null);
+        var result = function.validate(Operator.EQ, "invalid", null);
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureDetail()).contains("Invalid right-operand: ");
     }

--- a/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
+++ b/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
@@ -107,9 +107,14 @@ public class PolicyDefinitionEndToEndTest {
                     Arguments.of(frameworkPolicy(namespace + "Dismantler.allowedBrands", Operator.EQ, List.of("Moskvich", "Lada")), "Dismantler allowedBrands (EQ, exact match)"),
                     Arguments.of(frameworkPolicy(namespace + "Dismantler.allowedBrands", Operator.IS_NONE_OF, List.of("Yugo", "Tatra")), "Dismantler allowedBrands (IS_NONE_OF, no intersect)"),
                     Arguments.of(frameworkPolicy(namespace + "Dismantler.allowedBrands", Operator.IN, List.of("Moskvich", "Tatra", "Yugo", "Lada")), "Dismantler allowedBrands (IN, fully contained)"),
-                    Arguments.of(frameworkPolicy(Map.of(namespace + "UsagePurpose", "cx.core.industrycore:1")), "Usage Purpose"),
                     Arguments.of(frameworkPolicy(Map.of(namespace + "ContractReference", "contractReference")), "Contract reference"),
-                    Arguments.of(frameworkPolicy(namespace + "AffiliatesRegion", Operator.IS_ANY_OF, List.of("cx.region.all:1", "cx.region.europe:1", "cx.region.northAmerica:1"), true), "Affiliates Region")
+                    Arguments.of(frameworkPolicy(namespace + "AffiliatesRegion", Operator.IS_ANY_OF, List.of("cx.region.all:1", "cx.region.europe:1", "cx.region.northAmerica:1"), true), "Affiliates Region"),
+                    Arguments.of(frameworkPolicy(namespace + "Precedence", Operator.EQ,  "cx.precedence.contractreference:1"), "Precedence"),
+                    Arguments.of(frameworkPolicy(namespace + "UsagePurpose", Operator.IS_ALL_OF,  List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), true), "Usage Purpose"),
+                    Arguments.of(frameworkPolicy(namespace + "VersionChanges", Operator.EQ,  "cx.versionchanges.minor:1"), "Version Changes"),
+                    Arguments.of(frameworkPolicy(namespace + "Warranty", Operator.EQ,  "cx.warranty.none:1"), "Warranty"),
+                    Arguments.of(frameworkPolicy(namespace + "WarrantyDefinition", Operator.EQ,  "cx.warranty.contractenddate:1"), "Warranty Definition"),
+                    Arguments.of(frameworkPolicy(namespace + "WarrantyDurationMonths", Operator.EQ,  3), "Warranty Duration Months")
             );
         }
     }

--- a/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
+++ b/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
@@ -108,7 +108,8 @@ public class PolicyDefinitionEndToEndTest {
                     Arguments.of(frameworkPolicy(namespace + "Dismantler.allowedBrands", Operator.IS_NONE_OF, List.of("Yugo", "Tatra")), "Dismantler allowedBrands (IS_NONE_OF, no intersect)"),
                     Arguments.of(frameworkPolicy(namespace + "Dismantler.allowedBrands", Operator.IN, List.of("Moskvich", "Tatra", "Yugo", "Lada")), "Dismantler allowedBrands (IN, fully contained)"),
                     Arguments.of(frameworkPolicy(Map.of(namespace + "UsagePurpose", "cx.core.industrycore:1")), "Usage Purpose"),
-                    Arguments.of(frameworkPolicy(Map.of(namespace + "ContractReference", "contractReference")), "Contract reference")
+                    Arguments.of(frameworkPolicy(Map.of(namespace + "ContractReference", "contractReference")), "Contract reference"),
+                    Arguments.of(frameworkPolicy(namespace + "AffiliatesRegion", Operator.IS_ANY_OF, List.of("cx.region.all:1", "cx.region.europe:1", "cx.region.northAmerica:1"), true), "Affiliates Region")
             );
         }
     }


### PR DESCRIPTION
## WHAT

* add validation for the new data constraints which were introduced in the [cx-odrl-profile](https://github.com/catenax-eV/cx-odrl-profile/tree/main/schema/constraint)
* add validation for PrecedenceConstraintFunction
* add validation for ExcludingUsageConstraintFunction
* add validation for UsageRestrictionConstraintFunction
* add validation for VersionChangesConstraintFunction
* add validation for WarrantyConstraintFunction
* add validation for WarrantyDefinitionConstraintFunction
* add validation for WarrantyDurationMonthsConstraintFunction
* adjust validation for UsagePurposeConstraintFunction

## WHY

To ensure that policies are valid

## FURTHER NOTES

* tests are added to validate that the changes work correctly
* manual testing has been done

This PR is based on #2086 and should best be reviewed after the base PR is merged

## Issue

Refs: #2083