### PR TITLE
feat(constraint): add validation for framework constraint

### DIFF
--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/framework/FrameworkAgreementCredentialConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/framework/FrameworkAgreementCredentialConstraintFunction.java
@@ -113,7 +113,6 @@ public class FrameworkAgreementCredentialConstraintFunction<C extends Participan
             return false;
         }
         return true;
-
     }
 
     /**
@@ -122,6 +121,18 @@ public class FrameworkAgreementCredentialConstraintFunction<C extends Participan
     @Override
     public boolean canHandle(Object leftValue) {
         return leftValue instanceof String && leftValue.toString().startsWith(CX_POLICY_NS + FRAMEWORK_AGREEMENT_LITERAL);
+    }
+
+    @Override
+    public Result<Void> validate(Object leftOperand, Operator operator, Object rightValue, Permission rule) {
+        if (!Operator.EQ.equals(operator)) {
+            return Result.failure("Invalid operator: this constraint only allows the following operators: %s, but received '%s'.".formatted(Operator.EQ, operator));
+        }
+
+        return rightValue instanceof String s && s.equals("DataExchangeGovernance:2.0") ?
+                Result.success() :
+                Result.failure("Invalid right-operand: allowed values are '%s'."
+                        .formatted("DataExchangeGovernance:2.0"));
     }
 
     @NotNull
@@ -181,5 +192,4 @@ public class FrameworkAgreementCredentialConstraintFunction<C extends Participan
     private String capitalize(@NotNull String input) {
         return input.substring(0, 1).toUpperCase() + input.substring(1);
     }
-
 }

--- a/edc-tests/e2e/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/AbstractIatpConsumerPullTest.java
+++ b/edc-tests/e2e/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/AbstractIatpConsumerPullTest.java
@@ -293,9 +293,7 @@ public abstract class AbstractIatpConsumerPullTest extends ConsumerPullBaseTest 
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return Stream.of(
                     Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "Membership", "active")), "MembershipCredential"),
-                    Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "FrameworkAgreement.pcf", "active")), "PCF Use Case (legacy notation)"),
-                    Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "FrameworkAgreement", "Pcf")), "PCF Use Case (new notation)"),
-                    Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "FrameworkAgreement", "DataExchangeGovernance:1.0.0")), "DataExchangeGovernance use case"),
+                    Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "FrameworkAgreement", "DataExchangeGovernance:2.0")), "DataExchangeGovernance use case"),
                     Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "Dismantler", "active")), "Dismantler Credential"),
                     Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "Dismantler.activityType", "vehicleDismantle")), "Dismantler Cred (activity type)"),
                     Arguments.of(frameworkPolicy(CX_POLICY_NS + "Dismantler.allowedBrands", Operator.IS_ANY_OF, List.of("Moskvich", "Tatra")), "Dismantler allowedBrands (IS_ANY_OF, one intersects)"),
@@ -310,8 +308,6 @@ public abstract class AbstractIatpConsumerPullTest extends ConsumerPullBaseTest 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return Stream.of(
-                    Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "FrameworkAgreement.sustainability", "active")), "Sustainability Use Case (legacy notation)"),
-                    Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "FrameworkAgreement", "traceability")), "Traceability Use Case (new notation)"),
                     Arguments.of(frameworkPolicy(Map.of(CX_POLICY_NS + "Dismantler.activityType", "vehicleScrap")), "Dismantler activityType does not match"),
                     Arguments.of(frameworkPolicy(CX_POLICY_NS + "Dismantler.allowedBrands", Operator.NEQ, List.of("Moskvich", "Lada")), "Dismantler allowedBrands (NEQ, but is equal)"),
                     Arguments.of(frameworkPolicy(CX_POLICY_NS + "Dismantler.allowedBrands", Operator.IS_NONE_OF, List.of("Yugo", "Lada")), "Dismantler allowedBrands (IS_NONE_OF, but is one contains)"),

--- a/edc-tests/e2e/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/iatp/harness/DataspaceIssuer.java
+++ b/edc-tests/e2e/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/iatp/harness/DataspaceIssuer.java
@@ -112,7 +112,7 @@ public class DataspaceIssuer extends IdentityParticipant {
         var subject = Json.createObjectBuilder()
                 .add("type", credentialType)
                 .add("holderIdentifier", bpn)
-                .add("contractVersion", "1.0.0")
+                .add("contractVersion", "2.0")
                 .add("contractTemplate", "https://public.catena-x.org/contracts/traceabilty.v1.pdf")
                 .add("id", did)
                 .build();

--- a/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
+++ b/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
@@ -98,9 +98,7 @@ public class PolicyDefinitionEndToEndTest {
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return Stream.of(
                     Arguments.of(frameworkPolicy(Map.of(namespace + "Membership", "active")), "MembershipCredential"),
-                    Arguments.of(frameworkPolicy(Map.of(namespace + "FrameworkAgreement.pcf", "active")), "PCF Use Case (legacy notation)"),
-                    Arguments.of(frameworkPolicy(Map.of(namespace + "FrameworkAgreement", "Pcf")), "PCF Use Case (new notation)"),
-                    Arguments.of(frameworkPolicy(Map.of(namespace + "FrameworkAgreement", "DataExchangeGovernance:1.0.0")), "DataExchangeGovernance use case"),
+                    Arguments.of(frameworkPolicy(Map.of(namespace + "FrameworkAgreement", "DataExchangeGovernance:2.0")), "DataExchangeGovernance use case"),
                     Arguments.of(frameworkPolicy(Map.of(namespace + "Dismantler", "active")), "Dismantler Credential"),
                     Arguments.of(frameworkPolicy(Map.of(namespace + "Dismantler.activityType", "vehicleDismantle")), "Dismantler Cred (activity type)"),
                     Arguments.of(frameworkPolicy(namespace + "Dismantler.allowedBrands", Operator.IS_ANY_OF, List.of("Moskvich", "Tatra")), "Dismantler allowedBrands (IS_ANY_OF, one intersects)"),


### PR DESCRIPTION
## WHAT

* add validation for the new data constraints which were introduced in the [cx-odrl-profile](https://github.com/catenax-eV/cx-odrl-profile/tree/main/schema/constraint)
* add validation for the framework constraint

## WHY

To ensure that policies are valid

## FURTHER NOTES

* tests are added to validate that the changes work correctly

## Issues

Refs: #2083
