### PR TITLE
feat: update namespace for BPN to CX-namespace

### DIFF
--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/BaseBusinessPartnerGroupApiController.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/BaseBusinessPartnerGroupApiController.java
@@ -35,7 +35,7 @@ import java.util.List;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
-import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
 
 
 public abstract class BaseBusinessPartnerGroupApiController {
@@ -52,7 +52,7 @@ public abstract class BaseBusinessPartnerGroupApiController {
         return businessPartnerService.resolveForBpn(bpn)
                 .map(result -> Json.createObjectBuilder()
                         .add(ID, bpn)
-                        .add(TX_NAMESPACE + "groups", Json.createArrayBuilder(result))
+                        .add(CX_POLICY_NS + "groups", Json.createArrayBuilder(result))
                         .build())
                 .orElseThrow(failure -> new ObjectNotFoundException(List.class, failure.getFailureDetail()));
     }
@@ -96,7 +96,7 @@ public abstract class BaseBusinessPartnerGroupApiController {
     @NotNull
     private List<String> getGroups(JsonObject object) {
         try {
-            return object.getJsonArray(TX_NAMESPACE + "groups")
+            return object.getJsonArray(CX_POLICY_NS + "groups")
                     .stream()
                     .map(jv -> ((JsonString) jv.asJsonObject().get(VALUE)).getString())
                     .toList();

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3Controller.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/main/java/org/eclipse/tractusx/edc/api/bpn/v3/BusinessPartnerGroupApiV3Controller.java
@@ -39,7 +39,7 @@ import org.eclipse.tractusx.edc.validation.businesspartner.spi.store.BusinessPar
 import java.util.List;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
-import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
 
 
 @Consumes({ MediaType.APPLICATION_JSON })
@@ -65,7 +65,7 @@ public class BusinessPartnerGroupApiV3Controller extends BaseBusinessPartnerGrou
         return businessPartnerService.resolveForBpnGroup(group)
                 .map(result -> Json.createObjectBuilder()
                         .add(ID, group)
-                        .add(TX_NAMESPACE + "bpns", Json.createArrayBuilder(result))
+                        .add(CX_POLICY_NS + "bpns", Json.createArrayBuilder(result))
                         .build())
                 .orElseThrow(failure -> new ObjectNotFoundException(List.class, failure.getFailureDetail()));
     }
@@ -76,7 +76,7 @@ public class BusinessPartnerGroupApiV3Controller extends BaseBusinessPartnerGrou
     public JsonObject resolveGroupsV3() {
         return businessPartnerService.resolveForBpnGroups()
                 .map(result -> Json.createObjectBuilder()
-                        .add(TX_NAMESPACE + "groups", Json.createArrayBuilder(result))
+                        .add(CX_POLICY_NS + "groups", Json.createArrayBuilder(result))
                         .build())
                 .orElseThrow(failure -> new ObjectNotFoundException(List.class, failure.getFailureDetail()));
     }

--- a/edc-extensions/bpn-validation/bpn-validation-api/src/test/java/org/eclipse/tractusx/edc/api/bpn/BaseBusinessPartnerGroupApiControllerTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-api/src/test/java/org/eclipse/tractusx/edc/api/bpn/BaseBusinessPartnerGroupApiControllerTest.java
@@ -36,8 +36,8 @@ import static io.restassured.http.ContentType.JSON;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
-import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
-import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_PREFIX;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_PREFIX;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -52,7 +52,7 @@ public abstract class BaseBusinessPartnerGroupApiControllerTest extends RestCont
     @BeforeEach
     void setUp() {
         jsonLdService.registerNamespace("edc", EDC_NAMESPACE);
-        jsonLdService.registerNamespace("tx", TX_NAMESPACE);
+        jsonLdService.registerNamespace(CX_POLICY_PREFIX, CX_POLICY_NS);
     }
 
     @Test
@@ -171,8 +171,8 @@ public abstract class BaseBusinessPartnerGroupApiControllerTest extends RestCont
     private JsonObject createJsonObject() {
         return jsonLdService.expand(Json.createObjectBuilder()
                 .add(ID, "test-bpn")
-                .add(CONTEXT, Json.createObjectBuilder().add(TX_PREFIX, TX_NAMESPACE).build())
-                .add(TX_NAMESPACE + "groups", String.join(",", "group1", "group2", "group3"))
+                .add(CONTEXT, Json.createObjectBuilder().add(CX_POLICY_PREFIX, CX_POLICY_NS).build())
+                .add(CX_POLICY_NS + "groups", String.join(",", "group1", "group2", "group3"))
                 .build()).orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
     }
 

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/BusinessPartnerNumberValidationExtension.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/BusinessPartnerNumberValidationExtension.java
@@ -37,7 +37,7 @@ import static org.eclipse.edc.connector.controlplane.catalog.spi.policy.CatalogP
 import static org.eclipse.edc.connector.controlplane.contract.spi.policy.ContractNegotiationPolicyContext.NEGOTIATION_SCOPE;
 import static org.eclipse.edc.connector.controlplane.contract.spi.policy.TransferProcessPolicyContext.TRANSFER_SCOPE;
 import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
-import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
 import static org.eclipse.tractusx.edc.validation.businesspartner.BusinessPartnerNumberValidationExtension.NAME;
 
 /**
@@ -61,7 +61,7 @@ public class BusinessPartnerNumberValidationExtension implements ServiceExtensio
      * </pre>
      */
     public static final String BUSINESS_PARTNER_CONSTRAINT_KEY = "BusinessPartnerNumber";
-    public static final String TX_BUSINESS_PARTNER_CONSTRAINT_KEY = TX_NAMESPACE + BUSINESS_PARTNER_CONSTRAINT_KEY;
+    public static final String CX_BUSINESS_PARTNER_CONSTRAINT_KEY = CX_POLICY_NS + BUSINESS_PARTNER_CONSTRAINT_KEY;
     protected static final String NAME = "Business Partner Validation Extension";
     @Inject
     private RuleBindingRegistry ruleBindingRegistry;
@@ -85,10 +85,10 @@ public class BusinessPartnerNumberValidationExtension implements ServiceExtensio
         ruleBindingRegistry.bind("USE", scope);
         ruleBindingRegistry.bind(ODRL_SCHEMA + "use", scope);
         ruleBindingRegistry.bind(BUSINESS_PARTNER_CONSTRAINT_KEY, scope);
-        ruleBindingRegistry.bind(TX_BUSINESS_PARTNER_CONSTRAINT_KEY, scope);
+        ruleBindingRegistry.bind(CX_BUSINESS_PARTNER_CONSTRAINT_KEY, scope);
 
         policyEngine.registerFunction(contextType, Permission.class, BUSINESS_PARTNER_CONSTRAINT_KEY, function);
-        policyEngine.registerFunction(contextType, Permission.class, TX_BUSINESS_PARTNER_CONSTRAINT_KEY, function);
+        policyEngine.registerFunction(contextType, Permission.class, CX_BUSINESS_PARTNER_CONSTRAINT_KEY, function);
     }
 
 }

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunction.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerGroupFunction.java
@@ -44,7 +44,7 @@ import static org.eclipse.edc.policy.model.Operator.IS_ALL_OF;
 import static org.eclipse.edc.policy.model.Operator.IS_ANY_OF;
 import static org.eclipse.edc.policy.model.Operator.IS_NONE_OF;
 import static org.eclipse.edc.policy.model.Operator.NEQ;
-import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
 
 /**
  * This function evaluates, that a particular {@link ParticipantAgent} is a member of a particular group.
@@ -79,7 +79,7 @@ import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
  * @see BusinessPartnerStore
  */
 public class BusinessPartnerGroupFunction<C extends ParticipantAgentPolicyContext> implements AtomicConstraintRuleFunction<Permission, C> {
-    public static final String BUSINESS_PARTNER_CONSTRAINT_KEY = TX_NAMESPACE + "BusinessPartnerGroup";
+    public static final String BUSINESS_PARTNER_CONSTRAINT_KEY = CX_POLICY_NS + "BusinessPartnerGroup";
     private static final List<Operator> ALLOWED_OPERATORS = List.of(EQ, NEQ, IN, IS_ALL_OF, IS_ANY_OF, IS_NONE_OF);
     private static final Map<Operator, Function<BpnGroupHolder, Boolean>> OPERATOR_EVALUATOR_MAP = new HashMap<>();
     private final BusinessPartnerStore store;

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/BusinessPartnerNumberValidationExtensionTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/BusinessPartnerNumberValidationExtensionTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.eclipse.tractusx.edc.validation.businesspartner.BusinessPartnerNumberValidationExtension.BUSINESS_PARTNER_CONSTRAINT_KEY;
-import static org.eclipse.tractusx.edc.validation.businesspartner.BusinessPartnerNumberValidationExtension.TX_BUSINESS_PARTNER_CONSTRAINT_KEY;
+import static org.eclipse.tractusx.edc.validation.businesspartner.BusinessPartnerNumberValidationExtension.CX_BUSINESS_PARTNER_CONSTRAINT_KEY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -64,7 +64,7 @@ class BusinessPartnerNumberValidationExtensionTest {
                 .registerFunction(
                         isA(Class.class),
                         eq(Permission.class),
-                        eq(TX_BUSINESS_PARTNER_CONSTRAINT_KEY),
+                        eq(CX_BUSINESS_PARTNER_CONSTRAINT_KEY),
                         any());
 
         verify(ruleBindingRegistry, times(3))
@@ -72,7 +72,7 @@ class BusinessPartnerNumberValidationExtensionTest {
                         anyString());
 
         verify(ruleBindingRegistry, times(3))
-                .bind(eq(TX_BUSINESS_PARTNER_CONSTRAINT_KEY),
+                .bind(eq(CX_BUSINESS_PARTNER_CONSTRAINT_KEY),
                         anyString());
     }
 

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/helpers/PolicyHelperFunctions.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/helpers/PolicyHelperFunctions.java
@@ -47,13 +47,13 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 
 public class PolicyHelperFunctions {
 
-    public static final String TX_NAMESPACE = "https://w3id.org/tractusx/v0.0.1/ns/";
+    public static final String CX_POLICY_NS = "https://w3id.org/catenax/policy/";
     private static final String ODRL_JSONLD = "http://www.w3.org/ns/odrl.jsonld";
     private static final String BUSINESS_PARTNER_EVALUATION_KEY = "BusinessPartnerNumber";
 
-    public static final String BUSINESS_PARTNER_LEGACY_EVALUATION_KEY = TX_NAMESPACE + BUSINESS_PARTNER_EVALUATION_KEY;
+    public static final String BUSINESS_PARTNER_LEGACY_EVALUATION_KEY = CX_POLICY_NS + BUSINESS_PARTNER_EVALUATION_KEY;
 
-    private static final String BUSINESS_PARTNER_CONSTRAINT_KEY = TX_NAMESPACE + "BusinessPartnerGroup";
+    private static final String BUSINESS_PARTNER_CONSTRAINT_KEY = CX_POLICY_NS + "BusinessPartnerGroup";
 
     private static final ObjectMapper MAPPER = JacksonJsonLd.createObjectMapper();
 
@@ -166,7 +166,7 @@ public class PolicyHelperFunctions {
     private static JsonObject permission(String... bpns) {
 
         var bpnConstraints = Stream.of(bpns)
-                .map(bpn -> atomicConstraint(TX_NAMESPACE + BUSINESS_PARTNER_EVALUATION_KEY, "eq", bpn, false))
+                .map(bpn -> atomicConstraint(CX_POLICY_NS + BUSINESS_PARTNER_EVALUATION_KEY, "eq", bpn, false))
                 .collect(Json::createArrayBuilder, JsonArrayBuilder::add, JsonArrayBuilder::add);
 
         return Json.createObjectBuilder()

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java
@@ -55,7 +55,7 @@ import static org.eclipse.edc.util.io.Ports.getFreePort;
 import static org.eclipse.tractusx.edc.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_AGREEMENT_ID;
 import static org.eclipse.tractusx.edc.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_REASON;
 import static org.eclipse.tractusx.edc.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_TYPE;
-import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
 
 
 /**
@@ -158,7 +158,7 @@ public abstract class TractusxParticipantBase extends IdentityParticipant {
     public void storeBusinessPartner(String bpn, String... groups) {
         var body = createObjectBuilder()
                 .add(ID, bpn)
-                .add(TX_NAMESPACE + "groups", Json.createArrayBuilder(Arrays.asList(groups)))
+                .add(CX_POLICY_NS + "groups", Json.createArrayBuilder(Arrays.asList(groups)))
                 .build();
         baseManagementRequest()
                 .contentType(JSON)
@@ -175,7 +175,7 @@ public abstract class TractusxParticipantBase extends IdentityParticipant {
     public void updateBusinessPartner(String bpn, String... groups) {
         var body = createObjectBuilder()
                 .add(ID, bpn)
-                .add(TX_NAMESPACE + "groups", Json.createArrayBuilder(Arrays.asList(groups)))
+                .add(CX_POLICY_NS + "groups", Json.createArrayBuilder(Arrays.asList(groups)))
                 .build();
         baseManagementRequest()
                 .contentType(JSON)


### PR DESCRIPTION
## WHAT

The BPN policy constraints (`BusinessPartnerNumber`, `BusinessPartnerGroup`) previously used the `TX_NAMESPACE = "https://w3id.org/tractusx/v0.0.1/ns/"`. Since these constraints are now part of the new policy schema defined under the CX_POLICY_NAMESPACE, their namespace has been updated accordingly to use the cx namespace.

## WHY

The updated policy standard mandates the use of the cx namespace for all constraint definitions. Therefore, the change ensures compliance with the new specification.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Related to #2083
