### PR TITLE
Deprecate the Mock Connector Runtime

### DIFF
--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/MatchType.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/MatchType.java
@@ -26,6 +26,8 @@ package org.eclipse.tractusx.edc.mock;
  *     <li>PARTIAL: only the specified properties must match, disregarding others</li>
  *     <li>PARTIAL: all properties must match, those that are not listed are expected to be null</li>
  * </ul>
+ *
+ *  @deprecated since 0.11.0
  */
 @Deprecated(since = "0.11.0")
 public enum MatchType {

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/MatchType.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/MatchType.java
@@ -27,6 +27,7 @@ package org.eclipse.tractusx.edc.mock;
  *     <li>PARTIAL: all properties must match, those that are not listed are expected to be null</li>
  * </ul>
  */
+@Deprecated(since = "0.11.0")
 public enum MatchType {
     CLASS, PARTIAL, EXACT
 }

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/MockServiceExtension.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/MockServiceExtension.java
@@ -51,6 +51,7 @@ import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+@Deprecated(since = "0.11.0")
 public class MockServiceExtension implements ServiceExtension {
     private final Queue<RecordedRequest<?, ?>> recordedRequests = new ConcurrentLinkedQueue<>();
     @Inject

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/MockServiceExtension.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/MockServiceExtension.java
@@ -51,6 +51,11 @@ import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+/**
+ * Extension for the mock connector
+ *
+ * @deprecated since 0.11.0
+ */
 @Deprecated(since = "0.11.0")
 public class MockServiceExtension implements ServiceExtension {
     private final Queue<RecordedRequest<?, ?>> recordedRequests = new ConcurrentLinkedQueue<>();

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/RecordedRequest.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/RecordedRequest.java
@@ -27,6 +27,8 @@ import org.eclipse.edc.spi.result.ServiceFailure;
  * like name and description and a {@link MatchType}.
  * In addition, it can have a {@link ServiceFailure}, in which case the {@code output} object is disregarded and the failure is always returned.
  * This can be used to mock a failed API call.
+ *
+ * @deprecated since 0.11.0
  */
 @Deprecated(since = "0.11.0")
 @JsonDeserialize(using = RecordedResponseDeserializer.class)

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/RecordedRequest.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/RecordedRequest.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.spi.result.ServiceFailure;
  * In addition, it can have a {@link ServiceFailure}, in which case the {@code output} object is disregarded and the failure is always returned.
  * This can be used to mock a failed API call.
  */
+@Deprecated(since = "0.11.0")
 @JsonDeserialize(using = RecordedResponseDeserializer.class)
 public final class RecordedRequest<I, O> {
     private final I input;

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/RecordedResponseDeserializer.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/RecordedResponseDeserializer.java
@@ -31,6 +31,8 @@ import java.util.Optional;
 /**
  * Custom deserializer for a {@link RecordedRequest} object, to be able to instantiate the input and output objects according
  * to their class description.
+ *
+ * @deprecated since 0.11.0
  */
 @Deprecated(since = "0.11.0")
 class RecordedResponseDeserializer extends StdDeserializer<RecordedRequest<?, ?>> {

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/RecordedResponseDeserializer.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/RecordedResponseDeserializer.java
@@ -32,6 +32,7 @@ import java.util.Optional;
  * Custom deserializer for a {@link RecordedRequest} object, to be able to instantiate the input and output objects according
  * to their class description.
  */
+@Deprecated(since = "0.11.0")
 class RecordedResponseDeserializer extends StdDeserializer<RecordedRequest<?, ?>> {
 
     public static final String INPUT_OBJECT = "input";

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/ResponseQueue.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/ResponseQueue.java
@@ -33,6 +33,8 @@ import java.util.Queue;
 
 /**
  * Container object that maintains the queue of {@link RecordedRequest} objects and grants high-level access to it.
+ *
+ * @deprecated since 0.11.0
  */
 @Deprecated(since = "0.11.0")
 public class ResponseQueue {

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/ResponseQueue.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/ResponseQueue.java
@@ -34,6 +34,7 @@ import java.util.Queue;
 /**
  * Container object that maintains the queue of {@link RecordedRequest} objects and grants high-level access to it.
  */
+@Deprecated(since = "0.11.0")
 public class ResponseQueue {
     private final Queue<RecordedRequest<?, ?>> recordedRequests; // todo guard access with locks?
     private final Monitor monitor;

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/ServiceFailureDeserializer.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/ServiceFailureDeserializer.java
@@ -31,6 +31,8 @@ import java.util.Arrays;
 /**
  * Custom deserializer for {@link ServiceFailure}. We need this because there is no default
  * CTor, and the public constructor with args is not annotated with {@link com.fasterxml.jackson.annotation.JsonProperty}.
+ *
+ * @deprecated since 0.11.0
  */
 @Deprecated(since = "0.11.0")
 public class ServiceFailureDeserializer extends StdDeserializer<ServiceFailure> {

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/ServiceFailureDeserializer.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/ServiceFailureDeserializer.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
  * Custom deserializer for {@link ServiceFailure}. We need this because there is no default
  * CTor, and the public constructor with args is not annotated with {@link com.fasterxml.jackson.annotation.JsonProperty}.
  */
+@Deprecated(since = "0.11.0")
 public class ServiceFailureDeserializer extends StdDeserializer<ServiceFailure> {
     public static final String REASON_FIELD = "reason";
     public static final String MESSAGES_FIELD = "messages";

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/api/instrumentation/InstrumentationApi.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/api/instrumentation/InstrumentationApi.java
@@ -32,6 +32,11 @@ import org.eclipse.tractusx.edc.mock.RecordedRequest;
 
 import java.util.List;
 
+/**
+ * Instrumentation API for the mock connector.
+ *
+ * @deprecated since 0.11.0
+ */
 @Deprecated(since = "0.11.0")
 @OpenAPIDefinition(info = @Info(description = "This API allows to insert ", title = "Business Partner Group API"))
 @Tag(name = "Business Partner Group")

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/api/instrumentation/InstrumentationApi.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/api/instrumentation/InstrumentationApi.java
@@ -32,6 +32,7 @@ import org.eclipse.tractusx.edc.mock.RecordedRequest;
 
 import java.util.List;
 
+@Deprecated(since = "0.11.0")
 @OpenAPIDefinition(info = @Info(description = "This API allows to insert ", title = "Business Partner Group API"))
 @Tag(name = "Business Partner Group")
 public interface InstrumentationApi {

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/api/instrumentation/InstrumentationApiController.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/api/instrumentation/InstrumentationApiController.java
@@ -32,6 +32,11 @@ import org.eclipse.tractusx.edc.mock.ResponseQueue;
 
 import java.util.List;
 
+/**
+ * Instrumentation controller for the mock connector.
+ *
+ * @deprecated since 0.11.0
+ */
 @Deprecated(since = "0.11.0")
 @Consumes({ MediaType.APPLICATION_JSON })
 @Produces({ MediaType.APPLICATION_JSON })

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/api/instrumentation/InstrumentationApiController.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/api/instrumentation/InstrumentationApiController.java
@@ -32,6 +32,7 @@ import org.eclipse.tractusx.edc.mock.ResponseQueue;
 
 import java.util.List;
 
+@Deprecated(since = "0.11.0")
 @Consumes({ MediaType.APPLICATION_JSON })
 @Produces({ MediaType.APPLICATION_JSON })
 @Path("/instrumentation")

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/AbstractServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/AbstractServiceStub.java
@@ -21,6 +21,11 @@ package org.eclipse.tractusx.edc.mock.services;
 
 import org.eclipse.tractusx.edc.mock.ResponseQueue;
 
+/**
+ * For abstract service stubs.
+ *
+ * @deprecated since 0.11.0
+ */
 @Deprecated(since = "0.11.0")
 public abstract class AbstractServiceStub {
     protected final ResponseQueue responseQueue;

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/AbstractServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/AbstractServiceStub.java
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.edc.mock.services;
 
 import org.eclipse.tractusx.edc.mock.ResponseQueue;
 
+@Deprecated(since = "0.11.0")
 public abstract class AbstractServiceStub {
     protected final ResponseQueue responseQueue;
 

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/AssetServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/AssetServiceStub.java
@@ -28,6 +28,7 @@ import org.eclipse.tractusx.edc.mock.ResponseQueue;
 
 import java.util.List;
 
+@Deprecated(since = "0.11.0")
 public class AssetServiceStub implements AssetService {
 
     private final ResponseQueue responseQueue;

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/AssetServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/AssetServiceStub.java
@@ -28,6 +28,11 @@ import org.eclipse.tractusx.edc.mock.ResponseQueue;
 
 import java.util.List;
 
+/**
+ * Stub implementation of the {@link AssetService} for testing purposes.
+ *
+ * @deprecated since 0.11.0
+ */
 @Deprecated(since = "0.11.0")
 public class AssetServiceStub implements AssetService {
 

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/ContractAgreementServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/ContractAgreementServiceStub.java
@@ -29,6 +29,7 @@ import org.eclipse.tractusx.edc.mock.ResponseQueue;
 
 import java.util.List;
 
+@Deprecated(since = "0.11.0")
 public class ContractAgreementServiceStub extends AbstractServiceStub implements ContractAgreementService {
 
     public ContractAgreementServiceStub(ResponseQueue responseQueue) {

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/ContractAgreementServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/ContractAgreementServiceStub.java
@@ -29,6 +29,11 @@ import org.eclipse.tractusx.edc.mock.ResponseQueue;
 
 import java.util.List;
 
+/**
+ * Stub implementation of the {@link ContractAgreementService} for testing purposes.
+ *
+ * @deprecated since 0.11.0
+ */
 @Deprecated(since = "0.11.0")
 public class ContractAgreementServiceStub extends AbstractServiceStub implements ContractAgreementService {
 

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/ContractDefinitionServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/ContractDefinitionServiceStub.java
@@ -28,6 +28,7 @@ import org.eclipse.tractusx.edc.mock.ResponseQueue;
 
 import java.util.List;
 
+@Deprecated(since = "0.11.0")
 public class ContractDefinitionServiceStub extends AbstractServiceStub implements ContractDefinitionService {
 
 

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/ContractDefinitionServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/ContractDefinitionServiceStub.java
@@ -28,6 +28,11 @@ import org.eclipse.tractusx.edc.mock.ResponseQueue;
 
 import java.util.List;
 
+/**
+ * Stub implementation of the {@link ContractDefinitionService}.
+ *
+ * @deprecated since 0.11.0
+ */
 @Deprecated(since = "0.11.0")
 public class ContractDefinitionServiceStub extends AbstractServiceStub implements ContractDefinitionService {
 

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/ContractNegotiationServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/ContractNegotiationServiceStub.java
@@ -31,6 +31,11 @@ import org.eclipse.tractusx.edc.mock.ResponseQueue;
 
 import java.util.List;
 
+/**
+ * Stub implementation of the {@link ContractNegotiationService} for testing purposes.
+ *
+ * @deprecated since 0.11.0
+ */
 @Deprecated(since = "0.11.0")
 public class ContractNegotiationServiceStub extends AbstractServiceStub implements ContractNegotiationService {
     public ContractNegotiationServiceStub(ResponseQueue responseQueue) {

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/ContractNegotiationServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/ContractNegotiationServiceStub.java
@@ -31,6 +31,7 @@ import org.eclipse.tractusx.edc.mock.ResponseQueue;
 
 import java.util.List;
 
+@Deprecated(since = "0.11.0")
 public class ContractNegotiationServiceStub extends AbstractServiceStub implements ContractNegotiationService {
     public ContractNegotiationServiceStub(ResponseQueue responseQueue) {
         super(responseQueue);

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/PolicyDefinitionServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/PolicyDefinitionServiceStub.java
@@ -31,6 +31,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
+/**
+ * Stub implementation of the PolicyDefinitionService.
+ *
+ * @deprecated since 0.11.0
+ */
 @Deprecated(since = "0.11.0")
 public class PolicyDefinitionServiceStub extends AbstractServiceStub implements PolicyDefinitionService {
 

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/PolicyDefinitionServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/PolicyDefinitionServiceStub.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
+@Deprecated(since = "0.11.0")
 public class PolicyDefinitionServiceStub extends AbstractServiceStub implements PolicyDefinitionService {
 
     public PolicyDefinitionServiceStub(ResponseQueue responseQueue) {

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/TransferProcessServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/TransferProcessServiceStub.java
@@ -37,6 +37,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
+@Deprecated(since = "0.11.0")
 public class TransferProcessServiceStub extends AbstractServiceStub implements TransferProcessService {
 
     public TransferProcessServiceStub(ResponseQueue responseQueue) {

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/TransferProcessServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/TransferProcessServiceStub.java
@@ -37,6 +37,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
+/**
+ * Stub implementation of the {@link TransferProcessService} for testing purposes.
+ *
+ * @deprecated since 0.11.0
+ */
 @Deprecated(since = "0.11.0")
 public class TransferProcessServiceStub extends AbstractServiceStub implements TransferProcessService {
 

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/VersionServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/VersionServiceStub.java
@@ -30,6 +30,11 @@ import org.eclipse.tractusx.edc.mock.ResponseQueue;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Stub implementation of the VersionService.
+ *
+ * @deprecated since 0.11.0
+ */
 @Deprecated(since = "0.11.0")
 public class VersionServiceStub extends AbstractServiceStub implements VersionService {
 

--- a/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/VersionServiceStub.java
+++ b/edc-tests/runtime/mock-connector/src/main/java/org/eclipse/tractusx/edc/mock/services/VersionServiceStub.java
@@ -30,6 +30,7 @@ import org.eclipse.tractusx.edc.mock.ResponseQueue;
 
 import java.util.concurrent.CompletableFuture;
 
+@Deprecated(since = "0.11.0")
 public class VersionServiceStub extends AbstractServiceStub implements VersionService {
 
     private final ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
## WHAT

Deprecates the mock connector runtime since the v0.11.0.

## WHY

This runtime does not seem to be used by anyone and so the effort of maintaining it is unnecessary.

Added javadoc due checkstyle's failing.

Closes #1918 
