### PR TITLE
feat: Allow to create dated SNAPSHOT manually

### DIFF
--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -30,10 +30,16 @@ on:
     workflows: [ "Run-All-Tests" ]
     branches:
       - main
-      - bugfix/*
+      - release/*
     types:
       - completed
   workflow_dispatch:
+    inputs:
+      dated_snapshot:
+        description: 'Dated snapshot version.'
+        default: false
+        type: boolean
+        required: true
 
   # periodic build triggers are defined in run-all-tests.yml, which triggers this workflow
 
@@ -76,7 +82,7 @@ jobs:
           
           IFS=.- read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH SNAPSHOT<<<$(grep "version" gradle.properties | awk -F= '{print $2}')
           
-          if [[ ${{ github.event.workflow_run.event }} == "schedule" ]]; then
+          if [[ "${{ github.event.workflow_run.event }}" == "schedule" || "${{ inputs.dated_snapshot }}" == "true" ]]; then
             echo "VERSION=$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$RELEASE_VERSION_PATCH-$(date +"%Y%m%d")-SNAPSHOT" >> "$GITHUB_OUTPUT"
           else
             echo "VERSION=$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$RELEASE_VERSION_PATCH-SNAPSHOT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -37,9 +37,7 @@ on:
     inputs:
       dated_snapshot:
         description: 'Dated snapshot version.'
-        default: false
         type: boolean
-        required: true
 
   # periodic build triggers are defined in run-all-tests.yml, which triggers this workflow
 

--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -37,6 +37,7 @@ on:
     inputs:
       dated_snapshot:
         description: 'Dated snapshot version.'
+        default: false
         type: boolean
 
   # periodic build triggers are defined in run-all-tests.yml, which triggers this workflow


### PR DESCRIPTION
## WHAT

This PR makes it possible to run the "Publish new snapshot" workflow manually with identification of whether it is dated or not.

## WHY

To provide flexibility in producing daily SNAPSHOT builds outside of the weekly schedule.

## FURTHER NOTES
As we do not use the `bugfix/*` in the new [release process](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/docs/development/decision-records/2025-05-26-release-process), it will be changed to `release/*`

Closes #2130
