### PR TITLE
fix: add missing test packages to compatibility tests

### DIFF
--- a/edc-tests/dsp-compatibility-tests/compatibility-test-runner/build.gradle.kts
+++ b/edc-tests/dsp-compatibility-tests/compatibility-test-runner/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
     testImplementation(libs.dsp.tck.runtime)
     testImplementation(libs.dsp.tck.api)
     testImplementation(libs.dsp.tck.system)
+    testRuntimeOnly(libs.dsp.tck.metadata)
+    testRuntimeOnly(libs.dsp.tck.catalog)
     testRuntimeOnly(libs.dsp.tck.transferprocess)
     testRuntimeOnly(libs.dsp.tck.contractnegotiation)
     testImplementation(libs.junit.platform.launcher)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -142,6 +142,8 @@ dsp-tck-runtime = { module = "org.eclipse.dataspacetck.dsp:tck-runtime", version
 dsp-tck-core = { module = "org.eclipse.dataspacetck.dsp:core", version.ref = "dsp-tck" }
 dsp-tck-api = { module = "org.eclipse.dataspacetck.dsp:dsp-api", version.ref = "dsp-tck" }
 dsp-tck-system = { module = "org.eclipse.dataspacetck.dsp:dsp-system", version.ref = "dsp-tck" }
+dsp-tck-metadata = { module = "org.eclipse.dataspacetck.dsp:dsp-metadata", version.ref = "dsp-tck" }
+dsp-tck-catalog = { module = "org.eclipse.dataspacetck.dsp:dsp-catalog", version.ref = "dsp-tck" }
 dsp-tck-contractnegotiation = { module = "org.eclipse.dataspacetck.dsp:dsp-contract-negotiation", version.ref = "dsp-tck" }
 dsp-tck-transferprocess = { module = "org.eclipse.dataspacetck.dsp:dsp-transfer-process", version.ref = "dsp-tck" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }


### PR DESCRIPTION
## WHAT

adds missing tck packages to compatibility tests. 

## WHY

To verify metadata and catalog endpoints according to dsp 2025-1


Closes #2040 
