### PR TITLE
feat: cx namespace update

### DIFF
--- a/core/json-ld-core/src/main/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtension.java
+++ b/core/json-ld-core/src/main/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtension.java
@@ -52,7 +52,7 @@ public class JsonLdExtension implements ServiceExtension {
     public static final String SECURITY_JWS_V1 = "https://w3id.org/security/suites/jws-2020/v1";
     public static final String SECURITY_ED25519_V1 = "https://w3id.org/security/suites/ed25519-2020/v1";
 
-    public static final String CX_POLICY_CONTEXT = "https://w3id.org/tractusx/policy/v1.0.0";
+    public static final String CX_POLICY_CONTEXT = "https://w3id.org/catenax/2025/9/policy/";
     public static final String TX_AUTH_CONTEXT = "https://w3id.org/tractusx/auth/v1.0.0";
 
     private static final String PREFIX = "document" + File.separator;

--- a/core/json-ld-core/src/main/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtension.java
+++ b/core/json-ld-core/src/main/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtension.java
@@ -52,7 +52,7 @@ public class JsonLdExtension implements ServiceExtension {
     public static final String SECURITY_JWS_V1 = "https://w3id.org/security/suites/jws-2020/v1";
     public static final String SECURITY_ED25519_V1 = "https://w3id.org/security/suites/ed25519-2020/v1";
 
-    public static final String CX_POLICY_CONTEXT = "https://w3id.org/catenax/2025/9/policy/";
+    public static final String CX_POLICY_CONTEXT = "https://w3id.org/catenax/2025/9/policy/context.jsonld";
     public static final String TX_AUTH_CONTEXT = "https://w3id.org/tractusx/auth/v1.0.0";
 
     private static final String PREFIX = "document" + File.separator;

--- a/core/json-ld-core/src/main/resources/document/cx-policy-v1.jsonld
+++ b/core/json-ld-core/src/main/resources/document/cx-policy-v1.jsonld
@@ -16,10 +16,10 @@
       "@id": "cx-policy:AffiliatesRegion"
     },
     "BusinessPartnerGroup": {
-      "@id": "cx-policy:BusinessPartnerGroup"
+      "@id": "https://w3id.org/tractusx/v0.0.1/ns/BusinessPartnerGroup"
     },
     "BusinessPartnerNumber": {
-      "@id": "cx-policy:BusinessPartnerNumber"
+      "@id": "https://w3id.org/tractusx/v0.0.1/ns/BusinessPartnerNumber"
     },
     "ConfidentialInformationMeasures": {
       "@id": "cx-policy:ConfidentialInformationMeasures"

--- a/core/json-ld-core/src/main/resources/document/cx-policy-v1.jsonld
+++ b/core/json-ld-core/src/main/resources/document/cx-policy-v1.jsonld
@@ -4,7 +4,7 @@
     "@protected": true,
     "cred": "https://www.w3.org/2018/credentials#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
-    "cx-policy": "https://w3id.org/catenax/policy/",
+    "cx-policy": "https://w3id.org/catenax/2025/9/policy/",
     "Dismantler": "cx-policy:Dismantler",
     "Dismantler.activityType": "cx-policy:Dismantler.activityType",
     "Dismantler.allowedBrands": "cx-policy:Dismantler.allowedBrands",

--- a/core/json-ld-core/src/main/resources/document/cx-policy-v1.jsonld
+++ b/core/json-ld-core/src/main/resources/document/cx-policy-v1.jsonld
@@ -5,18 +5,93 @@
     "cred": "https://www.w3.org/2018/credentials#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "cx-policy": "https://w3id.org/catenax/2025/9/policy/",
-    "Dismantler": "cx-policy:Dismantler",
-    "Dismantler.activityType": "cx-policy:Dismantler.activityType",
-    "Dismantler.allowedBrands": "cx-policy:Dismantler.allowedBrands",
-    "Membership": "cx-policy:Membership",
-    "UsagePurpose": "cx-policy:UsagePurpose",
-    "ContractReference": "cx-policy:ContractReference",
-    "FrameworkAgreement": "cx-policy:FrameworkAgreement",
-    "FrameworkAgreement.behavioraltwin": "cx-policy:FrameworkAgreement.behavioraltwin",
-    "FrameworkAgreement.pcf": "cx-policy:FrameworkAgreement.pcf",
-    "FrameworkAgreement.quality": "cx-policy:FrameworkAgreement.quality",
-    "FrameworkAgreement.resiliency": "cx-policy:FrameworkAgreement.resiliency",
-    "FrameworkAgreement.sustainability": "cx-policy:FrameworkAgreement.sustainability",
-    "FrameworkAgreement.traceability": "cx-policy:FrameworkAgreement.traceability"
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "access": {
+      "@id": "cx-policy:access"
+    },
+    "AffiliatesBpnl": {
+      "@id": "cx-policy:AffiliatesBpnl"
+    },
+    "AffiliatesRegion": {
+      "@id": "cx-policy:AffiliatesRegion"
+    },
+    "BusinessPartnerGroup": {
+      "@id": "cx-policy:BusinessPartnerGroup"
+    },
+    "BusinessPartnerNumber": {
+      "@id": "cx-policy:BusinessPartnerNumber"
+    },
+    "ConfidentialInformationMeasures": {
+      "@id": "cx-policy:ConfidentialInformationMeasures"
+    },
+    "ConfidentialInformationSharing": {
+      "@id": "cx-policy:ConfidentialInformationSharing"
+    },
+    "ContractReference": {
+      "@id": "cx-policy:ContractReference"
+    },
+    "ContractTermination": {
+      "@id": "cx-policy:ContractTermination"
+    },
+    "DataFrequency": {
+      "@id": "cx-policy:DataFrequency"
+    },
+    "DataProvisioningEndDate": {
+      "@id": "cx-policy:DataProvisioningEndDate"
+    },
+    "DataProvisioningEndDurationDays": {
+      "@id": "cx-policy:DataProvisioningEndDurationDays"
+    },
+    "DataUsageEndDate": {
+      "@id": "cx-policy:DataUsageEndDate"
+    },
+    "DataUsageEndDurationDays": {
+      "@id": "cx-policy:DataUsageEndDurationDays"
+    },
+    "DataUsageEndDefinition": {
+      "@id": "cx-policy:DataUsageEndDefinition"
+    },
+    "ExclusiveUsage": {
+      "@id": "cx-policy:ExclusiveUsage"
+    },
+    "FrameworkAgreement": {
+      "@id": "cx-policy:FrameworkAgreement"
+    },
+    "JurisdictionLocation": {
+      "@id": "cx-policy:JurisdictionLocation"
+    },
+    "JurisdictionLocationReference": {
+      "@id": "cx-policy:JurisdictionLocationReference"
+    },
+    "Liability": {
+      "@id": "cx-policy:Liability"
+    },
+    "ManagedLegalEntityBpnl": {
+      "@id": "cx-policy:ManagedLegalEntityBpnl"
+    },
+    "ManagedLegalEntityRegion": {
+      "@id": "cx-policy:ManagedLegalEntityRegion"
+    },
+    "Membership": {
+      "@id": "cx-policy:Membership"
+    },
+    "Precedence": {
+      "@id": "cx-policy:Precedence"
+    },
+    "UsagePurpose": {
+      "@id": "cx-policy:UsagePurpose"
+    },
+    "UsageRestriction": {
+      "@id": "cx-policy:UsageRestriction"
+    },
+    "VersionChanges": {
+      "@id": "cx-policy:VersionChanges"
+    },
+    "Warranty": {
+      "@id": "cx-policy:Warranty"
+    },
+    "WarrantyDuration": {
+      "@id": "cx-policy:WarrantyDuration"
+    }
   }
 }

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/LogicalConstraintValidatorTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/LogicalConstraintValidatorTest.java
@@ -33,11 +33,12 @@ import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.tractusx.edc.policy.cx.validator.PolicyBuilderFixtures.atomicConstraint;
 import static org.eclipse.tractusx.edc.policy.cx.validator.PolicyBuilderFixtures.logicalConstraint;
 import static org.eclipse.tractusx.edc.policy.cx.validator.PolicyValidationConstants.ACTION_ACCESS;
+import static org.eclipse.tractusx.edc.policy.cx.validator.PolicyValidationConstants.FRAMEWORK_AGREEMENT_LITERAL;
 
 class LogicalConstraintValidatorTest {
 
     private final JsonLdPath path = JsonLdPath.path();
-    private final String validAccessPolicyLeftOperand = "https://w3id.org/catenax/policy/FrameworkAgreement";
+    private final String validAccessPolicyLeftOperand = FRAMEWORK_AGREEMENT_LITERAL;
 
     @Test
     void shouldReturnSuccess_whenValidAndConstraint() {

--- a/spi/core-spi/src/main/java/org/eclipse/tractusx/edc/edr/spi/CoreConstants.java
+++ b/spi/core-spi/src/main/java/org/eclipse/tractusx/edc/edr/spi/CoreConstants.java
@@ -32,7 +32,7 @@ public final class CoreConstants {
     public static final String TX_AUTH_NS = "https://w3id.org/tractusx/auth/";
     public static final String EDC_CONTEXT = "https://w3id.org/edc/v0.0.1";
     public static final String CX_CREDENTIAL_NS = "https://w3id.org/catenax/credentials/";
-    public static final String CX_POLICY_NS = "https://w3id.org/catenax/policy/";
+    public static final String CX_POLICY_NS = "https://w3id.org/catenax/2025/9/policy/";
 
     // constants related to token refresh/renewal
     public static final String EDR_PROPERTY_AUTHORIZATION = EDC_NAMESPACE + "authorization";


### PR DESCRIPTION
## WHAT

Updates the CX namespace to `https://w3id.org/catenax/2025/9/policy/`, in alignment with the latest version of the policy schema [context](https://github.com/catenax-eV/cx-odrl-profile/blob/33d62716335f567d6e3df718779bb7f1ae743779/schema/context/context.jsonld#L4), which now defines the CX namespace as `https://w3id.org/catenax/2025/9/policy/`.

## WHY

This change ensures consistency with the updated policy schema specification.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
