### PR TITLE
chore: update Fraunhofer license headers

### DIFF
--- a/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerNumberPermissionFunction.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/main/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerNumberPermissionFunction.java
@@ -1,5 +1,6 @@
 /********************************************************************************
  * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  * Copyright (c) 2025 Cofinity-X GmbH
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -58,9 +59,9 @@ public class BusinessPartnerNumberPermissionFunction<C extends ParticipantAgentP
             Operator.IS_ALL_OF,
             Operator.HAS_PART
     );
-    
+
     private BdrsClient bdrsClient;
-    
+
     public BusinessPartnerNumberPermissionFunction(BdrsClient bdrsClient) {
         this.bdrsClient = bdrsClient;
     }
@@ -80,7 +81,7 @@ public class BusinessPartnerNumberPermissionFunction<C extends ParticipantAgentP
             context.reportProblem("Identity of the participant agent cannot be null");
             return false;
         }
-        
+
         if (identity.startsWith(DID_PREFIX)) {
             identity = bdrsClient.resolveBpn(identity);
         }

--- a/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerNumberPermissionFunctionTest.java
+++ b/edc-extensions/bpn-validation/bpn-validation-core/src/test/java/org/eclipse/tractusx/edc/validation/businesspartner/functions/BusinessPartnerNumberPermissionFunctionTest.java
@@ -1,5 +1,6 @@
 /********************************************************************************
  * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -80,16 +81,16 @@ class BusinessPartnerNumberPermissionFunctionTest {
         assertThat(policyContext.getProblems()).hasSize(1)
                 .anyMatch(it -> it.contains("Identity of the participant agent cannot be null"));
     }
-    
+
     @Test
     void testBdrsClientCalledWhenIdentityIsDid() {
         var did = "did:web:foo";
         var bpn = "foo";
         when(participantAgent.getIdentity()).thenReturn(did);
         when(bdrsClient.resolveBpn(did)).thenReturn(bpn);
-        
+
         var result = validation.evaluate(Operator.EQ, "foo", unusedPermission, policyContext);
-        
+
         assertThat(result).isTrue();
         verify(bdrsClient).resolveBpn(did);
     }

--- a/edc-extensions/cx-policy/build.gradle.kts
+++ b/edc-extensions/cx-policy/build.gradle.kts
@@ -1,5 +1,6 @@
 /********************************************************************************
  * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/CxPolicyExtension.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/CxPolicyExtension.java
@@ -1,5 +1,6 @@
 /********************************************************************************
  * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/AccessPolicyValidator.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/AccessPolicyValidator.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/ActionTypeIs.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/ActionTypeIs.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/ArrayIsEmpty.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/ArrayIsEmpty.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/AtLeastOneRuleExists.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/AtLeastOneRuleExists.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/AtomicConstraintValidator.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/AtomicConstraintValidator.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/ConstraintValidator.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/ConstraintValidator.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/CxPolicyDefinitionValidator.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/CxPolicyDefinitionValidator.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/LeftOperandValidator.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/LeftOperandValidator.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/LogicalConstraintValidator.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/LogicalConstraintValidator.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/PolicyTypeResolver.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/PolicyTypeResolver.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/PolicyValidationConstants.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/PolicyValidationConstants.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/TypedMandatoryArray.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/TypedMandatoryArray.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/UsagePolicyValidator.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/UsagePolicyValidator.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/AccessPolicyValidatorTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/AccessPolicyValidatorTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/ActionTypeIsTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/ActionTypeIsTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/ArrayIsEmptyTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/ArrayIsEmptyTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/AtomicConstraintValidatorTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/AtomicConstraintValidatorTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/ConstraintValidatorTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/ConstraintValidatorTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/CxPolicyDefinitionValidatorTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/CxPolicyDefinitionValidatorTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/LeftOperandValidatorTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/LeftOperandValidatorTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/LogicalConstraintValidatorTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/LogicalConstraintValidatorTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/PolicyTypeResolverTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/PolicyTypeResolverTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/TypedMandatoryArrayTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/TypedMandatoryArrayTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/UsagePolicyValidatorTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/UsagePolicyValidatorTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-extensions/cx-policy/src/testFixtures/java/org/eclipse/tractusx/edc/policy/cx/validator/PolicyBuilderFixtures.java
+++ b/edc-extensions/cx-policy/src/testFixtures/java/org/eclipse/tractusx/edc/policy/cx/validator/PolicyBuilderFixtures.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/helpers/PolicyHelperFunctions.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/helpers/PolicyHelperFunctions.java
@@ -1,5 +1,6 @@
 /********************************************************************************
  * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-tests/e2e/catalog-tests/src/test/java/org/eclipse/tractusx/edc/tests/catalog/CatalogTest.java
+++ b/edc-tests/e2e/catalog-tests/src/test/java/org/eclipse/tractusx/edc/tests/catalog/CatalogTest.java
@@ -1,5 +1,6 @@
 /********************************************************************************
  * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -83,7 +84,7 @@ public class CatalogTest {
 
     @RegisterExtension
     private static final RuntimeExtension PROVIDER_RUNTIME = pgRuntime(PROVIDER, POSTGRES);
-    
+
     @BeforeEach
     void setup() {
         CONSUMER.setJsonLd(CONSUMER_RUNTIME.getService(JsonLd.class));

--- a/edc-tests/e2e/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/AbstractIatpConsumerPullTest.java
+++ b/edc-tests/e2e/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/AbstractIatpConsumerPullTest.java
@@ -1,5 +1,6 @@
 /********************************************************************************
  * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
+++ b/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
@@ -1,5 +1,6 @@
 /********************************************************************************
  * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/edc-tests/e2e/transfer-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/RetireAgreementTest.java
+++ b/edc-tests/e2e/transfer-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/RetireAgreementTest.java
@@ -1,5 +1,6 @@
 /********************************************************************************
  * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.


### PR DESCRIPTION
## WHAT

Updates "Fraunhofer Institute for Software and Systems Engineering" to "Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V." in all affected license headers that have been introduced with https://github.com/eclipse-tractusx/tractusx-edc/commit/4da7c72760855a4382507845e0db091f32a41112.

## WHY

Maintain correct license information.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
