### PR TITLE
build: adapt maven publication to the new flow

### DIFF
--- a/.github/workflows/trigger-maven-publish.yaml
+++ b/.github/workflows/trigger-maven-publish.yaml
@@ -37,49 +37,29 @@ on:
 
 jobs:
   maven-release:
-    name: 'Publish all artefacts to Sonatype/MavenCentral'
+    name: 'Publish all artefacts to MavenCentral'
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      # Set-Up
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-java
 
-      # Import GPG Key
-      - uses: ./.github/actions/import-gpg-key
-        name: "Import GPG Key"
-        with:
-          gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
-
-      # publish releases
-      - name: Publish version
-        env:
-          CENTRAL_SONATYPE_TOKEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
-          CENTRAL_SONATYPE_TOKEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
-        run: |-
-          
+      - run: |
           echo "Input Version: ${{ inputs.version }}"
 
-          # check if version input was specified, else read from gradle.properties 
-          
+          # set the input version in gradle.properties, if passed
           if [ ! -z ${{ inputs.version }} ];
           then
+            sed -i 's#^version=.*#version='"${{ inputs.version }}"'#g' $(find . -name "gradle.properties")
             VERSION=${{ inputs.version }}
-            echo "Publishing using version from parameter: $VERSION"
-          else
-            VERSION=$(./gradlew properties -q | grep "version:" | awk '{print $2}')
-            echo "Publishing using version from gradle.properties: $VERSION"
           fi
-          
-          # check if the version is a SNAPSHOT, and if not, append command to close staging repo
-          
-          cmd=""
-          if [[ $VERSION != *-SNAPSHOT ]]
-          then
-            cmd="closeAndReleaseSonatypeStagingRepository";
-          fi
-          echo "Publishing Version $VERSION to Sonatype"
-          
-          ./gradlew publishToSonatype ${cmd} --no-parallel -Pversion=$VERSION -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ secrets.ORG_GPG_PASSPHRASE }}"
+
+          grep version gradle.properties | (echo -n "Publishing using " && cat)
+
+      - uses: eclipse-edc/.github/.github/actions/publish-maven-artifacts@main
+        with:
+          gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          username: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          password: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ format.version = "1.1"
 
 [versions]
 edc = "0.14.0"
-edc-build = "0.1.0"
+edc-build = "0.1.1"
 allure = "2.29.1"
 awaitility = "4.3.0"
 aws = "2.32.24"


### PR DESCRIPTION
## WHAT

Switch the maven artifacts publication to the "new way", so, instead to publish them to the staging repo ([deprecated method](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/)), they gets published directly using APIs (preferred method) by using the [`gradle-maven-publish-plugin`](https://github.com/vanniktech/gradle-maven-publish-plugin)

Release publication will work as well. (tested upstream)

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES

- I called the upstream `publish-maven-artifacts` action because the way we publish is strictly dependent to the edc-build plugin, so there's no reason to maintan that piece of code also in tractusx-edc

Closes #2178 