### PR TITLE
feat: validate required usage policy constraints

### DIFF
--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/CxPolicyDefinitionValidatorTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/CxPolicyDefinitionValidatorTest.java
@@ -82,8 +82,9 @@ class CxPolicyDefinitionValidatorTest {
 
     @Test
     void shouldReturnSuccess_whenValidUsagePolicy() {
-        JsonObject constraint = atomicConstraint(USAGE_PURPOSE_LITERAL);
-        JsonObject permission = rule(ACTION_USAGE, constraint);
+        JsonObject usagePurposeConstraint = atomicConstraint(USAGE_PURPOSE_LITERAL);
+        JsonObject frameworkAgreementConstraint = atomicConstraint(FRAMEWORK_AGREEMENT_LITERAL);
+        JsonObject permission = rule(ACTION_USAGE, usagePurposeConstraint, frameworkAgreementConstraint);
         JsonObject policy = policy(ODRL_PERMISSION_ATTRIBUTE, permission);
         JsonObject input = policyDefinition(policy, "some-id");
 

--- a/edc-extensions/cx-policy/src/testFixtures/java/org/eclipse/tractusx/edc/policy/cx/validator/PolicyBuilderFixtures.java
+++ b/edc-extensions/cx-policy/src/testFixtures/java/org/eclipse/tractusx/edc/policy/cx/validator/PolicyBuilderFixtures.java
@@ -125,6 +125,17 @@ public final class PolicyBuilderFixtures {
                 .build();
     }
 
+    public static JsonObject appendRulesToPolicy(JsonObject policy, String ruleType, JsonObject... rules) {
+        var rulesArrayBuilder = Json.createArrayBuilder();
+        for (JsonObject rule : rules) {
+            rulesArrayBuilder.add(rule);
+        }
+
+        return Json.createObjectBuilder(policy)
+                .add(ruleType, rulesArrayBuilder)
+                .build();
+    }
+
     public static JsonObject policyDefinition(JsonObject policy, String id) {
         return Json.createObjectBuilder()
                 .add(ID, id)

--- a/edc-extensions/dcp/tx-dcp/src/test/java/org/eclipse/tractusx/edc/iam/iatp/scope/CredentialScopeExtractorTest.java
+++ b/edc-extensions/dcp/tx-dcp/src/test/java/org/eclipse/tractusx/edc/iam/iatp/scope/CredentialScopeExtractorTest.java
@@ -1,5 +1,6 @@
 /********************************************************************************
  * Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -27,6 +28,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractO
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferRequestMessage;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferTerminationMessage;
 import org.eclipse.edc.policy.context.request.spi.RequestPolicyContext;
+import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.iam.RequestContext;
 import org.eclipse.edc.spi.iam.RequestScope;
@@ -66,9 +68,9 @@ public class CredentialScopeExtractorTest {
         var requestContext = RequestContext.Builder.newInstance().message(message).direction(RequestContext.Direction.Egress).build();
         var ctx = new TestRequestPolicyContext(requestContext, null);
 
-        var scopes = extractor.extractScopes(CoreConstants.CX_POLICY_2025_09_NS + FRAMEWORK_CREDENTIAL_PREFIX + ".pfc", null, null, ctx);
+        var scopes = extractor.extractScopes(CoreConstants.CX_POLICY_2025_09_NS + FRAMEWORK_CREDENTIAL_PREFIX + ".pcf", null, null, ctx);
 
-        assertThat(scopes).contains(CREDENTIAL_TYPE_NAMESPACE + ":PfcCredential:read");
+        assertThat(scopes).contains(CREDENTIAL_TYPE_NAMESPACE + ":PcfCredential:read");
     }
 
     @DisplayName("Scope extractor with not supported messages")
@@ -79,6 +81,15 @@ public class CredentialScopeExtractorTest {
         var ctx = new TestRequestPolicyContext(requestContext, null);
 
         var scopes = extractor.extractScopes(CoreConstants.CX_POLICY_2025_09_NS + FRAMEWORK_CREDENTIAL_PREFIX + ".pfc", null, null, ctx);
+
+        assertThat(scopes).isEmpty();
+    }
+
+    @Test
+    void verify_extractScopes_isEmpty_whenLeftOperandDoesNotMapToCredential() {
+        var ctx = new TestRequestPolicyContext(null, null);
+
+        var scopes = extractor.extractScopes(CoreConstants.CX_POLICY_2025_09_NS + "UsagePurpose", Operator.IS_ANY_OF, "cx.pcf.base:1", ctx);
 
         assertThat(scopes).isEmpty();
     }

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/helpers/PolicyHelperFunctions.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/helpers/PolicyHelperFunctions.java
@@ -137,6 +137,7 @@ public class PolicyHelperFunctions {
         if (!leftOperand.equals(USAGE_PURPOSE_LITERAL) && action.contains("use")) {
             constraintsBuilder.add(usagePurposeConstraint());
         }
+
         var permission = Json.createObjectBuilder()
                 .add("action", action)
                 .add("constraint", Json.createObjectBuilder()

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/helpers/PolicyHelperFunctions.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/helpers/PolicyHelperFunctions.java
@@ -59,8 +59,8 @@ public class PolicyHelperFunctions {
 
     private static final String BUSINESS_PARTNER_CONSTRAINT_KEY = TX_NAMESPACE + "BusinessPartnerGroup";
 
-    private static final String FRAMEWORK_AGREEMENT_LITERAL = CX_POLICY_NS + "FrameworkAgreement";
-    private static final String USAGE_PURPOSE_LITERAL = CX_POLICY_NS + "UsagePurpose";
+    private static final String FRAMEWORK_AGREEMENT_LITERAL = CX_POLICY_2025_09_NS + "FrameworkAgreement";
+    private static final String USAGE_PURPOSE_LITERAL = CX_POLICY_2025_09_NS + "UsagePurpose";
 
     private static final ObjectMapper MAPPER = JacksonJsonLd.createObjectMapper();
 

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/helpers/PolicyHelperFunctions.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/helpers/PolicyHelperFunctions.java
@@ -130,11 +130,13 @@ public class PolicyHelperFunctions {
         var constraintsBuilder = Json.createArrayBuilder()
                 .add(constraint);
 
-        if (action.contains("use")) {
+        if (!leftOperand.equals(FRAMEWORK_AGREEMENT_LITERAL) && action.contains("use")) {
             constraintsBuilder.add(frameworkAgreementConstraint());
-            constraintsBuilder.add(usagePurposeConstraint());
         }
 
+        if (!leftOperand.equals(USAGE_PURPOSE_LITERAL) && action.contains("use")) {
+            constraintsBuilder.add(usagePurposeConstraint());
+        }
         var permission = Json.createObjectBuilder()
                 .add("action", action)
                 .add("constraint", Json.createObjectBuilder()
@@ -292,8 +294,12 @@ public class PolicyHelperFunctions {
                 .collect(Json::createArrayBuilder, JsonArrayBuilder::add, JsonArrayBuilder::add);
 
         if (action.contains("use")) {
-            constraints.add(frameworkAgreementConstraint());
-            constraints.add(usagePurposeConstraint());
+            if (!permissions.containsKey(FRAMEWORK_AGREEMENT_LITERAL)) {
+                constraints.add(frameworkAgreementConstraint());
+            }
+            if (!permissions.containsKey(USAGE_PURPOSE_LITERAL)) {
+                constraints.add(usagePurposeConstraint());
+            }
         }
 
         return Json.createObjectBuilder()

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/helpers/PolicyHelperFunctions.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/helpers/PolicyHelperFunctions.java
@@ -287,10 +287,14 @@ public class PolicyHelperFunctions {
     }
 
     public static JsonObject frameworkPermission(Map<String, String> permissions, String action) {
-
         var constraints = permissions.entrySet().stream()
                 .map(permission -> atomicConstraint(permission.getKey(), "eq", permission.getValue(), false))
                 .collect(Json::createArrayBuilder, JsonArrayBuilder::add, JsonArrayBuilder::add);
+
+        if (action.contains("use")) {
+            constraints.add(frameworkAgreementConstraint());
+            constraints.add(usagePurposeConstraint());
+        }
 
         return Json.createObjectBuilder()
                 .add("action", action)

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/runtimes/Runtimes.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/runtimes/Runtimes.java
@@ -30,7 +30,7 @@ import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
 import org.eclipse.tractusx.edc.tests.MockBdrsClient;
-import org.eclipse.tractusx.edc.tests.MockMembershipCredentialIdentityService;
+import org.eclipse.tractusx.edc.tests.MockVcIdentityService;
 import org.eclipse.tractusx.edc.tests.participant.TractusxParticipantBase;
 
 import java.util.function.Function;
@@ -52,7 +52,7 @@ public interface Runtimes {
                 new EmbeddedRuntime(participant.getName(), ":edc-tests:runtime:runtime-postgresql")
                         .configurationProvider(() -> participant.getConfig().merge(postgres.getConfig(participant.getName())))
                         .configurationProvider(configurationProvider)
-                        .registerServiceMock(IdentityService.class, new MockMembershipCredentialIdentityService(participant.getBpn(), participant.getDid()))
+                        .registerServiceMock(IdentityService.class, new MockVcIdentityService(participant.getBpn(), participant.getDid()))
                         .registerServiceMock(AudienceResolver.class, remoteMessage -> Result.success(remoteMessage.getCounterPartyAddress()))
                         .registerServiceMock(BdrsClient.class, new MockBdrsClient(bpnToDid, didToBpn))
                         .registerServiceMock(DefaultParticipantIdExtractionFunction.class, ct -> "id")
@@ -73,7 +73,7 @@ public interface Runtimes {
 
     static RuntimeExtension discoveryRuntime(TractusxParticipantBase participant, String module) {
         return new ParticipantRuntimeExtension(new EmbeddedRuntime(participant.getName(), module)
-                .registerServiceMock(IdentityService.class, new MockMembershipCredentialIdentityService(participant.getBpn(), participant.getDid()))
+                .registerServiceMock(IdentityService.class, new MockVcIdentityService(participant.getBpn(), participant.getDid()))
                 .registerServiceMock(AudienceResolver.class, remoteMessage -> Result.success(remoteMessage.getCounterPartyAddress()))
                 .configurationProvider(participant::getConfig));
     }

--- a/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
+++ b/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
@@ -114,6 +114,7 @@ public class PolicyDefinitionEndToEndTest {
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return Stream.of(
                     Arguments.of(frameworkPolicy(Map.of(namespace + "Membership", "active"), CX_POLICY_2025_09_NS + "access"), "MembershipCredential"),
+                    Arguments.of(frameworkPolicy(Map.of(namespace + "FrameworkAgreement", "DataExchangeGovernance:2.0"), "use"), "DataExchangeGovernance use case"),
                     Arguments.of(frameworkPolicy(namespace + "AffiliatesRegion", Operator.IS_ANY_OF, List.of("cx.region.all:1", "cx.region.europe:1", "cx.region.northAmerica:1"), "use", true), "Affiliates Region"),
                     Arguments.of(frameworkPolicy(namespace + "AffiliatesRegion", Operator.IS_ANY_OF, List.of("cx.region.europe:1"), "use", true), "Affiliates Region (IS_ANY_OF, one element)"),
                     Arguments.of(frameworkPolicy(namespace + "AffiliatesBpnl", Operator.IS_ANY_OF, "BPNL00000000001A", "use", true), "Affiliates BPNL"),

--- a/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
+++ b/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
@@ -51,6 +51,7 @@ import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PROVIDER_N
 import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.emptyPolicy;
 import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.frameworkPermission;
 import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.frameworkPolicy;
+import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.inForceDateUsagePolicy;
 import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.policyFromRules;
 import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.policyWithEmptyRule;
 import static org.eclipse.tractusx.edc.tests.runtimes.Runtimes.pgRuntime;
@@ -114,7 +115,6 @@ public class PolicyDefinitionEndToEndTest {
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return Stream.of(
                     Arguments.of(frameworkPolicy(Map.of(namespace + "Membership", "active"), CX_POLICY_2025_09_NS + "access"), "MembershipCredential"),
-                    Arguments.of(frameworkPolicy(Map.of(namespace + "FrameworkAgreement", "DataExchangeGovernance:2.0"), "use"), "DataExchangeGovernance use case"),
                     Arguments.of(frameworkPolicy(namespace + "AffiliatesRegion", Operator.IS_ANY_OF, List.of("cx.region.all:1", "cx.region.europe:1", "cx.region.northAmerica:1"), "use", true), "Affiliates Region"),
                     Arguments.of(frameworkPolicy(namespace + "AffiliatesRegion", Operator.IS_ANY_OF, List.of("cx.region.europe:1"), "use", true), "Affiliates Region (IS_ANY_OF, one element)"),
                     Arguments.of(frameworkPolicy(namespace + "AffiliatesBpnl", Operator.IS_ANY_OF, "BPNL00000000001A", "use", true), "Affiliates BPNL"),
@@ -154,7 +154,7 @@ public class PolicyDefinitionEndToEndTest {
             return Stream.concat(super.provideArguments(extensionContext), Stream.of(
                     Arguments.of(emptyPolicy(), "Empty Policy"),
                     Arguments.of(policyWithEmptyRule(this.namespace + "access"), "Access policy with empty permission"),
-                    Arguments.of(inForceDatePolicy("gteq", "contractAgreement+0s", "lteq", "contractAgreement+10s"), "In force date policy")
+                    Arguments.of(inForceDateUsagePolicy("gteq", "contractAgreement+0s", "lteq", "contractAgreement+10s"), "In force date policy")
             ));
         }
     }

--- a/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
+++ b/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.inForceDatePolicy;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_2025_09_NS;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.CONSUMER_BPN;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.CONSUMER_DID;

--- a/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyMonitorEndToEndTest.java
+++ b/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyMonitorEndToEndTest.java
@@ -48,6 +48,7 @@ import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.DSP_2025_P
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PROVIDER_BPN;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PROVIDER_DID;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PROVIDER_NAME;
+import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.emptyPolicy;
 import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.inForceDateUsagePolicy;
 import static org.eclipse.tractusx.edc.tests.participant.TractusxParticipantBase.ASYNC_TIMEOUT;
 import static org.eclipse.tractusx.edc.tests.runtimes.Runtimes.pgRuntime;
@@ -100,9 +101,11 @@ public class PolicyMonitorEndToEndTest {
         );
         PROVIDER.createAsset(assetId, Map.of(), dataAddress);
 
-        var policy = inForceDateUsagePolicy("gteq", "contractAgreement+0s", "lteq", "contractAgreement+10s");
-        var policyId = PROVIDER.createPolicyDefinition(policy);
-        PROVIDER.createContractDefinition(assetId, UUID.randomUUID().toString(), policyId, policyId);
+        var accessPolicy = emptyPolicy();
+        var accessPolicyId = PROVIDER.createPolicyDefinition(accessPolicy);
+        var usagePolicy = inForceDateUsagePolicy("gteq", "contractAgreement+0s", "lteq", "contractAgreement+10s");
+        var usagePolicyId = PROVIDER.createPolicyDefinition(usagePolicy);
+        PROVIDER.createContractDefinition(assetId, UUID.randomUUID().toString(), accessPolicyId, usagePolicyId);
 
 
         var transferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)

--- a/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyMonitorEndToEndTest.java
+++ b/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyMonitorEndToEndTest.java
@@ -37,7 +37,6 @@ import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.TERMINATED;
-import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.inForceDatePolicy;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.STARTED;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
@@ -49,6 +48,7 @@ import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.DSP_2025_P
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PROVIDER_BPN;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PROVIDER_DID;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PROVIDER_NAME;
+import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.inForceDateUsagePolicy;
 import static org.eclipse.tractusx.edc.tests.participant.TractusxParticipantBase.ASYNC_TIMEOUT;
 import static org.eclipse.tractusx.edc.tests.runtimes.Runtimes.pgRuntime;
 
@@ -100,7 +100,7 @@ public class PolicyMonitorEndToEndTest {
         );
         PROVIDER.createAsset(assetId, Map.of(), dataAddress);
 
-        var policy = inForceDatePolicy("gteq", "contractAgreement+0s", "lteq", "contractAgreement+10s");
+        var policy = inForceDateUsagePolicy("gteq", "contractAgreement+0s", "lteq", "contractAgreement+10s");
         var policyId = PROVIDER.createPolicyDefinition(policy);
         PROVIDER.createContractDefinition(assetId, UUID.randomUUID().toString(), policyId, policyId);
 

--- a/edc-tests/e2e/transfer-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/TransferPullEndToEndTest.java
+++ b/edc-tests/e2e/transfer-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/TransferPullEndToEndTest.java
@@ -40,7 +40,6 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.inForceDatePolicy;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.CONSUMER_BPN;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.CONSUMER_DID;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.CONSUMER_NAME;
@@ -50,6 +49,7 @@ import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.DSP_2025_P
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PROVIDER_BPN;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PROVIDER_DID;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PROVIDER_NAME;
+import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.inForceDateUsagePolicy;
 import static org.eclipse.tractusx.edc.tests.runtimes.Runtimes.pgRuntime;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -184,7 +184,7 @@ public class TransferPullEndToEndTest {
         }
 
         protected JsonObject inForcePolicy() {
-            return inForceDatePolicy("gteq", "contractAgreement+0s", "lteq", "contractAgreement+10s");
+            return inForceDateUsagePolicy("gteq", "contractAgreement+0s", "lteq", "contractAgreement+10s");
         }
 
 


### PR DESCRIPTION
## WHAT

Adds a new json validator for usage policy validation. This validator checks whether a `FrameworkAgreement` and a `UsagePurpose` constraint are present in a given usage policy. Fails the validation if any of these constraints is missing.

## WHY

Policy standard compliance

## FURTHER NOTES

Updates the `CredentialScopeExtractor` to check whether a scope contains a valid credential type before returning it, so that it does not extract e.g. a scope for a non-existing type like `UsagePurposeCredential`, as that leads to a failure during credential request.

Also updates the mock identity service to always return a `DataExchangeGovernanceCredential`, as the corresponding policy constraint now is included in every usage policy.
