### PR TITLE
perf: add index for foreign key references

### DIFF
--- a/edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/contractnegotiation/V0_0_10__Alter_ContractNegotiation_CreateLeaseIndex.sql
+++ b/edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/contractnegotiation/V0_0_10__Alter_ContractNegotiation_CreateLeaseIndex.sql
@@ -1,0 +1,18 @@
+--
+--  Copyright (c) 2025 SAP SE
+--
+--  This program and the accompanying materials are made available under the
+--  terms of the Apache License, Version 2.0 which is available at
+--  https://www.apache.org/licenses/LICENSE-2.0
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+--  Contributors:
+--       SAP SE - add index for foreign keys
+--
+
+CREATE INDEX IF NOT EXISTS contract_negotiation_lease_id_index
+    ON edc_contract_negotiation (lease_id);
+
+CREATE INDEX IF NOT EXISTS contract_negotiation_agreement_id_index
+    ON edc_contract_negotiation (agreement_id);

--- a/edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/policy-monitor/V0_0_3__Alter_PolicyMonitor_CreateLeaseIndex.sql
+++ b/edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/policy-monitor/V0_0_3__Alter_PolicyMonitor_CreateLeaseIndex.sql
@@ -1,0 +1,15 @@
+--
+--  Copyright (c) 2025 SAP SE
+--
+--  This program and the accompanying materials are made available under the
+--  terms of the Apache License, Version 2.0 which is available at
+--  https://www.apache.org/licenses/LICENSE-2.0
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+--  Contributors:
+--       SAP SE - add index for foreign keys
+--
+
+CREATE INDEX IF NOT EXISTS policy_monitor_lease_id_index
+    ON edc_policy_monitor (lease_id);

--- a/edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/transferprocess/V0_0_17__Alter_TransferProcess_CreateLeaseIndex.sql
+++ b/edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/transferprocess/V0_0_17__Alter_TransferProcess_CreateLeaseIndex.sql
@@ -1,0 +1,15 @@
+--
+--  Copyright (c) 2025 SAP SE
+--
+--  This program and the accompanying materials are made available under the
+--  terms of the Apache License, Version 2.0 which is available at
+--  https://www.apache.org/licenses/LICENSE-2.0
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+--  Contributors:
+--       SAP SE - add index for foreign keys
+--
+
+CREATE INDEX IF NOT EXISTS transfer_process_lease_id_index
+    ON edc_transfer_process (lease_id);

--- a/edc-extensions/migrations/data-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/dataplane/V0_0_6__Alter_Dataplane_CreateLeaseIndex.sql
+++ b/edc-extensions/migrations/data-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/dataplane/V0_0_6__Alter_Dataplane_CreateLeaseIndex.sql
@@ -1,0 +1,14 @@
+--
+--  Copyright (c) 2025 SAP SE
+--
+--  This program and the accompanying materials are made available under the
+--  terms of the Apache License, Version 2.0 which is available at
+--  https://www.apache.org/licenses/LICENSE-2.0
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+--  Contributors:
+--       SAP SE - add index for foreign keys
+--
+
+CREATE INDEX IF NOT EXISTS data_plane_lease_id ON edc_data_plane (lease_id);

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/TestRuntimeConfiguration.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/TestRuntimeConfiguration.java
@@ -25,7 +25,7 @@ public class TestRuntimeConfiguration {
     public static final String DID_PREFIX = "did:web:";
     public static final String CONSUMER_NAME = "CONSUMER";
     public static final String CONSUMER_BPN = CONSUMER_NAME + BPN_SUFFIX;
-    public static final String CONSUMER_DID = DID_PREFIX + CONSUMER_NAME ;
+    public static final String CONSUMER_DID = DID_PREFIX + CONSUMER_NAME;
     public static final String PROVIDER_NAME = "PROVIDER";
     public static final String PROVIDER_BPN = PROVIDER_NAME + BPN_SUFFIX;
     public static final String PROVIDER_DID = DID_PREFIX + PROVIDER_NAME;


### PR DESCRIPTION
This PR adds flyway migrations for new indexes which are not created by Postgres automatically for foreign keys. The same indexes have been added to upstream's schema.sql files (https://github.com/eclipse-edc/Connector/issues/5179). This will accelerate the deletion of leases and selects of contract negotiations.

Closes #2181 