### PR TITLE
fix: automatic PR labeling for breaking changes on release notes

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -22,22 +22,22 @@
 changelog:
   exclude:
     labels:
-      - dependencies
+      - 'dependencies'
     authors:
       - 'dependabot[bot]'
   categories:
     - title: Breaking changes
       labels:
-        - breaking-change
+        - 'breaking change'
     - title: Bugfixes
       labels:
-        - bug
+        - 'bug'
     - title: New Features & Improvements
       labels:
-        - enhancement
+        - 'enhancement'
     - title: Documentation
       labels:
-        - documentation
+        - 'documentation'
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
## WHAT

fixes automatic PR labeling for breaking changes on release notes

## WHY

Breaking changes were not being correctly identified.

closes #2193
