### PR TITLE
fix: make possible to disable migration

### DIFF
--- a/edc-extensions/migrations/postgresql-migration-lib/src/main/java/org/eclipse/tractusx/edc/postgresql/migration/AbstractPostgresqlMigrationExtension.java
+++ b/edc-extensions/migrations/postgresql-migration-lib/src/main/java/org/eclipse/tractusx/edc/postgresql/migration/AbstractPostgresqlMigrationExtension.java
@@ -64,6 +64,7 @@ abstract class AbstractPostgresqlMigrationExtension implements ServiceExtension 
 
         ConfigUtil.propertyCompatibility(context, MIGRATION_ENABLED_TEMPLATE.formatted(subSystemName), MIGRATION_ENABLED_TEMPLATE_DEPRECATED.formatted(subSystemName), Boolean.valueOf(DEFAULT_MIGRATION_ENABLED_TEMPLATE));
         if (!enabled) {
+            context.getMonitor().info("Migration for subsystem %s disabled".formatted(subSystemName));
             return;
         }
 
@@ -84,6 +85,10 @@ abstract class AbstractPostgresqlMigrationExtension implements ServiceExtension 
 
     @Override
     public void prepare() {
+        if (migrationExecutor == null) {
+            return;
+        }
+
         var migrateResult = migrationExecutor.get();
 
         if (!migrateResult.success) {


### PR DESCRIPTION
## WHAT

This PR provides a fix for the migration extension
## WHY
To make it possible to disable migration without exception.

Closes #2197
