### PR TITLE
feat - added otel appender for log4j2 [TAP 7.2]

### DIFF
--- a/edc-controlplane/edc-controlplane-base/build.gradle.kts
+++ b/edc-controlplane/edc-controlplane-base/build.gradle.kts
@@ -68,4 +68,5 @@ dependencies {
     runtimeOnly(libs.edc.validator.data.address.http.data)
     runtimeOnly(libs.log4j2.core)
     runtimeOnly(libs.log4j2.json.template)
+    runtimeOnly(libs.opentelemetry.log4j.appender)
 }

--- a/edc-dataplane/edc-dataplane-base/build.gradle.kts
+++ b/edc-dataplane/edc-dataplane-base/build.gradle.kts
@@ -52,4 +52,5 @@ dependencies {
     runtimeOnly(libs.edc.dpf.azblob)
     runtimeOnly(libs.edc.identity.did.web)
     runtimeOnly(libs.log4j2.core)
+    runtimeOnly(libs.opentelemetry.log4j.appender)
 }

--- a/edc-extensions/log4j2-monitor/build.gradle.kts
+++ b/edc-extensions/log4j2-monitor/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
     implementation(libs.opentelemetry.instrumentation.annotations)
     testImplementation(libs.edc.junit)
     testImplementation(libs.log4j2.core.test)
-    runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-log4j-appender-2.17:1.32.0-alpha")
 }
 
 

--- a/edc-extensions/log4j2-monitor/build.gradle.kts
+++ b/edc-extensions/log4j2-monitor/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
     implementation(libs.opentelemetry.instrumentation.annotations)
     testImplementation(libs.edc.junit)
     testImplementation(libs.log4j2.core.test)
-    implementation("io.opentelemetry.instrumentation:opentelemetry-log4j-appender-2.17:1.32-alpha")
+    runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-log4j-appender-2.17:1.32.0-alpha")
 }
 
 

--- a/edc-extensions/log4j2-monitor/build.gradle.kts
+++ b/edc-extensions/log4j2-monitor/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     implementation(libs.opentelemetry.instrumentation.annotations)
     testImplementation(libs.edc.junit)
     testImplementation(libs.log4j2.core.test)
+    implementation("io.opentelemetry.instrumentation:opentelemetry-log4j-appender-2.17:1.32-alpha")
 }
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ nimbus = "10.4.2"
 netty-mockserver = "5.15.0"
 opentelemetry = "2.19.0"
 opentelemetry-instrumentation = "2.19.0"
+opentelemetry-log4j-appender = "2.19.0-alpha"
 postgres = "42.7.7"
 restAssured = "5.5.5"
 rsApi = "4.0.0"
@@ -219,6 +220,7 @@ log4j2-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log
 log4j2-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j2" }
 log4j2-core-test = { module = "org.apache.logging.log4j:log4j-core-test", version.ref = "log4j2" }
 log4j2-json-template = { module = "org.apache.logging.log4j:log4j-layout-template-json", version.ref = "log4j2" }
+opentelemetry-log4j-appender = { module = "io.opentelemetry.instrumentation:opentelemetry-log4j-appender-2.17", version.ref = "opentelemetry-log4j-appender" }
 
 [bundles]
 edc-monitoring = ["edc-micrometer-core", "edc-micrometer-jersey", "edc-micrometer-jetty"]


### PR DESCRIPTION
## WHAT
Added log4j2 opentelemetry appender dependency 

## WHY
In order to integrate OTEL with log4j2 and umbrella helm charts

## FURTHER NOTES
Blocking:
[[TAP 7.2] - feat(observability): Log4j2 integration with OTEL](https://github.com/eclipse-tractusx/tractus-x-umbrella/pull/316)

