### PR TITLE
chore: change bitnami images to bitnamilegacy

### DIFF
--- a/charts/tractusx-connector/README.md
+++ b/charts/tractusx-connector/README.md
@@ -288,6 +288,8 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.10.0 \
 | postgresql.auth.database | string | `"edc"` |  |
 | postgresql.auth.password | string | `"password"` |  |
 | postgresql.auth.username | string | `"user"` |  |
+| postgresql.image.repository | string | `"bitnamilegacy/postgresql"` |  |
+| postgresql.image.tag | string | `"16.2.0-debian-12-r10"` |  |
 | postgresql.jdbcUrl | string | `"jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/edc"` |  |
 | postgresql.primary.persistence.enabled | bool | `false` |  |
 | postgresql.readReplicas.persistence.enabled | bool | `false` |  |

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -630,6 +630,9 @@ dataplane:
     public: ""
 
 postgresql:
+  image:
+    repository: "bitnamilegacy/postgresql"
+    tag: "16.2.0-debian-12-r10"
   jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/edc"
   primary:
     persistence:

--- a/edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml
+++ b/edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml
@@ -80,6 +80,9 @@ dataplane:
     verifier:
       publickey_alias: "key-1"
 postgresql:
+  image:
+    repository: "bitnamilegacy/postgresql"
+    tag: "16.2.0-debian-12-r10"
   jdbcUrl: jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/edc
   auth:
     username: user


### PR DESCRIPTION
## WHAT

Changes the used bitnami images to the legacy repository.

## WHY

Due to https://github.com/bitnami/containers/issues/83267

Closes #2200 

To be considered for #2210 
