### PR TITLE
fix: Remove switch to use dcp 1.0 from charts

### DIFF
--- a/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
+++ b/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
@@ -223,8 +223,6 @@ spec:
               value: "idsc:IDS_CONNECTORS_ALL"
             - name: "EDC_OAUTH_ENDPOINT_AUDIENCE"
               value: {{ printf "%s%s" (include "txdc.runtime.url.protocol" . ) .Values.runtime.endpoints.protocol.path | quote }}
-            - name: "EDC_DCP_V08_FORCED"
-              value: "true"
 
             #############################
             ## IATP / STS / DIM CONFIG ##

--- a/charts/tractusx-connector/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-controlplane.yaml
@@ -210,8 +210,6 @@ spec:
               value: "idsc:IDS_CONNECTORS_ALL"
             - name: "EDC_OAUTH_ENDPOINT_AUDIENCE"
               value: {{ printf "%s%s" (include "txdc.controlplane.url.protocol" . ) .Values.controlplane.endpoints.protocol.path | quote }}
-            - name: "EDC_DCP_V08_FORCED"
-              value: "true"
 
             ################
             ## POSTGRESQL ##


### PR DESCRIPTION
## WHAT

Remove the EDC_DCP_V08_FORCED environment setting from the chart templates

## WHY

In 0.10.0 this was needed to enforce the usage of the old DCP protocol, since version 0.11.0 uses the new protocol, this setting must not be set.

Related to: #2212