### PR TITLE
chore: Update bdrs version used for testing

### DIFF
--- a/edc-extensions/bdrs-client/src/test/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientImplComponentTest.java
+++ b/edc-extensions/bdrs-client/src/test/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientImplComponentTest.java
@@ -97,7 +97,7 @@ class BdrsClientImplComponentTest {
     private static final Network DOCKER_NETWORK = Network.newNetwork();
 
     @Container
-    private static final GenericContainer<?> BDRS_SERVER_CONTAINER = new GenericContainer<>("tractusx/bdrs-server-memory:0.5.4")
+    private static final GenericContainer<?> BDRS_SERVER_CONTAINER = new GenericContainer<>("tractusx/bdrs-server-memory:0.5.7")
             .withEnv("EDC_HTTP_MANAGEMENT_AUTH_KEY", "password")
             .withEnv("WEB_HTTP_MANAGEMENT_PATH", "/api/management")
             .withEnv("WEB_HTTP_MANAGEMENT_PORT", "8081")

--- a/edc-tests/e2e/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/extension/BdrsServerExtension.java
+++ b/edc-tests/e2e/iatp-tests/src/test/java/org/eclipse/tractusx/edc/tests/transfer/extension/BdrsServerExtension.java
@@ -41,7 +41,7 @@ public class BdrsServerExtension implements BeforeAllCallback, AfterAllCallback 
     private final LazySupplier<URI> directoryEndpoint = new LazySupplier<>(() -> URI.create("http://localhost:%d%s".formatted(getFreePort(), "/directory")));
     private final LazySupplier<URI> managementEndpoint = new LazySupplier<>(() -> URI.create("http://localhost:%d%s".formatted(getFreePort(), "/management")));
 
-    private final GenericContainer<?> bdrsServer = new GenericContainer<>("tractusx/bdrs-server-memory:0.5.4")
+    private final GenericContainer<?> bdrsServer = new GenericContainer<>("tractusx/bdrs-server-memory:0.5.7")
             .withLogConsumer(o -> System.out.println("[BDRS] " + o.getUtf8StringWithoutLineEnding()))
             .withNetworkMode("host");
 


### PR DESCRIPTION
## WHAT

Use BDRS version 0.5.7 instead of 0.5.4

## WHY

Update to the latest version released to keep up with the development of the component, so that testing checks potential inconsistencies with the version used in the field soon
