### PR TITLE
fix: add missing log4j2 json template dep

### DIFF
--- a/edc-dataplane/edc-dataplane-base/build.gradle.kts
+++ b/edc-dataplane/edc-dataplane-base/build.gradle.kts
@@ -52,5 +52,6 @@ dependencies {
     runtimeOnly(libs.edc.dpf.azblob)
     runtimeOnly(libs.edc.identity.did.web)
     runtimeOnly(libs.log4j2.core)
+    runtimeOnly(libs.log4j2.json.template)
     runtimeOnly(libs.opentelemetry.log4j.appender)
 }


### PR DESCRIPTION
## WHAT

Adds a missing dependency to the base dataplane bom.

## WHY

It was missing and the dataplane was not booting properly.

Closes #2220 
