### PR TITLE
fix: create JtiValidationPostgresqlMigrationExtension extension

### DIFF
--- a/edc-extensions/migrations/control-plane-migration/src/main/java/org/eclipse/tractusx/edc/postgresql/migration/JtiValidationPostgresqlMigrationExtension.java
+++ b/edc-extensions/migrations/control-plane-migration/src/main/java/org/eclipse/tractusx/edc/postgresql/migration/JtiValidationPostgresqlMigrationExtension.java
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (c) 2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.postgresql.migration;
+
+public class JtiValidationPostgresqlMigrationExtension extends AbstractPostgresqlMigrationExtension {
+    private static final String NAME_SUBSYSTEM = "jti-validation";
+
+    @Override
+    protected String getSubsystemName() {
+        return NAME_SUBSYSTEM;
+    }
+
+    @Override
+    protected String getMigrationSubsystem() {
+        return NAME_SUBSYSTEM;
+    }
+}

--- a/edc-extensions/migrations/control-plane-migration/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/edc-extensions/migrations/control-plane-migration/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -27,6 +27,7 @@ org.eclipse.tractusx.edc.postgresql.migration.ContractNegotiationPostgresqlMigra
 org.eclipse.tractusx.edc.postgresql.migration.DataPlaneInstancePostgresqlMigrationExtension
 org.eclipse.tractusx.edc.postgresql.migration.EdrIndexPostgresqlMigrationExtension
 org.eclipse.tractusx.edc.postgresql.migration.FederatedCatalogCacheMigrationExtension
+org.eclipse.tractusx.edc.postgresql.migration.JtiValidationPostgresqlMigrationExtension
 org.eclipse.tractusx.edc.postgresql.migration.PolicyMonitorPostgresqlMigrationExtension
 org.eclipse.tractusx.edc.postgresql.migration.PolicyPostgresqlMigrationExtension
 org.eclipse.tractusx.edc.postgresql.migration.TransferProcessPostgresqlMigrationExtension

--- a/edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/jti-validation/V0_0_1__Init_JtiValidation_Database_Schema.sql
+++ b/edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/jti-validation/V0_0_1__Init_JtiValidation_Database_Schema.sql
@@ -1,0 +1,24 @@
+--
+--  Copyright (c) 2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+--
+--  This program and the accompanying materials are made available under the
+--  terms of the Apache License, Version 2.0 which is available at
+--  https://www.apache.org/licenses/LICENSE-2.0
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+--  Contributors:
+--       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+--
+
+--
+-- table: edc_jti_validation
+--
+
+CREATE TABLE IF NOT EXISTS edc_jti_validation
+(
+    token_id   VARCHAR NOT NULL PRIMARY KEY,
+    expires_at BIGINT -- expiry time in epoch millis
+);
+
+


### PR DESCRIPTION
## WHAT

Creates an extension to apply migrations to the JTI Validation table

## WHY

This extension is required to apply the schema expected as per the upstream Connector [JtiValidationStore](https://github.com/eclipse-edc/Connector/tree/e4eb7eceda2f141d408e116d49b24b00025ac49f/extensions/common/store/sql/jti-validation-store-sql), which is required by the [IdentityAndTrust](https://github.com/eclipse-edc/Connector/blob/e4eb7eceda2f141d408e116d49b24b00025ac49f/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java#L157) extension

## FURTHER NOTES

Closes https://github.com/eclipse-tractusx/tractusx-edc/issues/2217