### PR TITLE
fix: Revert file deletion to still publish on github pages

### DIFF
--- a/core/json-ld-core/src/main/resources/document/tx-v1.jsonld
+++ b/core/json-ld-core/src/main/resources/document/tx-v1.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "BusinessPartnerNumber": "tx:BusinessPartnerNumber",
+    "BusinessPartnerGroup": "tx:BusinessPartnerGroup"
+  }
+}


### PR DESCRIPTION
## WHAT

Revert deletion of context file, as this is published on github pages. In order to prevent backward compatibility issues, the file is added, but not loaded in the connector.

## WHY

Because the resons for the publication is unknown and it might be needed by previous versions of the connector
