### PR TITLE
fix: Remove deactivation of publication

### DIFF
--- a/edc-extensions/token-interceptor/build.gradle.kts
+++ b/edc-extensions/token-interceptor/build.gradle.kts
@@ -32,7 +32,3 @@ dependencies {
 
     testImplementation(libs.edc.junit)
 }
-
-edcBuild {
-    publish.set(false)
-}


### PR DESCRIPTION
## WHAT

Token Interceptor publication of component was deactivated by accident

## WHY

Needed for, e.g., running compatibility tests
