### PR TITLE
fix: cancel older running "Publish new snapshot"

### DIFF
--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -44,8 +44,8 @@ on:
 
 
 concurrency:
-  # cancel only running jobs on pull requests
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  # cancel older running jobs on the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## WHAT

This PR makes the workflow to cancel older running "Publish new snapshot".

## WHY

To avoid overwriting each other

Closes #2281
