### PR TITLE
fix: evaluate BPN group constraint with string or array

### DIFF
--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/businesspartner/BusinessPartnerGroupConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/businesspartner/BusinessPartnerGroupConstraintFunction.java
@@ -124,7 +124,7 @@ public class BusinessPartnerGroupConstraintFunction<C extends ParticipantAgentPo
         var allowedGroups = bpnGroupHolder.allowedGroups;
         return bpnGroupHolder.assignedGroups
                 .stream()
-                .anyMatch(allowedGroups::contains);
+                .anyMatch(assigned -> allowedGroups.contains(assigned) || allowedGroups.stream().anyMatch(allowed -> allowed.contains("string=%s,".formatted(assigned))));
     }
 
     private boolean evaluateIsNoneOf(BpnGroupHolder bpnGroupHolder) {

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/helpers/PolicyHelperFunctions.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/helpers/PolicyHelperFunctions.java
@@ -65,7 +65,11 @@ public class PolicyHelperFunctions {
     private static final ObjectMapper MAPPER = JacksonJsonLd.createObjectMapper();
 
     public static JsonObject bpnGroupPolicy(Operator operator, String... allowedGroups) {
-        return bpnGroupPolicy(operator.getOdrlRepresentation(), allowedGroups);
+        return bpnGroupPolicy(operator.getOdrlRepresentation(), false, allowedGroups);
+    }
+
+    public static JsonObject bpnGroupPolicyWithRightOperandAsArray(Operator operator, String... allowedGroups) {
+        return bpnGroupPolicy(operator.getOdrlRepresentation(), true, allowedGroups);
     }
 
     /**
@@ -279,9 +283,9 @@ public class PolicyHelperFunctions {
                 .build();
     }
 
-    private static JsonObject bpnGroupPolicy(String operator, String... allowedGroups) {
+    private static JsonObject bpnGroupPolicy(String operator, boolean rightOperandAsArray, String... allowedGroups) {
 
-        var groupConstraint = atomicConstraint(BUSINESS_PARTNER_CONSTRAINT_KEY, operator, Arrays.asList(allowedGroups), false);
+        var groupConstraint = atomicConstraint(BUSINESS_PARTNER_CONSTRAINT_KEY, operator, Arrays.asList(allowedGroups), rightOperandAsArray);
 
         var permission = Json.createObjectBuilder()
                 .add("action", CX_POLICY_2025_09_NS + "access")


### PR DESCRIPTION
## WHAT

Updates the evaluation in `BusinessPartnerGroupConstraintFunction` to consider that the right operand may have been created as either a string or an array. If the right operand is created as a string, the set of allowed groups contains the group names as-is, but if the right operand is created as an array, the set of allowed groups contains the group names in the following format: `{@value={chars=<group-name>, string=<group-name>, valueType=STRING}}`.

## WHY

Previously, the evaluation considered the right operand only as string, causing the evaluation to fail if the right operand was created as an array.

Relates to #2221 
