### PR TITLE
fix: ConnectorParamsDiscoveryResquest format

### DIFF
--- a/docs/migration/2025-09-Version_0.10.x_0.11.x.md
+++ b/docs/migration/2025-09-Version_0.10.x_0.11.x.md
@@ -54,13 +54,13 @@ counterPartyId, resp. policy/assigner: <provider-did>
 ```
 
 The property values to be used for a specific connector can be retrieved from the new management endpoint
-`/v4alpha/connectordiscovery`. It takes as request parameter a payload like:
+`/v4alpha/connectordiscovery/dspversionparams`. It takes as request parameter a payload like:
 
 ```json
 {
   "@context": {
     "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
-    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/"
   },
   "tx:bpnl": "BPNL1234567890",
   "edc:counterPartyAddress": "https://provider.domain.com/api/v1/dsp"

--- a/edc-extensions/connector-discovery/connector-discovery-api/src/main/java/org/eclipse/tractusx/edc/discovery/v4alpha/api/ConnectorDiscoveryV4AlphaApi.java
+++ b/edc-extensions/connector-discovery/connector-discovery-api/src/main/java/org/eclipse/tractusx/edc/discovery/v4alpha/api/ConnectorDiscoveryV4AlphaApi.java
@@ -56,7 +56,7 @@ public interface ConnectorDiscoveryV4AlphaApi {
     JsonObject discoverDspVersionParamsV4Alpha(JsonObject querySpecJson);
 
 
-    @Schema(name = "ConnectorParamsDiscoveryRequestSchema", example = ConnectorParamsDiscoveryRequestSchema.EXAMPLE)
+    @Schema(name = "ConnectorParamsDiscoveryRequest", example = ConnectorParamsDiscoveryRequestSchema.EXAMPLE)
     record ConnectorParamsDiscoveryRequestSchema(
             @Schema(name = CONTEXT, requiredMode = REQUIRED)
             Object context,
@@ -71,7 +71,7 @@ public interface ConnectorDiscoveryV4AlphaApi {
                 {
                     "@context": {
                         "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
-                        "edc": "https://w3id.org/edc/v0.0.1/ns/",
+                        "edc": "https://w3id.org/edc/v0.0.1/ns/"
                     },
                     "@type": "tx:ConnectorParamsDiscoveryRequest",
                     "tx:bpnl": "BPNL1234567890",


### PR DESCRIPTION
## WHAT

Removes an unnecessary trailing comma from an ConnectorDiscoveryV4AlphaAPI example.

## WHY

It was messing with formatting in the Swagger UI for that particular example.

## FURTHER NOTES

Closes #2262 
