### PR TITLE
docs: adds connector discovery walkthrough

### DIFF
--- a/docs/usage/management-api-walkthrough/04_catalog.md
+++ b/docs/usage/management-api-walkthrough/04_catalog.md
@@ -233,7 +233,7 @@ policies included.
 
 
 ## Reference
-- [Connector Discovery API](https://eclipse-tractusx.github.io/tractusx-edc/openapi/control-plane-api/0.11.0/#/Connector%20Discovery/discoverDspVersionParamsV4Alpha)
+- [Connector Discovery API](https://eclipse-tractusx.github.io/tractusx-edc/openapi/control-plane-api/#/Connector%20Discovery/discoverDspVersionParamsV4Alpha)
 
 ## Notice
 


### PR DESCRIPTION
## WHAT

Adds a page for connector version params discovery.

## WHY

The feature was introduced but documentation was missing.


Closes #2219 
