### PR TITLE
fix: draft-release workflow shouldn't be sensitive to casing

### DIFF
--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -45,7 +45,9 @@ jobs:
           fetch-depth: 0
       - id: validation
         name: "Validations"
+        shell: bash
         run: |
+          shopt -s nocasematch
           IFS=.- read -r MAJOR_INPUT MINOR_INPUT PATCH_INPUT SNAPSHOT_INPUT<<<"${{ inputs.version }}" 
 
           VERSION=$(grep "version" gradle.properties  | awk -F= '{print $2}')


### PR DESCRIPTION
## WHAT

This PR provides disabling case sensitivity for the draft-release workflow when checking the release version.

## WHY

To avoid dependence on sensitive cases

Closes #2295
