### PR TITLE
feat: ignore org.eclipse.dataspacetck.dsp/dcp by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,9 @@ updates:
       - "dependencies"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "org.eclipse.dataspacetck.dsp:*"
+      - dependency-name: "org.eclipse.dataspacetck.dcp:*"
 
   # Github Actions
   -
@@ -43,9 +46,6 @@ updates:
       - "github-actions"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "org.eclipse.dataspacetck.dsp:*"
-      - dependency-name: "org.eclipse.dataspacetck.dcp:*"
 
   # Docker
   - package-ecosystem: "docker"


### PR DESCRIPTION
## WHAT

This PR configures Dependabot to ignore dependencies for `org.eclipse.dataspacetck.dsp` and `org.eclipse.dataspacetck.dcp`.

## WHY

To avoid redundant pull requests for version updates, since the DCP_TCK and DSP_TCK versions must stay aligned with those used by the EDC Connector.

Closes #2314
