### PR TITLE
docs: fix openapi RetirementExample schema name (#2313)

### DIFF
--- a/edc-extensions/agreements/retirement-evaluation-api/src/main/java/org/eclipse/tractusx/edc/agreements/retirement/api/v3/AgreementsRetirementApiV3.java
+++ b/edc-extensions/agreements/retirement-evaluation-api/src/main/java/org/eclipse/tractusx/edc/agreements/retirement/api/v3/AgreementsRetirementApiV3.java
@@ -69,7 +69,7 @@ public interface AgreementsRetirementApiV3 {
     void retireAgreementV3(JsonObject entry);
 
 
-    @Schema(name = "Retirement Example", example = RetirementSchema.EXAMPLE)
+    @Schema(name = "RetirementExample", example = RetirementSchema.EXAMPLE)
     record RetirementSchema(
             @Schema(name = ID) String id,
             String reason


### PR DESCRIPTION
## WHAT

Fixes RetriementExample openapi schema name.

## WHY

Generating a Java client from the definition fails to the the space in the schema name.

Closes #2313 
