### PR TITLE
chore: Remove obsolete json ld contexts and publication of it

### DIFF
--- a/core/json-ld-core/src/main/resources/document/tx-v1.jsonld
+++ b/core/json-ld-core/src/main/resources/document/tx-v1.jsonld
@@ -1,9 +1,0 @@
-{
-  "@context": {
-    "@version": 1.1,
-    "@protected": true,
-    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
-    "BusinessPartnerNumber": "tx:BusinessPartnerNumber",
-    "BusinessPartnerGroup": "tx:BusinessPartnerGroup"
-  }
-}


### PR DESCRIPTION
## WHAT

The file core/json-ld-core/src/main/resources/document/tx-v1.jsonld is removed and the publication of it has stopped.

## WHY

The file core/json-ld-core/src/main/resources/document/tx-v1.jsonld became obsolete with the latest changes concerning policies.

Closes #2266
