### PR TITLE
docs: Update migration guide concerning policy changes

### DIFF
--- a/docs/migration/2025-09-Version_0.10.x_0.11.x.md
+++ b/docs/migration/2025-09-Version_0.10.x_0.11.x.md
@@ -131,7 +131,8 @@ Another impact on the new policies affects access policies, i.e., the policies i
 to filter catalog entries. Access policies are not in the scope of backward compatibility, i.e., an access policy never
 leaves the provider connector. As a consequence, in a connector of version 0.11.0, only policies according to CX-0152 on
 Saturn level are usable, old access policies are not evaluated correctly, i.e., a contract definition that uses such
-a policy will never be visible in a catalog.
+a policy will never be visible in a catalog. Be aware, that it is still possible to create Jupiter-level policies and
+to use them as access policies, as the contract definition creation does not block that.
 
 ### Impact on migration
 


### PR DESCRIPTION
## WHAT

The former section in the migration guide concerning policies was written prior to some important aspects becoming visible. I adapted the guide to give more support when involved in a migration from a Jupiter based connector to a Saturn based.

## WHY

To provide better guidance in necessary efforts required from someone who wants to transfer existing contract definitions to a Saturn based connector.

Closes #2380 