### PR TITLE
infra: Enable code coverage measurements

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -75,9 +75,44 @@ jobs:
       - uses: ./.github/actions/setup-java
 
       - name: Run Unit tests
-        run: ./gradlew test
+        run: ./gradlew test testCodeCoverage
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
+
+      # uploads the jacoco report as artifact
+      - name: Upload JaCoCo Coverage Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: JaCoCo coverage-report
+          path: build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+          retention-days: 1
+
+      # generates coverage-report.md
+      - name: JaCoCo Code Coverage Report
+        id: jacoco_reporter
+        uses: PavanMudigonda/jacoco-reporter@v5.0
+        with:
+          coverage_results_path: build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+          skip_check_run: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Publish Coverage Job Summary
+      - name: Output KPIs from JaCoCo report
+        run: |
+          echo "| Outcome | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
+          echo "| Code Coverage % | ${{ steps.jacoco_reporter.outputs.coverage_percentage }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| :heavy_check_mark: Number of Lines Covered | ${{ steps.jacoco_reporter.outputs.covered_lines }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| :x: Number of Lines Missed | ${{ steps.jacoco_reporter.outputs.missed_lines }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Total Number of Lines | ${{ steps.jacoco_reporter.outputs.total_lines }} |" >> $GITHUB_STEP_SUMMARY
+
+      # uploads the coverage-report.md artifact
+      - name: Upload Code Coverage Markdown Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report-markdown
+          path: "*/coverage-results.md"
+          retention-days: 1
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
     checkstyle
     `java-library`
     `maven-publish`
+    jacoco
     `jacoco-report-aggregation`
     `java-test-fixtures`
     alias(libs.plugins.shadow)
@@ -61,6 +62,7 @@ val edcBuildId = libs.plugins.edc.build.get().pluginId
 allprojects {
     apply(plugin = edcBuildId)
     apply(plugin = "org.eclipse.edc.autodoc")
+    apply(plugin = "jacoco")
 
     dependencies {
 


### PR DESCRIPTION
## WHAT

Add jacoco code coverage features to the gradle build
Add jacoco reporting to the verify Github Workflow

## WHY

To fulfil requirements from overall test management

Closes #1946
