### PR TITLE
fix: consider inForceDate constraint in legacy policy check

### DIFF
--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/LegacyPolicyCheck.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/validator/LegacyPolicyCheck.java
@@ -30,12 +30,13 @@ public class LegacyPolicyCheck {
     
     private static final String BPN_LEGACY_LEFT_OPERAND = "https://w3id.org/tractusx/v0.0.1/ns/BusinessPartnerNumber";
     private static final String BPN_GROUP_LEGACY_LEFT_OPERAND = "https://w3id.org/tractusx/v0.0.1/ns/BusinessPartnerGroup";
-    
+    private static final String IN_FORCE_DATE_LEGACY_LEFT_OPERAND = "https://w3id.org/edc/v0.0.1/ns/inForceDate";
+
     private LegacyPolicyCheck() {}
     
     /**
      * Checks whether a policy is a legacy policy. Returns true, if the legacy namespace is found
-     * or a legacy BPN constraint, which utilizes a different namespace.
+     * or a legacy BPN or inForceDate constraint, which utilizes a different namespace.
      *
      * @param policy the policy
      * @return true, if any legacy reference is encountered; false otherwise
@@ -46,7 +47,9 @@ public class LegacyPolicyCheck {
         if (json.contains(CX_POLICY_NS)) {
             return true;
         } else {
-            return json.contains(BPN_LEGACY_LEFT_OPERAND) || json.contains(BPN_GROUP_LEGACY_LEFT_OPERAND);
+            return json.contains(BPN_LEGACY_LEFT_OPERAND) ||
+                    json.contains(BPN_GROUP_LEGACY_LEFT_OPERAND) ||
+                    json.contains(IN_FORCE_DATE_LEGACY_LEFT_OPERAND);
         }
     }
     

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/LegacyPolicyCheckTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/validator/LegacyPolicyCheckTest.java
@@ -71,4 +71,14 @@ class LegacyPolicyCheckTest {
         
         assertThat(result).isTrue();
     }
+
+    @Test
+    void legacyInForceDateConstraint_shouldReturnTrue() {
+        var permission = rule(ACTION_USAGE, atomicConstraint("https://w3id.org/edc/v0.0.1/ns/inForceDate"));
+        var policy = policy(ODRL_PERMISSION_ATTRIBUTE, permission);
+
+        var result = LegacyPolicyCheck.isLegacy(policy);
+
+        assertThat(result).isTrue();
+    }
 }


### PR DESCRIPTION
## WHAT

Considers the legacy constraint `https://w3id.org/edc/v0.0.1/ns/inForceDate` in the `LegacyPolicyCheck`, as it was previously not regarded there.

## WHY

Backward compatibility

Closes #2384 
