### PR TITLE
chore: remove outdated context URL from JSON example

### DIFF
--- a/docs/usage/management-api-walkthrough/04_catalog.md
+++ b/docs/usage/management-api-walkthrough/04_catalog.md
@@ -73,7 +73,6 @@ Content-Type: application/json
 ```json
 {
   "@context": [
-    "https://w3id.org/catenax/2025/9/policy/context.jsonld",
     {
       "@vocab":"https://w3id.org/edc/v0.0.1/ns/"
     }


### PR DESCRIPTION
## WHAT

I have tried to follow the EDC walkthrough for the Catalog Request and it was failing as described here in this matrix chat thread:

https://matrix.to/#/!mYxOilDPMLCQhMoIVc:matrix.eclipse.org/$x7OqkuI8MfJQF4JOgoc9iX0MwBOpsmZB3duC__SWgR0?via=matrix.eclipse.org&via=matrix.org&via=eecc.de

I was getting something like this:

```json
[
    {
        "message": "mandatory value 'https://w3id.org/edc/v0.0.1/ns/querySpec/https://w3id.org/edc/v0.0.1/ns/filterExpression/https://w3id.org/edc/v0.0.1/ns/operator' is missing or it is blank",
        "type": "ValidationFailure",
        "path": "https://w3id.org/edc/v0.0.1/ns/querySpec/https://w3id.org/edc/v0.0.1/ns/filterExpression/https://w3id.org/edc/v0.0.1/ns/operator",
        "invalidValue": null
    
   }
]
```

It solves itself when doing the query without the odrl context.

## WHY

Needed to fix it.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
