### PR TITLE
fix: Make a draft release with a failed dependency check

### DIFF
--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -110,12 +110,6 @@ jobs:
       - name: Create Release branch
         run: git checkout -b ${{ needs.validate-and-prepare.outputs.branch_name }}
       - uses: ./.github/actions/setup-java
-      - name: Check dependencies before release
-        uses: ./.github/actions/generate-and-check-dependencies
-        with:
-          run: ${{ needs.validate-and-prepare.outputs.is_official_release == true && 'strict' || 'standard' }}
-      - name: Replace published DEPENDENCIES file link in NOTICE with the one just created
-        run: sed -i "s#\[DEPENDENCIES\]\(.*\)#\[DEPENDENCIES\]\(DEPENDENCIES\)#g" NOTICE.md
       - name: Version and Chart Updates
         uses: ./.github/actions/update-version-and-charts
         with:
@@ -123,3 +117,23 @@ jobs:
           bump_version: "false"
       - name: Push new branch
         run: git push origin ${{ needs.validate-and-prepare.outputs.branch_name }}
+      - name: Check dependencies before release
+        uses: ./.github/actions/generate-and-check-dependencies
+        with:
+          run: ${{ needs.validate-and-prepare.outputs.is_official_release == 'true' && 'strict' || 'standard' }}
+      - name: Replace published DEPENDENCIES file link in NOTICE with the one just created
+        run: sed -i "s#\[DEPENDENCIES\]\(.*\)#\[DEPENDENCIES\]\(DEPENDENCIES\)#g" NOTICE.md
+      - name: Commit DEPENDENCIES changes
+        shell: bash
+        run: |
+          if git diff --quiet -- DEPENDENCIES; then
+            echo "No changes in DEPENDENCIES, skipping commit."
+            exit 0
+          fi
+          
+          git add DEPENDENCIES
+          git config user.name "eclipse-tractusx-bot"
+          git config user.email "tractusx-bot@eclipse.org"
+          git commit --message "Update DEPENDENCIES file"
+          git push origin ${{ needs.validate-and-prepare.outputs.branch_name }}
+          echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/generate-and-publish-dependencies.yaml
+++ b/.github/workflows/generate-and-publish-dependencies.yaml
@@ -25,6 +25,7 @@ on:
   push:
     branches:
       - main
+      - release/*
 
 permissions:
   contents: write
@@ -35,15 +36,49 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-java
+      - name: Output release type
+        id: release_type
+        shell: bash
+        run: |
+          VERSION=$(grep "version" gradle.properties  | awk -F= '{print $2}')
+          IFS=.- read -r MAJOR MINOR PATCH SNAPSHOT<<<"$VERSION"
+          
+          if [[ ! -z $SNAPSHOT ]] then
+            echo "is_official_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_official_release=true" >> "$GITHUB_OUTPUT"
+          fi
       - uses: ./.github/actions/generate-and-check-dependencies
+        with:
+          run: ${{ steps.release_type.outputs.is_official_release == 'true' && 'strict' || 'standard' }}
       - name: Prepare to publish
+        if: ${{ github.ref_name == 'main' }}
         shell: bash
         run: |
           mkdir public
           cp DEPENDENCIES public/
       - name: Publish to GitHub Pages
+        if: ${{ github.ref_name == 'main' }}
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: public
           keep_files: true
+      - name: Replace published DEPENDENCIES file link in NOTICE with the one just created
+        if: ${{ startsWith(github.ref_name, 'release/') }}
+        run: sed -i "s#\[DEPENDENCIES\]\(.*\)#\[DEPENDENCIES\]\(DEPENDENCIES\)#g" NOTICE.md
+      - name: Commit DEPENDENCIES changes
+        if: ${{ startsWith(github.ref_name, 'release/') }}
+        shell: bash
+        run: |
+          if git diff --quiet -- DEPENDENCIES; then
+           echo "No changes in DEPENDENCIES, skipping commit."
+           exit 0
+          fi
+          
+          git add DEPENDENCIES
+          git config user.name "eclipse-tractusx-bot"
+          git config user.email "tractusx-bot@eclipse.org"
+          git commit --message "Update DEPENDENCIES file"
+          git push origin ${{ github.ref_name }}
+          echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## WHAT

This PR allows creating a branch for draft-release even if the dependency check fails.

## WHY
To make it possible to fix the dependency for a new release

## FURTHER NOTES

Workflow `generate-and-publish-dependencies.yaml` was extended to run also in a `release/*` branches.

Closes #2365