### PR TITLE
fix: OpenAPI spec - latest release

### DIFF
--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -123,6 +123,7 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.determine-version.outputs.VERSION }}
+      latest: false
 
   publish-latest-versioned-snapshot:
     name: "Publish latest versioned snapshot in GitHub Pages"

--- a/.github/workflows/publish-openapi-ui.yml
+++ b/.github/workflows/publish-openapi-ui.yml
@@ -28,6 +28,11 @@ on:
         required: false
         description: "Version of the Tractus-X EDC API to be should be published"
         type: string
+      latest:
+        description: "Latest release"
+        required: true
+        type: boolean
+        default: false
 
   workflow_call:
     inputs:
@@ -35,6 +40,11 @@ on:
         required: false
         description: "Version of the Tractus-X EDC API to be should be published"
         type: string
+      latest:
+        description: "Latest release"
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   generate-openapi-spec:
@@ -101,7 +111,7 @@ jobs:
 
       - name: Generate Swagger UI stable version
         uses: Legion2/swagger-ui-action@v1
-        if: ${{ !endsWith( env.VERSION, '-SNAPSHOT') }}
+        if: ${{ inputs.latest }}
         with:
           output: dist
           spec-file: ${{ matrix.apiGroup.name }}.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,12 @@ run-name: "Release from ${{ github.ref_name }}"
 
 on:
   workflow_dispatch:
+    inputs:
+      latest:
+        description: "Latest release"
+        required: true
+        type: boolean
+        default: false
 
 
 jobs:
@@ -165,7 +171,7 @@ jobs:
           generateReleaseNotes: true
           tag: ${{ needs.validation.outputs.RELEASE_VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          makeLatest: ${{ needs.validation.outputs.update_main_branch_version == 'true' }}
+          makeLatest: ${{ inputs.latest }}
           removeArtifacts: true
 
   # Release: Publish specs to GitHub Pages
@@ -178,6 +184,7 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.validation.outputs.RELEASE_VERSION }}
+      latest: ${{ inputs.latest }}
 
   # Release: Update Release Notes with Allure Report Link
   publish-allure-report-link-to-release:


### PR DESCRIPTION
## WHAT
This PR makes it possible to identify the latest release manually when running the `Release` workflow, and based on it generates OpenAPI spec.

## WHY
For better control of the `latest` in the release and OpenAPI spec.

## FURTHER NOTES

Closes #2382
