### PR TITLE
fix: add missing comma to dspace.jsonld

### DIFF
--- a/core/json-ld-core/src/main/resources/document/dspace.jsonld
+++ b/core/json-ld-core/src/main/resources/document/dspace.jsonld
@@ -55,7 +55,7 @@
     "odrl:leftOperand": { "@type": "@id" },
     "odrl:operator": { "@type": "@id" },
     "odrl:rightOperandReference": { "@type": "@id" },
-    "odrl:profile": { "@container": "@set" }
+    "odrl:profile": { "@container": "@set" },
     "odrl:assigner": { "@type": "@id" },
     "odrl:assignee": { "@type": "@id" }
   }


### PR DESCRIPTION
## WHAT

Added a missing comma to `dspace.jsonld`

## WHY

The JSONLD had wrong syntax

## FURTHER NOTES

Closes #2430 
