### PR TITLE
Propose small adaptations to migration guide for version 0.10.x to 0.11.x

### DIFF
--- a/docs/migration/2025-09-Version_0.10.x_0.11.x.md
+++ b/docs/migration/2025-09-Version_0.10.x_0.11.x.md
@@ -114,7 +114,7 @@ standard are handled by the DSP version 2025-1 support.
 
 A consequence of this is that a consumer sees both offers and has to decide based on his own capabilities (Jupiter or
 Saturn), which offer to negotiate for. The difference can be determined by the namespace used for defining the operands.
-A policy fulfilling the Jupiter standard will have a context binding like this:
+A policy fulfilling the Saturn standard CX-0152 will have a context binding like this:
 
 ```json
 {


### PR DESCRIPTION
## WHAT

Updated references to policy builder 
Adapted naming of usage policy valid in Jupiter

## WHY

Tractus-X policy builder is available. 
Reference to Saturn is more clear when reference to CX-0152

## FURTHER NOTES

none
