### PR TITLE
FIX: V0_0_1__Init_ContractNegotiation_Database_Schema.sql not being idempotent

### DIFF
--- a/edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/contractnegotiation/V0_0_1__Init_ContractNegotiation_Database_Schema.sql
+++ b/edc-extensions/migrations/control-plane-migration/src/main/resources/org/eclipse/tractusx/edc/postgresql/migration/contractnegotiation/V0_0_1__Init_ContractNegotiation_Database_Schema.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS edc_lease
 COMMENT ON COLUMN edc_lease.leased_at IS 'posix timestamp of lease';
 COMMENT ON COLUMN edc_lease.lease_duration IS 'duration of lease in milliseconds';
 
-CREATE UNIQUE INDEX lease_lease_id_uindex
+CREATE UNIQUE INDEX IF NOT EXISTS lease_lease_id_uindex
     ON edc_lease (lease_id);
 
 --


### PR DESCRIPTION
## WHAT

Adding idempotence to create of unique index "lease_lease_id_uindex"

## WHY

When starting control plane in combination with Identity Hub (IH) e.g. as MXD setup, IH may be faster with creating the index which causes the control plane to fail / not to start at all. 
