### PR TITLE
Add .env as pattern in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,5 @@ buildNumber.properties
 bin/
 
 edc-tests/miw-tests/src/test/resources/docker-environment/postgres_data/
+
+.env


### PR DESCRIPTION
## WHAT

As title says

## WHY

To be able to manage a local environment without exposing it to the repo
