### PR TITLE
Add all relevant versions of openapi specs to api-hub

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -2,5 +2,11 @@ product: "Tractus-X EDC"
 leadingRepository: "https://github.com/eclipse-tractusx/tractusx-edc"
 repositories: []
 openApiSpecs:
-- "https://eclipse-tractusx.github.io/tractusx-edc/openapi/control-plane-api/control-plane.yaml"
-- "https://eclipse-tractusx.github.io/tractusx-edc/openapi/data-plane-api/data-plane.yaml"
+- "https://eclipse-tractusx.github.io/tractusx-edc/openapi/control-plane-api/0.11.2/control-plane.yaml"
+- "https://eclipse-tractusx.github.io/tractusx-edc/openapi/data-plane-api/0.11.2/data-plane.yaml"
+- "https://eclipse-tractusx.github.io/tractusx-edc/openapi/control-plane-api/0.10.2/control-plane.yaml"
+- "https://eclipse-tractusx.github.io/tractusx-edc/openapi/data-plane-api/0.10.2/data-plane.yaml"
+- "https://eclipse-tractusx.github.io/tractusx-edc/openapi/control-plane-api/0.9.0/control-plane.yaml"
+- "https://eclipse-tractusx.github.io/tractusx-edc/openapi/data-plane-api/0.9.0/data-plane.yaml"
+- "https://eclipse-tractusx.github.io/tractusx-edc/openapi/control-plane-api/0.8.1/control-plane.yaml"
+- "https://eclipse-tractusx.github.io/tractusx-edc/openapi/data-plane-api/0.8.1/data-plane.yaml"


### PR DESCRIPTION
## WHAT

Add the openapi spec of older versions of the connector to the api-hub.

## WHY

To support usage of older versions of the connector for development of solutions
