### PR TITLE
docs: Add decision record for DID document based connector discovery

### DIFF
--- a/docs/development/decision-records/2026-01-06_service_retrieval_from_did_document/README.md
+++ b/docs/development/decision-records/2026-01-06_service_retrieval_from_did_document/README.md
@@ -3,10 +3,9 @@
 ## Decision
 
 We will implement an additional endpoint in the connector discovery endpoint family. The endpoint will, based on a
-DID retrieves the DID document, parses the service section for `DataService` entries, and retrieves for the detected
-connector endpoints the dsp version parameters. It returns a list of version parameter sets one for each found connector
-in the DID document. There will be a general support for other identifiers, using BPNLs as a second supported
-identifier type.
+DID, extract the connector endpoints from a DID document and determine the right dsp version parameters for each
+found connector. These parameters are returned in a list. There will be a general support for other identifiers,
+using BPNLs as a second supported identifier type.
 
 ## Rationale
 
@@ -44,7 +43,7 @@ called `/connectors` in this management api section that takes the following inp
 }
 ```
 
-The `counterPartId` field is type-neutral, in order to support different identifier types. The service will interpret
+The `counterPartyId` field is type-neutral, in order to support different identifier types. The service will interpret
 the identifier based on properties of the identifier, for now, DIDs and BPNLs will be supported. The mechanism
 will be implemented in an extensible fashion, so that a general mapping from any identifier to a DID can be added.
 The default implementation will detect DIDs and map them to themselves. A second extension will allow to handle


### PR DESCRIPTION
## WHAT

A decision record, that describes the solution for the distributed connector discovery based on the `DataService` entries in the DID document of a provider. 

## WHY

To prevent the need for applications to implement the logic of DID document processing and to bring this together in a support functionality provided by the connector.

Relates to #2461
