### PR TITLE
fix: add scaling considerations to self registration DR

### DIFF
--- a/docs/development/decision-records/2025-11-27-did-service-registration/README.md
+++ b/docs/development/decision-records/2025-11-27-did-service-registration/README.md
@@ -22,44 +22,35 @@ to avoid creating duplicate `service` entries and manage itself.
 
 1. Introduce configuration options in application and helm chart.
 2. Create a new SPI including an interface that represents the feature in an abstract manner.
-3. An extension that implements the SPI's interface as client for [SAP DIV's write endpoint to the did document](https://api.sap.com/api/DIV/path/CompanyIdentityV2HttpController_updateCompanyIdentity_v2.0.0).
-4. Another extension that will implement the lifecycle management logic.
+3. Add an extension that will implement the lifecycle management logic.
+4. Another extension implements the SPI's interface as client for [SAP DIV's write endpoint to the did document](https://api.sap.com/api/DIV/path/CompanyIdentityV2HttpController_updateCompanyIdentity_v2.0.0).
 
-The lifecycle management logic shall look like:
+The lifecycle management logic is designed to ensure functional correctness while limiting outbound HTTP traffic on 
+startup. It shall behave acoording to the following diagram:
 
 ```mermaid
 flowchart TD
     J@{ shape: stadium, label: "Terminal point" }
     A@{ shape: circle, label: "Connector</br>starts up" }
     A --> H{reg-enabled}
-    H -->|false| J
-    H -->|true,id| B{id already<br/>exists?}
-    B --> |true| C{same url?}
-    B --> |false| F[add to did doc]
-    C -->|true| D[do nothing]
-    C -->|false| E[update existing entry with URL]
-    D -->|shutdown| G{dereg-enabled}
-    E -->|shutdown| G
-    F -->|shutdown| G
+    H -->|false| G
+    H -->|true</br>serves id and url| E[delete and recreate existing entry with URL]
+    E -->|shutdown| G{dereg-enabled}
     G -->|true| K[deregister]
     K --> J
     G -->|false| J
 ```
 
-The SPI will look something like
+The SPI will look like
 
 ```java
 
-public interface DidServiceClient {
+public interface DidDocumentServiceClient {
 
-    void createService(String id, String urlOfWellKnown);
+    ServiceResult<Void> update(Service service);
     
-    void updateService(String id, String urlOfWellKnown);
-    
-    void deleteService(String id);
-    
+    ServiceResult<Void> deleteById(String id);
 }
-
 ```
 
 ## Scaling considerations
@@ -73,7 +64,7 @@ The container image should receive two new environment variables:
 - `TX_EDC_DID_SERVICE_SELF_REGISTRATION_ENABLED` (labeled *reg-enabled* in flowchart)
 - `TX_EDC_DID_SERVICE_SELF_DEREGISTRATION_ENABLED` (labeled *dereg-enabled* in flowchart)
 
-At the same time, requiring an admin to consider this when deploying the helm chart is unrealistic. That's why the
+At the same time, requiring an admin to consider this when deploying the helm chart is burdensome. That's why the
 values yaml should look like:
 
 ```yaml
@@ -93,6 +84,9 @@ by inspecting the scaling configuration like:
 - name: "TX_EDC_DID_SERVICE_SELF_DEREGISTRATION_ENABLED"
   value: {{ and (eq .Values.controlplane.replicacount 1) (not .Values.controlplane.autoscaling.enabled) }}
 ```
+
+Disabling deregistration in the non-scaled case (`!controlplane.autoscaling.enabled` and `controlplane.replicacount==1`)
+they can set `TX_EDC_DID_SERVICE_SELF_DEREGISTRATION_ENABLED=false` in the map `controlplane.env`.
 
 This approach may result in dangling references from the did document to dead endpoints. Cleanup of those lies outside
 tractusx-edc responsibility and should be done on the DID service directly. This state is more desirable than having 


### PR DESCRIPTION
## WHAT

Appends to the DR made prior to the implementation of the did service self-registration feature.

## WHY

The DR didn't consider scenarios horizontally scaled pods shut down while leaving the endpoint (like a kubernetes service) intact.

## FURTHER NOTES

Relates #2509 