### PR TITLE
fix: clear lease table before applying lease migrations

### DIFF
--- a/edc-extensions/migrations/connector-migration/src/main/resources/migrations/connector/V1_1_0__Lease_Fix.sql
+++ b/edc-extensions/migrations/connector-migration/src/main/resources/migrations/connector/V1_1_0__Lease_Fix.sql
@@ -4,7 +4,7 @@ ALTER TABLE edc_data_plane_instance DROP CONSTRAINT data_plane_instance_lease_id
 ALTER TABLE edc_policy_monitor DROP CONSTRAINT policy_monitor_lease_lease_id_fk;
 ALTER TABLE edc_transfer_process DROP CONSTRAINT transfer_process_lease_lease_id_fk;
 
-DELETE FROM edc_lease WHERE lease_id IS NULL;
+DELETE FROM edc_lease;
 
 ALTER TABLE edc_lease
     ADD COLUMN resource_id varchar NOT NULL,


### PR DESCRIPTION
## WHAT

Clear the `edc_lease` in its entirety before applying migration

## WHY

if any rows remains in the table there will be an exception in migrations given by the addition of the 2 `NON NULL` columns 

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #2520
