### PR TITLE
fix: PULL request body processing

### DIFF
--- a/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/api/controller/ContainerRequestContextApiImpl.java
+++ b/edc-extensions/dataplane/dataplane-proxy/dataplane-public-api-v2/src/main/java/org/eclipse/tractusx/edc/dataplane/proxy/api/controller/ContainerRequestContextApiImpl.java
@@ -24,9 +24,7 @@ import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.spi.EdcException;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -63,8 +61,8 @@ public class ContainerRequestContextApiImpl implements ContainerRequestContextAp
 
     @Override
     public String body() {
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(context.getEntityStream()))) {
-            return br.lines().collect(Collectors.joining("\n"));
+        try {
+            return new String(context.getEntityStream().readAllBytes());
         } catch (IOException e) {
             throw new EdcException("Failed to read request body: " + e.getMessage());
         }


### PR DESCRIPTION
## WHAT

Changes the way that bodies sent via a PULL request are processed.

## WHY

The previous implementation  stripped carriage returns from the body making it impossible to use for multipart bodies.

## FURTHER NOTES

Closes #2410
