### PR TITLE
Fix OpenApi spec for connector discovery

### DIFF
--- a/edc-extensions/connector-discovery/connector-discovery-api/src/main/java/org/eclipse/tractusx/edc/discovery/v4alpha/api/ConnectorDiscoveryV4AlphaApi.java
+++ b/edc-extensions/connector-discovery/connector-discovery-api/src/main/java/org/eclipse/tractusx/edc/discovery/v4alpha/api/ConnectorDiscoveryV4AlphaApi.java
@@ -153,11 +153,11 @@ public interface ConnectorDiscoveryV4AlphaApi {
                         "edc": "https://w3id.org/edc/v0.0.1/ns/",
                         "tx": "https://w3id.org/tractusx/v0.0.1/ns/"
                     },
-                    "@type": "tx:ConnectorParamsDiscoveryRequest",
+                    "@type": "tx:ConnectorServiceDiscoveryRequest",
                     "edc:counterPartyId": "did:web:one-example.com",
                     "tx:knownConnectors": [
                         "https://provider.domain.com/conn1/api/dsp",
-                        "https://provider.domain.com/conn2/api/v1/dsp",
+                        "https://provider.domain.com/conn2/api/v1/dsp"
                     ]
                 }
                 """;


### PR DESCRIPTION
## WHAT

The OpenApi spec did not show the example properly, because it could not detect the structure. I hope, this fixes the issue

## WHY

Because it is ugly

