### PR TITLE
Fix JSON-LD registrations for management api

### DIFF
--- a/core/json-ld-core/build.gradle.kts
+++ b/core/json-ld-core/build.gradle.kts
@@ -27,5 +27,6 @@ dependencies {
     implementation(libs.edc.spi.jsonld)
     implementation(libs.dsp.spi.v2025)
     implementation(libs.dsp.spi.v08)
+    implementation(libs.edc.lib.management.api)
     testImplementation(testFixtures(libs.edc.junit))
 }

--- a/core/json-ld-core/src/main/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtension.java
+++ b/core/json-ld-core/src/main/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtension.java
@@ -34,6 +34,7 @@ import java.util.Map;
 
 import static java.lang.String.format;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp08Constants.DSP_SCOPE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_SCOPE_V_2025_1;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
@@ -81,6 +82,9 @@ public class JsonLdExtension implements ServiceExtension {
         jsonLdService.registerContext(TX_AUTH_CONTEXT, DSP_SCOPE_V_2025_1);
         jsonLdService.registerContext(CX_POLICY_2025_09_CONTEXT, DSP_SCOPE_V_2025_1);
         jsonLdService.registerContext(CX_ODRL_CONTEXT, DSP_SCOPE_V_2025_1);
+
+        jsonLdService.registerContext(TX_AUTH_CONTEXT, MANAGEMENT_SCOPE);
+        jsonLdService.registerContext(CX_POLICY_2025_09_CONTEXT, MANAGEMENT_SCOPE);
 
         FILES.entrySet().stream().map(this::mapToFile)
                 .forEach(result -> result.onSuccess(entry -> jsonLdService.registerCachedDocument(entry.getKey(), entry.getValue().toURI()))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,7 +86,6 @@ edc-core-token = { module = "org.eclipse.edc:token-core", version.ref = "edc" }
 edc-controlplane-callback-staticendpoint = { module = "org.eclipse.edc:callback-static-endpoint", version.ref = "edc" }
 edc-junit = { module = "org.eclipse.edc:junit", version.ref = "edc" }
 edc-api-core = { module = "org.eclipse.edc:api-core", version.ref = "edc" }
-edc-api-management-dataplaneselector = { module = "org.eclipse.edc:data-plane-selector-api", version.ref = "edc" }
 edc-api-management-config = { module = "org.eclipse.edc:management-api-configuration", version.ref = "edc" }
 edc-api-management = { module = "org.eclipse.edc:management-api", version.ref = "edc" }
 edc-api-management-test-fixtures = { module = "org.eclipse.edc:management-api-test-fixtures", version.ref = "edc" }
@@ -109,6 +108,7 @@ edc-lib-boot = { module = "org.eclipse.edc:boot-lib", version.ref = "edc" }
 edc-lib-cryptocommon = { module = "org.eclipse.edc:crypto-common-lib", version.ref = "edc" }
 edc-lib-http = { module = "org.eclipse.edc:http-lib", version.ref = "edc" }
 edc-lib-jersey-providers = { module = "org.eclipse.edc:jersey-providers-lib", version.ref = "edc" }
+edc-lib-management-api = { module = "org.eclipse.edc:management-api-lib", version.ref = "edc" }
 edc-lib-jws2020 = { module = "org.eclipse.edc:jws2020-lib", version.ref = "edc" }
 edc-lib-query = { module = "org.eclipse.edc:query-lib", version.ref = "edc" }
 edc-lib-store = { module = "org.eclipse.edc:store-lib", version.ref = "edc" }


### PR DESCRIPTION
## WHAT

In a switch that happened between 0.10 and 0.11, the registration of json-ld contexts and namespaces has been changed to be scoped, but the registrations for the management api scope were omitted, this results in issues during compacting of json-ld objects

## WHY

To fix the compacting issues


Closes #2577 