### PR TITLE
Switch tx-auth in management scope to namespace

### DIFF
--- a/core/json-ld-core/src/main/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtension.java
+++ b/core/json-ld-core/src/main/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtension.java
@@ -83,7 +83,7 @@ public class JsonLdExtension implements ServiceExtension {
         jsonLdService.registerContext(CX_POLICY_2025_09_CONTEXT, DSP_SCOPE_V_2025_1);
         jsonLdService.registerContext(CX_ODRL_CONTEXT, DSP_SCOPE_V_2025_1);
 
-        jsonLdService.registerContext(TX_AUTH_CONTEXT, MANAGEMENT_SCOPE);
+        jsonLdService.registerNamespace(TX_AUTH_PREFIX, TX_AUTH_NS, MANAGEMENT_SCOPE);
         jsonLdService.registerContext(CX_POLICY_2025_09_CONTEXT, MANAGEMENT_SCOPE);
 
         FILES.entrySet().stream().map(this::mapToFile)

--- a/docs/migration/2026_03-Version_0.11.x_0.12.x.md
+++ b/docs/migration/2026_03-Version_0.11.x_0.12.x.md
@@ -13,8 +13,9 @@ This document is not a comprehensive feature list.
     * [Discovery of Connectors](#discovery-of-connectors)
     * [Changed Param Discovery Request Body](#changed-param-discovery-request-body)
   * [2. Participant ID](#2-participant-id)
-  * [3. Verifiable Presentation Caching](#3-verifiable-presentation-caching)
-  * [4. Deprecated instances](#4-deprecated-instances)
+  * [3. Changed behavior for old policies](#3-changed-behavior-for-old-policies)
+  * [4. Verifiable Presentation Caching](#4-verifiable-presentation-caching)
+  * [5. Deprecated instances](#5-deprecated-instances)
 <!-- TOC -->
 
 ## 1. Connector Discovery
@@ -101,7 +102,34 @@ as segment to make it usable for a tenant id later on.
 
 Note, that the connector contains a code segment that prevents starting a connector, if the identifier is not set.
 
-## 3. Verifiable Presentation Caching
+## 3. Changed behavior for old policies
+
+There is a change when old policies are compacted in a response from the management api. The behavior in 0.12.0 is
+breaking in contrast to Jupiter versions 0.10.x and earlier. The issue is, that with the redefinition of the policies,
+the prefix json-ld `cx-policy` has been redefined for the new policies.
+
+When creating an old policy at the management api, nothing changes, as you control the json-ld namespace, i.e., by using
+
+```json
+{
+  "@context": {
+    "cx-policy": "https://w3id.org/catenax/policy/"
+  }
+}
+```
+
+You still can refer to old policy terms in this way `cx-policy:UsagePurpose`. The issue is, that in the other direction,
+when requesting a policy via the management api, the connector cannot compact anymore to `cx-policy:Usage-Purpose`
+because in that direction, due to a breaking change in the Catena-X standardization, the prefix `cx-policy` is bound
+to `https://w3id.org/catenax/2025/9/policy/`.
+
+Due to a bug in 0.11.0 json-ld compacting is not done for Catena-X specifics in the management api, so 0.11.0 already has
+breaking behavior in comparison with 0.10.x and earlier. In 0.12.0, we fix these deviations, but for old policies,
+based on the `https://w3id.org/catenax/policy/` namespace, we cannot provide a solution, i.e., these terms in responses
+from the management api will always be fully expanded. This is the only solution, that does not add a breaking change
+on the level of json-ld, but a pure json based handling of responses will see unavoidable differences. 
+
+## 4. Verifiable Presentation Caching
 
 A new feature in the connector allows to cache verifiable presentations requested from the wallet to reduce the amount
 of requests to the consumer wallet and to improve processing time. The feature as such is switchable, using the
@@ -120,7 +148,8 @@ iatp:
     validity: 86400
 ```
 
-## 4. Deprecated instances
+## 5. Deprecated instances
+
 The `Data Plane Selector Configuration Extension` has been removed, as it has been deprecated since version 0.7.2.
 Additionally, several configuration parameters deprecated since version 0.7.x have also been removed. 
 Please use the updated configuration parameters instead.


### PR DESCRIPTION
## WHAT

Instead of registering a context for tx-auth, this change switches to registering a namespace, so that compacting results in
a prefixed version of the json element.

## WHY

The context based solution introduced a breaking issue, as a pure json based parsing of a response containing elements defined in tx-auth would miss the prefixes in the corresponding elements. With using namespaces, the behavior is as it was before in connector version 0.10.0 and earlier.

Closes #2577