### PR TITLE
Switch snapshot dependencies for tck helper to release

### DIFF
--- a/edc-tests/runtime/runtime-dsp/build.gradle.kts
+++ b/edc-tests/runtime/runtime-dsp/build.gradle.kts
@@ -26,7 +26,6 @@ plugins {
 dependencies {
     implementation(project(":edc-tests:runtime:runtime-postgresql"))
     runtimeOnly(libs.tck.extension)
-    runtimeOnly(libs.tck.lib)
 }
 
 application {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ format.version = "1.1"
 
 [versions]
 edc = "0.15.1"
+edc-next = "0.16.0"
 edc-build = "1.1.6"
 allure = "2.32.0"
 awaitility = "4.3.0"
@@ -169,8 +170,7 @@ dsp-tck-catalog = { module = "org.eclipse.dataspacetck.dsp:dsp-catalog", version
 dsp-tck-contractnegotiation = { module = "org.eclipse.dataspacetck.dsp:dsp-contract-negotiation", version.ref = "dsp-tck" }
 dsp-tck-transferprocess = { module = "org.eclipse.dataspacetck.dsp:dsp-transfer-process", version.ref = "dsp-tck" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
-tck-extension = { module = "org.eclipse.edc:tck-extension", version = "0.16.0-20260206-SNAPSHOT" }
-tck-lib = { module = "org.eclipse.edc:tck-lib", version = "0.16.0-20260206-SNAPSHOT" }
+tck-extension = { module = "org.eclipse.edc:tck-extension", version.ref = "edc-next" }
 
 # DSP libraries
 dsp-spi-http = { module = "org.eclipse.edc:dsp-http-spi", version.ref = "edc" }


### PR DESCRIPTION
## WHAT

We had to switch to a 0.16.0-SNAPSHOT version due to the participant id not properly supported in earlier versions, with release 0.16.0 we can refer to the release again.

## WHY

To prevent instabilities due to a snapshot dependency

