### PR TITLE
fix: Exclude Upstream Transitive Dependency data-plane-util

### DIFF
--- a/edc-dataplane/edc-dataplane-base/build.gradle.kts
+++ b/edc-dataplane/edc-dataplane-base/build.gradle.kts
@@ -23,6 +23,10 @@ plugins {
     id(libs.plugins.swagger.get().pluginId)
 }
 
+configurations.all {
+    exclude(group = "org.eclipse.edc", module = "data-plane-util")
+}
+
 dependencies {
     runtimeOnly(libs.edc.bom.dataplane.base)
 


### PR DESCRIPTION
## WHAT
- Exclude Upstream Transitive Dependency data-plane-util

## WHY


## FURTHER NOTES

Closes #2610 