### PR TITLE
docs: update catalog api walkthrough docs

### DIFF
--- a/docs/migration/2026_03-Version_0.11.x_0.12.x.md
+++ b/docs/migration/2026_03-Version_0.11.x_0.12.x.md
@@ -15,7 +15,8 @@ This document is not a comprehensive feature list.
   * [2. Participant ID](#2-participant-id)
   * [3. Changed behavior for old policies](#3-changed-behavior-for-old-policies)
   * [4. Verifiable Presentation Caching](#4-verifiable-presentation-caching)
-  * [5. Deprecated instances](#5-deprecated-instances)
+  * [5. Catalog response changes](#5-catalog-response-changes)
+  * [6. Deprecated instances](#6-deprecated-instances)
 <!-- TOC -->
 
 ## 1. Connector Discovery
@@ -148,7 +149,15 @@ iatp:
     validity: 86400
 ```
 
-## 5. Deprecated instances
+## 5. Catalog response changes
+
+Starting with version 0.11.0, the catalog response returned by `/v3/catalog/request` was changed 
+(see [walkthrough](../../docs/usage/management-api-walkthrough/04_catalog.md)). Each `distribution` entry now exposes its `format` 
+as a simple string (for example `AzureStorage-PUSH`, `HttpData-PULL`, `AmazonS3-PUSH`), and the top-level service attribute 
+is an array of `DataService` objects instead of a single object. This representation is emitted for DSP2025-1 catalogs and 
+should be expected by clients. The legacy structure is still emitted only when interacting with DSP0.8 connectors for backward compatibility.
+
+## 6. Deprecated instances
 
 The `Data Plane Selector Configuration Extension` has been removed, as it has been deprecated since version 0.7.2.
 Additionally, several configuration parameters deprecated since version 0.7.x have also been removed. 

--- a/docs/usage/management-api-walkthrough/04_catalog.md
+++ b/docs/usage/management-api-walkthrough/04_catalog.md
@@ -169,7 +169,7 @@ The returned payload is a `dcat:Catalog` as specified by the DSP version used in
     "@type": "Dataset",
     "hasPolicy": {
       "@id": "MQ==:MQ==:M2ZmZDRhY2MtMzkyNy00NGI4LWJlZDItNDcwY2RiZGRjN2Ex",
-      "@type": "odrl:Offer",
+      "@type": "Offer",
       "permission": {
         "action": "use",
         "constraint": {
@@ -183,51 +183,47 @@ The returned payload is a `dcat:Catalog` as specified by the DSP version used in
     },
     "distribution": [
       {
-        "@type": "dcat:Distribution",
-        "format": {
-          "@id": "AzureStorage-PUSH"
-        },
+        "@type": "Distribution",
+        "format": "AzureStorage-PUSH",
         "accessService": {
           "@id": "1338f9ac-1728-4a7e-b3dc-31fe5bc109f6",
           "@type": "DataService",
-          "terms": "connector",
-          "endpointUrl": "https://provider.domain.com/api/v1/dsp/2025-1"
-        }
-      },
-      {
-        "@type": "dcat:Distribution",
-        "format": {
-          "@id": "HttpData-PULL"
-        },
-        "accessService": {
-          "@id": "1338f9ac-1728-4a7e-b3dc-31fe5bc109f6",
-          "@type": "DataService",
-          "terms": "connector",
-          "endpointUrl": "https://provider.domain.com/api/v1/dsp/2025-1"
+          "endpointDescription": "dspace:connector",
+          "endpointURL": "https://provider.domain.com/api/v1/dsp/2025-1"
         }
       },
       {
         "@type": "Distribution",
-        "format": {
-          "@id": "AmazonS3-PUSH"
-        },
+        "format": "HttpData-PULL",
         "accessService": {
           "@id": "1338f9ac-1728-4a7e-b3dc-31fe5bc109f6",
-          "@type": "dcat:DataService",
-          "terms": "connector",
-          "endpointUrl": "https://provider.domain.com/api/v1/dsp/2025-1"
+          "@type": "DataService",
+          "endpointDescription": "dspace:connector",
+          "endpointURL": "https://provider.domain.com/api/v1/dsp/2025-1"
+        }
+      },
+      {
+        "@type": "Distribution",
+        "format":"AmazonS3-PUSH",
+        "accessService": {
+          "@id": "1338f9ac-1728-4a7e-b3dc-31fe5bc109f6",
+          "@type": "DataService",
+          "endpointDescription": "dspace:connector",
+          "endpointURL": "https://provider.domain.com/api/v1/dsp/2025-1"
         }
       }
     ],
     "description": "Product Connector Demo Asset 1",
     "id": "1"
   },
-  "service": {
-    "@id": "1338f9ac-1728-4a7e-b3dc-31fe5bc109f6",
-    "@type": "dcat:DataService",
-    "terms": "connector",
-    "endpointUrl": "https://provider.domain.com/api/v1/dsp/2025-1"
-  },
+  "service": [
+    {
+        "@id": "1338f9ac-1728-4a7e-b3dc-31fe5bc109f6",
+        "@type": "DataService",
+        "endpointDescription": "dspace:connector",
+        "endpointURL": "https://provider.domain.com/api/v1/dsp/2025-1"
+    }
+  ],
   "@context": [
     "https://w3id.org/tractusx/auth/v1.0.0",
     "https://w3id.org/catenax/2025/9/policy/context.jsonld",


### PR DESCRIPTION
## WHAT

This PR updated the catalog api walkthrough docs and migration notes

## WHY

To keep the documentation up-to-date.

Closes #2619
