### PR TITLE
chore: deprecate C-X ODRL context

### DIFF
--- a/core/json-ld-core/src/main/resources/document/edc-v1.jsonld
+++ b/core/json-ld-core/src/main/resources/document/edc-v1.jsonld
@@ -13,7 +13,7 @@
       "@id": "edc:policy",
       "@type": "@id",
       "@context": [
-        "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+        "https://w3id.org/dspace/2025/1/odrl-profile.jsonld"
       ]
     },
     "createdAt": "edc:createdAt",

--- a/core/json-ld-cx/src/main/java/org/eclipse/tractusx/edc/cx/CxJsonLdExtension.java
+++ b/core/json-ld-cx/src/main/java/org/eclipse/tractusx/edc/cx/CxJsonLdExtension.java
@@ -41,6 +41,7 @@ public class CxJsonLdExtension implements ServiceExtension {
 
     @Deprecated(since = "0.11.0")
     public static final String CX_POLICY_CONTEXT = "https://w3id.org/tractusx/policy/v1.0.0";
+    @Deprecated(since = "0.12.0")
     public static final String CX_ODRL_CONTEXT = "https://w3id.org/catenax/2025/9/policy/odrl.jsonld";
     public static final String CX_POLICY_2025_09_CONTEXT = "https://w3id.org/catenax/2025/9/policy/context.jsonld";
 
@@ -59,7 +60,6 @@ public class CxJsonLdExtension implements ServiceExtension {
         jsonLdService.registerNamespace(CX_POLICY_PREFIX, CX_POLICY_NS, DSP_SCOPE_V_08);
 
         jsonLdService.registerContext(CX_POLICY_2025_09_CONTEXT, DSP_SCOPE_V_2025_1);
-        jsonLdService.registerContext(CX_ODRL_CONTEXT, DSP_SCOPE_V_2025_1);
 
         jsonLdService.registerContext(CX_POLICY_2025_09_CONTEXT, MANAGEMENT_SCOPE);
 

--- a/docs/usage/management-api-walkthrough/02_policies.md
+++ b/docs/usage/management-api-walkthrough/02_policies.md
@@ -9,13 +9,13 @@ The `Policy` object is extensible. EDC generally follows the subset that
 the [Dataspace Protocol](https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1/message/schema/contract-schema.json#/definitions/Policy)
 has selected from [ODRL](https://www.w3.org/TR/odrl-model/#policy).
 
-| Variable                                                                   | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-|----------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `@context`                                                                 | In JSON-LD, `@context` is a fundamental concept used to define the mapping of terms used within the JSON-LD document to specific IRIs (Internationalized Resource Identifiers). It provides a way to establish a shared understanding of the vocabulary used in a JSON-LD document, making it possible to create structured and semantically rich data that can be easily integrated with other data sources on the web. You can choose to bind prefixes to namespaces manually via json properties. However, importing existing remote contexts like `"@context":[ "https://w3id.org/catenax/2025/9/policy/odrl.jsonld" ]` is usually less error-prone and strongly encouraged by the examples. |
-| `policy`.`@type`                                                           | `@type` is a property in every json-ld object that describes which class it belongs to. In this context, the only accepted value is `Set`. `Set` is aimed at scenarios where there is an open criteria for the semantics of the policy expressions.                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `policy`.`permission`<br/>`policy`.`obligation`<br/>`policy`.`prohibition` | These properties define the context of what may, may not under which condition be done with the Dataset in question.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `policy`.`permission/oblication/prohibition`.`action`                      | Currently only the actions "use" (reused from ODRL) and "access" (specific to Catena-X) are conventions in the Dataspace. In the context of tractusx-edc, `action` should only be used for access policies and `use` should only be used for usage policies in a [`ContractDefinition`](./03_contractdefinitions.md).                                                                                                                                                                                                                                                                                                                                                                            |
-| `policy`.`permission/oblication/prohibition`.`constraint`                  | A list of `Constraint` objects that each represent a boolean/logical expression. It binds an `action` to certain rules. The `leftOperand` instances must clearly be defined to indicate the semantics of the `Constraint`. In Catena-X, some `leftOperand`s of a `Constraint` are associated with a check on specific verifiable credentials (VC). As most are use-case-agreements, [this notation](https://github.com/eclipse-tractusx/tractusx-profiles/blob/main/cx/policy/specs/policy.mapping.md) is useful. **Right Operand:** The rightOperand is the value of the Constraint that is to be compared to the leftOperand.                                                                  |
+| Variable                                                                   | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+|----------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `@context`                                                                 | In JSON-LD, `@context` is a fundamental concept used to define the mapping of terms used within the JSON-LD document to specific IRIs (Internationalized Resource Identifiers). It provides a way to establish a shared understanding of the vocabulary used in a JSON-LD document, making it possible to create structured and semantically rich data that can be easily integrated with other data sources on the web. You can choose to bind prefixes to namespaces manually via json properties. However, importing existing remote contexts like `"@context":[ "https://w3id.org/dspace/2025/1/odrl-profile.jsonld" ]` is usually less error-prone and strongly encouraged by the examples.   |
+| `policy`.`@type`                                                           | `@type` is a property in every json-ld object that describes which class it belongs to. In this context, the only accepted value is `Set`. `Set` is aimed at scenarios where there is an open criteria for the semantics of the policy expressions.                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `policy`.`permission`<br/>`policy`.`obligation`<br/>`policy`.`prohibition` | These properties define the context of what may, may not under which condition be done with the Dataset in question.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `policy`.`permission/oblication/prohibition`.`action`                      | Currently only the actions "use" (reused from ODRL) and "access" (specific to Catena-X) are conventions in the Dataspace. In the context of tractusx-edc, `action` should only be used for access policies and `use` should only be used for usage policies in a [`ContractDefinition`](./03_contractdefinitions.md).                                                                                                                                                                                                                                                                                                                                                            |
+| `policy`.`permission/oblication/prohibition`.`constraint`                  | A list of `Constraint` objects that each represent a boolean/logical expression. It binds an `action` to certain rules. The `leftOperand` instances must clearly be defined to indicate the semantics of the `Constraint`. In Catena-X, some `leftOperand`s of a `Constraint` are associated with a check on specific verifiable credentials (VC). As most are use-case-agreements, [this notation](https://github.com/eclipse-tractusx/tractusx-profiles/blob/main/cx/policy/specs/policy.mapping.md) is useful. **Right Operand:** The rightOperand is the value of the Constraint that is to be compared to the leftOperand.                                                  |
 
 ## Policies in Catena-X
 
@@ -107,7 +107,7 @@ Content-Type: application/json
 ```json
 {
   "@context": [
-    "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
+    "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
     "https://w3id.org/catenax/2025/9/policy/context.jsonld",
     {
       "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
@@ -203,7 +203,7 @@ Agreement. The signing of the Agreement should be checked at the time of contrac
 ```json
 {
   "@context": [
-    "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
+    "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
     "https://w3id.org/catenax/2025/9/policy/context.jsonld",
     {
       "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
@@ -232,7 +232,7 @@ Agreement. The signing of the Agreement should be checked at the time of contrac
 ```json
 {
   "@context": [
-    "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
+    "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
     "https://w3id.org/catenax/2025/9/policy/context.jsonld",
     {
       "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
@@ -272,7 +272,7 @@ DismantlerCredential").
 ```json
 {
   "@context": [
-    "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
+    "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
     "https://w3id.org/catenax/2025/9/policy/context.jsonld",
     {
       "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
@@ -301,7 +301,7 @@ DismantlerCredential").
 ```json
 {
   "@context": [
-    "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
+    "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
     "https://w3id.org/catenax/2025/9/policy/context.jsonld",
     {
       "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
@@ -344,7 +344,7 @@ that the Connector interprets policies it can't evaluate as true by default. A c
 ```json
 {
   "@context": [
-    "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
+    "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
     "https://w3id.org/catenax/2025/9/policy/context.jsonld",
     {
       "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
@@ -373,7 +373,7 @@ it.
 ```json
 {
   "@context": [
-    "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
+    "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
     "https://w3id.org/catenax/2025/9/policy/context.jsonld",
     {
       "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
@@ -404,7 +404,7 @@ Constraints can be chained together via logical constraints. This is currently p
 ```json
 {
   "@context": [
-    "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
+    "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
     "https://w3id.org/catenax/2025/9/policy/context.jsonld",
     {
       "@vocab": "https://w3id.org/edc/v0.0.1/ns/"

--- a/docs/usage/management-api-walkthrough/04_catalog.md
+++ b/docs/usage/management-api-walkthrough/04_catalog.md
@@ -227,7 +227,6 @@ The returned payload is a `dcat:Catalog` as specified by the DSP version used in
   "@context": [
     "https://w3id.org/tractusx/auth/v1.0.0",
     "https://w3id.org/catenax/2025/9/policy/context.jsonld",
-    "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
     "https://w3id.org/dspace/2025/1/context.jsonld",
     "https://w3id.org/edc/dspace/v0.0.1"
   ]

--- a/docs/usage/management-api-walkthrough/05_contractnegotiations.md
+++ b/docs/usage/management-api-walkthrough/05_contractnegotiations.md
@@ -20,7 +20,7 @@ Content-Type: application/json
 ```json
 {
   "@context": [
-    "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
+    "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
     "https://w3id.org/catenax/2025/9/policy/context.jsonld",
     {
       "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
@@ -90,7 +90,6 @@ the `@id` property.
       "@context": [
         "https://w3id.org/tractusx/auth/v1.0.0",
         "https://w3id.org/catenax/2025/9/policy/context.jsonld",
-        "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
         "https://w3id.org/dspace/2025/1/context.jsonld",
         "https://w3id.org/edc/dspace/v0.0.1"
       ]
@@ -135,7 +134,6 @@ that will look like this:
   "@context": [
     "https://w3id.org/tractusx/auth/v1.0.0",
     "https://w3id.org/catenax/2025/9/policy/context.jsonld",
-    "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
     "https://w3id.org/dspace/2025/1/context.jsonld",
     "https://w3id.org/edc/dspace/v0.0.1"
   ]

--- a/docs/usage/management-api-walkthrough/07_edrs.md
+++ b/docs/usage/management-api-walkthrough/07_edrs.md
@@ -41,7 +41,7 @@ Content-Type: application/json
 {
     "@context": [
         "https://w3id.org/catenax/2025/9/policy/context.jsonld",
-        "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
+        "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
         {
             "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
         }

--- a/edc-extensions/bpn-validation/README.md
+++ b/edc-extensions/bpn-validation/README.md
@@ -46,7 +46,7 @@ The following example demonstrates a full JSON-LD structure in expanded form, co
 {
   "@type": "https://w3id.org/edc/v0.0.1/ns/PolicyDefinitionDto",
   "https://w3id.org/edc/v0.0.1/ns/policy": {
-    "@context": "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
+    "@context": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
     "permission": {
       "action": "USE",
       "constraint": {
@@ -92,7 +92,7 @@ the policy. Here, only the ODRL `eq"` operator is supported, and the `rightOpera
 {
   "@type": "https://w3id.org/edc/v0.0.1/ns/PolicyDefinitionDto",
   "https://w3id.org/edc/v0.0.1/ns/policy": {
-    "@context": "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
+    "@context": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
     "permission": [
       {
         "action": "USE",
@@ -124,7 +124,7 @@ In case multiple BPNs are to be white-listed, the policy would contain multiple 
 {
   "@type": "https://w3id.org/edc/v0.0.1/ns/PolicyDefinitionDto",
   "https://w3id.org/edc/v0.0.1/ns/policy": {
-    "@context": "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
+    "@context": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
     "permission": [
       {
         "action": "USE",

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/helpers/PolicyHelperFunctions.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/helpers/PolicyHelperFunctions.java
@@ -47,11 +47,12 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSTRAINT_TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_LOGICAL_CONSTRAINT_TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
-import static org.eclipse.tractusx.edc.cx.CxJsonLdExtension.CX_ODRL_CONTEXT;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_2025_09_NS;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
 
 public class PolicyHelperFunctions {
+
+    public static final String ODRL_CONTEXT = "https://w3id.org/dspace/2025/1/odrl-profile.jsonld";
 
     private static final String BUSINESS_PARTNER_EVALUATION_KEY = "BusinessPartnerNumber";
 
@@ -83,7 +84,7 @@ public class PolicyHelperFunctions {
 
     public static JsonObject frameworkPolicy(Map<String, String> permissions, String action) {
         return Json.createObjectBuilder()
-                .add(CONTEXT, CX_ODRL_CONTEXT)
+                .add(CONTEXT, ODRL_CONTEXT)
                 .add(TYPE, "Set")
                 .add("permission", Json.createArrayBuilder()
                         .add(frameworkConstraint(new HashMap<>(permissions), action, Operator.EQ, false)))
@@ -96,7 +97,7 @@ public class PolicyHelperFunctions {
 
     public static JsonObject frameworkPolicy(Map<String, String> permissions, String action, Operator operator) {
         return Json.createObjectBuilder()
-                .add(CONTEXT, CX_ODRL_CONTEXT)
+                .add(CONTEXT, ODRL_CONTEXT)
                 .add(TYPE, "Set")
                 .add("permission", Json.createArrayBuilder()
                         .add(frameworkConstraint(new HashMap<>(permissions), action, operator, false)))
@@ -106,7 +107,7 @@ public class PolicyHelperFunctions {
 
     public static JsonObject emptyPolicy() {
         return Json.createObjectBuilder()
-                .add(CONTEXT, CX_ODRL_CONTEXT)
+                .add(CONTEXT, ODRL_CONTEXT)
                 .add(TYPE, "Set")
                 .build();
     }
@@ -138,7 +139,7 @@ public class PolicyHelperFunctions {
                 .build();
 
         return Json.createObjectBuilder()
-                .add(CONTEXT, CX_ODRL_CONTEXT)
+                .add(CONTEXT, ODRL_CONTEXT)
                 .add(TYPE, "Set")
                 .add("permission", Json.createArrayBuilder().add(permission))
                 .build();
@@ -179,7 +180,7 @@ public class PolicyHelperFunctions {
                 .build();
         
         return Json.createObjectBuilder()
-                .add(CONTEXT, CX_ODRL_CONTEXT)
+                .add(CONTEXT, ODRL_CONTEXT)
                 .add(TYPE, "Set")
                 .add("permission", Json.createArrayBuilder().add(permission))
                 .build();
@@ -230,7 +231,7 @@ public class PolicyHelperFunctions {
 
     public static JsonObject bpnPolicy(String... bpns) {
         return Json.createObjectBuilder()
-                .add(CONTEXT, CX_ODRL_CONTEXT)
+                .add(CONTEXT, ODRL_CONTEXT)
                 .add(TYPE, "Set")
                 .add("permission", Json.createArrayBuilder()
                         .add(permission(bpns)))
@@ -256,7 +257,7 @@ public class PolicyHelperFunctions {
                         .build())
                 .build();
         return Json.createObjectBuilder()
-                .add(CONTEXT, CX_ODRL_CONTEXT)
+                .add(CONTEXT, ODRL_CONTEXT)
                 .add(TYPE, "Set")
                 .add("permission", Json.createArrayBuilder()
                         .add(permission))
@@ -276,7 +277,7 @@ public class PolicyHelperFunctions {
                 .build();
 
         return Json.createObjectBuilder()
-                .add(CONTEXT, CX_ODRL_CONTEXT)
+                .add(CONTEXT, ODRL_CONTEXT)
                 .add(TYPE, "Set")
                 .add("permission", permission)
                 .build();

--- a/edc-tests/e2e/dsp-compatibility-tests/src/test/java/org/eclipse/tractusx/edc/tests/tck/dsp/EdcCompatibilityPostgresTest.java
+++ b/edc-tests/e2e/dsp-compatibility-tests/src/test/java/org/eclipse/tractusx/edc/tests/tck/dsp/EdcCompatibilityPostgresTest.java
@@ -152,8 +152,6 @@ public class EdcCompatibilityPostgresTest {
                 "/etc/tck/tx-auth-v1.jsonld");
         TCK_CONTAINER.withCopyFileToContainer(MountableFile.forClasspathResource("document/cx-policy-v1.jsonld"),
                 "/etc/tck/cx-policy-v1.jsonld");
-        TCK_CONTAINER.withCopyFileToContainer(MountableFile.forClasspathResource("document/cx-odrl.jsonld"),
-                "/etc/tck/cx-odrl.jsonld");
         TCK_CONTAINER.withExtraHost("host.docker.internal",
                 "host-gateway");
         TCK_CONTAINER.withLogConsumer(outputFrame -> monitor.info(outputFrame.getUtf8String()));

--- a/edc-tests/e2e/dsp-compatibility-tests/src/test/resources/docker.tck.properties
+++ b/edc-tests/e2e/dsp-compatibility-tests/src/test/resources/docker.tck.properties
@@ -31,8 +31,6 @@ dataspacetck.dsp.jsonld.context.tractusx_auth.path=/etc/tck/tx-auth-v1.jsonld
 dataspacetck.dsp.jsonld.context.tractusx_auth.uri=https://w3id.org/tractusx/auth/v1.0.0
 dataspacetck.dsp.jsonld.context.tractusx_policy.path=/etc/tck/cx-policy-v1.jsonld
 dataspacetck.dsp.jsonld.context.tractusx_policy.uri=https://w3id.org/catenax/2025/9/policy/context.jsonld
-dataspacetck.dsp.jsonld.context.tractusx_policy_odrl.path=/etc/tck/cx-odrl.jsonld
-dataspacetck.dsp.jsonld.context.tractusx_policy_odrl.uri=https://w3id.org/catenax/2025/9/policy/odrl.jsonld
 dataspacetck.dsp.default.wait=7
 # must be 0.0.0.0 for docker inet binding to work
 dataspacetck.callback.address=http://0.0.0.0:8083

--- a/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
+++ b/edc-tests/e2e/policy-tests/src/test/java/org/eclipse/tractusx/edc/tests/policy/PolicyDefinitionEndToEndTest.java
@@ -46,7 +46,6 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.tractusx.edc.cx.CxJsonLdExtension.CX_ODRL_CONTEXT;
 import static org.eclipse.tractusx.edc.cx.CxJsonLdExtension.CX_POLICY_2025_09_CONTEXT;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.CONSUMER_BPN;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.CONSUMER_DID;
@@ -54,6 +53,7 @@ import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.CONSUMER_N
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PROVIDER_BPN;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PROVIDER_DID;
 import static org.eclipse.tractusx.edc.tests.TestRuntimeConfiguration.PROVIDER_NAME;
+import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.ODRL_CONTEXT;
 import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.emptyPolicy;
 import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.frameworkConstraint;
 import static org.eclipse.tractusx.edc.tests.helpers.PolicyHelperFunctions.inForceDateUsagePolicy;
@@ -245,7 +245,7 @@ public class PolicyDefinitionEndToEndTest {
             rulesArrayBuilder.add(rule);
         }
         var contextArrayBuilder = Json.createArrayBuilder();
-        contextArrayBuilder.add(CX_ODRL_CONTEXT);
+        contextArrayBuilder.add(ODRL_CONTEXT);
         if (!policyDefinition.isBlank()) {
             contextArrayBuilder.add(policyDefinition);
         }
@@ -264,7 +264,7 @@ public class PolicyDefinitionEndToEndTest {
         var rulesArrayBuilder = Json.createArrayBuilder();
         rulesArrayBuilder.add(rule);
         var contextArrayBuilder = Json.createArrayBuilder();
-        contextArrayBuilder.add(CX_ODRL_CONTEXT);
+        contextArrayBuilder.add(ODRL_CONTEXT);
         contextArrayBuilder.add(policyContext);
 
         return Json.createObjectBuilder()


### PR DESCRIPTION
## WHAT

Marks the Catena-X ODRL context as deprecated and removes it from the registered contexts, i.e. it will not be actively used for compaction anymore. Replaces all references to the context in tests and documentation with `http://www.w3.org/ns/odrl.jsonld`. 

For now, keeps the registration of the context file as a cached document, so that it remains processable, as it is still used by older connector versions. It may be removed completely in a future version.

## WHY

As stated in [this issue](https://github.com/catenax-eV/cx-ex-data-sovereignty/issues/36#issuecomment-3932262566), it was decided by the data sovereignty expert group to remove the Catena-X ODRL context. 

Relates to https://github.com/catenax-eV/cx-ex-data-sovereignty/issues/36