### PR TITLE
fix: change return type on provider to interface

### DIFF
--- a/edc-extensions/agreements-bpns/bpns-evaluation-store-sql/src/main/java/org/eclipse/tractusx/edc/agreements/bpns/store/SqlAgreementsBpnsStoreExtension.java
+++ b/edc-extensions/agreements-bpns/bpns-evaluation-store-sql/src/main/java/org/eclipse/tractusx/edc/agreements/bpns/store/SqlAgreementsBpnsStoreExtension.java
@@ -29,6 +29,7 @@ import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.tractusx.edc.agreements.bpns.spi.store.AgreementsBpnsStore;
 import org.eclipse.tractusx.edc.agreements.bpns.store.sql.PostgresAgreementsBpnsStatements;
 import org.eclipse.tractusx.edc.agreements.bpns.store.sql.SqlAgreementsBpnsStatements;
 import org.eclipse.tractusx.edc.agreements.bpns.store.sql.SqlAgreementsBpnsStore;
@@ -57,7 +58,7 @@ public class SqlAgreementsBpnsStoreExtension implements ServiceExtension {
     private SqlAgreementsBpnsStatements statements;
 
     @Provider
-    public SqlAgreementsBpnsStore sqlStore(ServiceExtensionContext context) {
+    public AgreementsBpnsStore sqlStore(ServiceExtensionContext context) {
         var dataSourceName = context.getConfig().getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
         return new SqlAgreementsBpnsStore(dataSourceRegistry, dataSourceName, transactionContext,
                 typeManager.getMapper(), queryExecutor, getStatements());


### PR DESCRIPTION
## WHAT

`SqlAgreementsBpnsStore` wasn't properly being injected because the method annotated with `@Provider` was retuning the implementation's class name and not that of the Interface.

## WHY

store bpn-agreementid-mappings in table, not memory

## FURTHER NOTES

I built the image, ran it on my cluster and found that the agreements negotiated based on it are persisted properly. I'd be unsure how to write unit tests for this.

<img width="715" height="104" alt="image" src="https://github.com/user-attachments/assets/97ab591d-5a15-405d-8bf2-2faf21d0dd28" />


Closes #2618 
