### PR TITLE
chore: limit dependency check to runtime dependencies

### DIFF
--- a/.github/actions/generate-and-check-dependencies/action.yml
+++ b/.github/actions/generate-and-check-dependencies/action.yml
@@ -33,7 +33,9 @@ runs:
     - name: Generate dependency list
       shell: bash
       run: |
-        ./gradlew allDependencies | grep -Poh "(?<=\s)[\w.-]+:[\w.-]+:[^:\s\[\]]+" | sort | uniq > dependency-list
+        ./gradlew :edc-controlplane:allDependencies --configuration runtimeClasspath | grep -Poh "(?<=\s)[\w.-]+:[\w.-]+:[^:\s\[\]]+" > dependency-list-c
+        ./gradlew :edc-dataplane:allDependencies --configuration runtimeClasspath | grep -Poh "(?<=\s)[\w.-]+:[\w.-]+:[^:\s\[\]]+" > dependency-list-d
+        cat dependency-list-c dependency-list-d | sort | uniq > dependency-list
         cat dependency-list
 
     - name: Run dash


### PR DESCRIPTION
## WHAT

Adapt the action that gathers all relevant dependencies to limit the detection to the runtimeClasspath of the control and the dataplane.

## WHY

For the dependency check, only dependencies relevant at runtime of the product are relevant. This limits the listing to those dependencies

Closes #2665 
