### PR TITLE
Remove Develocity configuration

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -76,8 +76,6 @@ jobs:
       - name: Build Production Code
         run: |
           ./gradlew compileJava --no-daemon --no-build-cache
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/publish-openapi-ui.yml
+++ b/.github/workflows/publish-openapi-ui.yml
@@ -55,8 +55,6 @@ jobs:
 
       - name: Generate openapi spec
         run: ./gradlew resolve
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - uses: actions/upload-artifact@v7
         with:
           name: openapi-spec
@@ -93,14 +91,10 @@ jobs:
         run: |
           ./gradlew -p ${{ matrix.apiGroup.folder }} downloadOpenapi
           cp ${{ matrix.apiGroup.folder }}/build/docs/openapi/* resources/openapi/yaml/${{ matrix.apiGroup.name }}
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       - name: Merge API specs
         run: |
           ./gradlew mergeOpenApiSpec --inputDir=${PWD}/resources/openapi/yaml/${{ matrix.apiGroup.name }} --output=${{ matrix.apiGroup.name }}.yaml --infoTitle="Tractus-X EDC ${{ matrix.apiGroup.name }} API" --infoDescription="Tractus-X EDC ${{ matrix.apiGroup.name }} API Documentation" --infoVersion=${{ env.VERSION }}
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       - name: Generate Swagger UI current version
         uses: Legion2/swagger-ui-action@v1

--- a/.github/workflows/upgradeability-test.yaml
+++ b/.github/workflows/upgradeability-test.yaml
@@ -89,8 +89,6 @@ jobs:
         run: |-
           ./gradlew :edc-controlplane:edc-controlplane-postgresql-hashicorp-vault:dockerize
           ./gradlew :edc-dataplane:edc-dataplane-hashicorp-vault:dockerize
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       - name: "Load images into KinD"
         shell: bash

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -53,8 +53,6 @@ jobs:
       - name: Run Checkstyle
         run: |
           ./gradlew checkstyleMain checkstyleTest
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
   verify-javadoc:
     runs-on: ubuntu-latest
@@ -64,8 +62,6 @@ jobs:
 
       - name: Run Javadoc
         run: ./gradlew javadoc
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -76,8 +72,6 @@ jobs:
 
       - name: Run Unit tests
         run: ./gradlew test testCodeCoverage
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       # uploads the jacoco report as artifact
       - name: Upload JaCoCo Coverage Report
@@ -125,8 +119,6 @@ jobs:
         run: |
           ./gradlew :edc-tests:runtime:mock-connector:dockerize
           ./gradlew test -DincludeTags="ComponentTest"
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
   api-tests:
     runs-on: ubuntu-latest
@@ -137,8 +129,6 @@ jobs:
 
       - name: Run API tests
         run: ./gradlew test -DincludeTags="ApiTest"
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
   prepare-end-to-end-tests:
     runs-on: ubuntu-latest
@@ -166,8 +156,6 @@ jobs:
         run: |
           ./gradlew compileJava compileTestJava
           ./gradlew -p edc-tests/e2e/${{ matrix.dir }} test -DincludeTags="EndToEndTest" -PverboseTest=true --no-build-cache
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       - name: Set sanitized artifact name
         run: |
@@ -188,8 +176,6 @@ jobs:
 
       - name: Run Postgresql E2E tests
         run: ./gradlew test -DincludeTags="PostgresqlIntegrationTest" -PverboseTest=true
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
   compatibility-tests:
     runs-on: ubuntu-latest
@@ -202,8 +188,6 @@ jobs:
 
       - name: Run Compatibility tests
         run: ./gradlew test -DincludeTags="CompatibilityTest" -PverboseTest=true --no-build-cache
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
   generate-allure-report:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,3 @@ version=0.13.0-SNAPSHOT
 txScmConnection=scm:git:git@github.com:eclipse-tractusx/tractusx-edc.git
 txWebsiteUrl=https://github.com/eclipse-tractusx/tractusx-edc.git
 txScmUrl=https://github.com/eclipse-tractusx/tractusx-edc.git
-
-org.gradle.caching=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -169,33 +169,3 @@ include(":edc-dataplane:edc-dataplane-hashicorp-vault")
 
 include(":samples:testing-with-mocked-connector")
 
-plugins {
-    id("com.gradle.develocity") version "4.3.2"
-    id("com.gradle.common-custom-user-data-gradle-plugin") version "2.4.0"
-}
-
-// Develocity
-val isCI = System.getenv("CI") != null // adjust to your CI provider
-
-develocity {
-    server = "https://develocity-staging.eclipse.org"
-    projectId = "automotive.tractusx"
-    buildScan {
-        uploadInBackground = !isCI
-        publishing.onlyIf { it.isAuthenticated }
-        obfuscation {
-            ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } }
-        }
-    }
-}
-
-buildCache {
-    local {
-        isEnabled = true
-    }
-
-    remote(develocity.buildCache) {
-        isEnabled = true
-        isPush = isCI
-    }
-}


### PR DESCRIPTION
The Eclipse Foundation has announced the discontinuation of the Develocity service offering (see [announcement](https://www.eclipse.org/lists/eclipse.org-committers/msg01557.html)).

This PR removes the Develocity configuration and remote build cache that was added in #1849.