### PR TITLE
fix: remove usagepurpose credential

### DIFF
--- a/edc-extensions/dcp/tx-dcp/src/main/java/org/eclipse/tractusx/edc/iam/iatp/scope/CredentialScopeExtractor.java
+++ b/edc-extensions/dcp/tx-dcp/src/main/java/org/eclipse/tractusx/edc/iam/iatp/scope/CredentialScopeExtractor.java
@@ -52,16 +52,7 @@ public class CredentialScopeExtractor implements ScopeExtractor {
     private static final Set<String> CATENA_X_CREDENTIALS = Set.of(
             "MembershipCredential",
             "BpnCredential",
-            "FrameworkAgreementCredential",
             "DismantlerCredential",
-            "TraceabilityCredential",
-            "PcfCredential",
-            "QualityCredential",
-            "CircularEconomyCredential",
-            "DemandCapacityCredential",
-            "PurisCredential",
-            "BusinessPartnerCredential",
-            "BehavioralTwinCredential",
             "DataExchangeGovernanceCredential"
     );
 

--- a/edc-extensions/dcp/tx-dcp/src/test/java/org/eclipse/tractusx/edc/iam/iatp/scope/CredentialScopeExtractorTest.java
+++ b/edc-extensions/dcp/tx-dcp/src/test/java/org/eclipse/tractusx/edc/iam/iatp/scope/CredentialScopeExtractorTest.java
@@ -46,12 +46,16 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.util.stream.Stream;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.tractusx.edc.TxIatpConstants.CREDENTIAL_TYPE_NAMESPACE;
 import static org.eclipse.tractusx.edc.iam.iatp.scope.CredentialScopeExtractor.FRAMEWORK_CREDENTIAL_PREFIX;
 import static org.mockito.Mockito.mock;
 
 public class CredentialScopeExtractorTest {
+
+    private static final String DATA_EXCHANGE_GOVERNANCE_RIGHT_VALUE = "DataExchangeGovernance:1.0";
+    private static final String DATA_EXCHANGE_GOVERNANCE_CREDENTIAL = "DataExchangeGovernanceCredential";
 
     private final Monitor monitor = mock();
     private CredentialScopeExtractor extractor;
@@ -68,9 +72,9 @@ public class CredentialScopeExtractorTest {
         var requestContext = RequestContext.Builder.newInstance().message(message).direction(RequestContext.Direction.Egress).build();
         var ctx = new TestRequestPolicyContext(requestContext, null);
 
-        var scopes = extractor.extractScopes(CoreConstants.CX_POLICY_NS + FRAMEWORK_CREDENTIAL_PREFIX + ".pcf", null, null, ctx);
+        var scopes = extractor.extractScopes(CoreConstants.CX_POLICY_NS + FRAMEWORK_CREDENTIAL_PREFIX, Operator.EQ, DATA_EXCHANGE_GOVERNANCE_RIGHT_VALUE, ctx);
 
-        assertThat(scopes).contains(CREDENTIAL_TYPE_NAMESPACE + ":PcfCredential:read");
+        assertThat(scopes).contains(format("%s:%s:read", CREDENTIAL_TYPE_NAMESPACE, DATA_EXCHANGE_GOVERNANCE_CREDENTIAL));
     }
 
     @DisplayName("Scope extractor with not supported messages")
@@ -80,7 +84,7 @@ public class CredentialScopeExtractorTest {
         var requestContext = RequestContext.Builder.newInstance().message(message).direction(RequestContext.Direction.Egress).build();
         var ctx = new TestRequestPolicyContext(requestContext, null);
 
-        var scopes = extractor.extractScopes(CoreConstants.CX_POLICY_NS + FRAMEWORK_CREDENTIAL_PREFIX + ".pcf", null, null, ctx);
+        var scopes = extractor.extractScopes(CoreConstants.CX_POLICY_NS + FRAMEWORK_CREDENTIAL_PREFIX, Operator.EQ, DATA_EXCHANGE_GOVERNANCE_RIGHT_VALUE, ctx);
 
         assertThat(scopes).isEmpty();
     }


### PR DESCRIPTION
## WHAT

Cherry picked [this commit](https://github.com/eclipse-tractusx/tractusx-edc/commit/2c3aba89c5115742d51d6bbf15add0d78df6f24d) and made small adjustments to fix for the appropriate policy profile.

## WHY

This fixes a compatibility version between 0.10.x and 0.11.x or newer versions when using the ssi-dim-wallet-stub.

## FURTHER NOTES

Closes #2667 
