### PR TITLE
infra: Migrate helm charts to use cloud pirates postgres charts

### DIFF
--- a/charts/tractusx-connector/Chart.yaml
+++ b/charts/tractusx-connector/Chart.yaml
@@ -54,7 +54,7 @@ dependencies:
   # HashiCorp Vault
   - name: vault
     alias: vault
-    version: "0.27.0"
+    version: "0.28.0"
     repository: https://helm.releases.hashicorp.com
     condition: install.vault
   # PostgreSQL

--- a/charts/tractusx-connector/Chart.yaml
+++ b/charts/tractusx-connector/Chart.yaml
@@ -58,8 +58,8 @@ dependencies:
     repository: https://helm.releases.hashicorp.com
     condition: install.vault
   # PostgreSQL
-  - name: postgresql
+  - name: postgres
     alias: postgresql
-    version: "15.2.1"
-    repository: https://charts.bitnami.com/bitnami
+    version: "0.18.3"
+    repository: oci://registry-1.docker.io/cloudpirates
     condition: install.postgresql

--- a/charts/tractusx-connector/README.md
+++ b/charts/tractusx-connector/README.md
@@ -287,7 +287,7 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.13.0-SNAPSHO
 | postgresql.image.registry | string | `"docker.io"` |  |
 | postgresql.image.repository | string | `"postgres"` |  |
 | postgresql.jdbcUrl | string | `"jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/edc"` |  |
-| postgresql.persistence.enabled | bool | `true` |  |
+| postgresql.persistence.enabled | bool | `false` |  |
 | postgresql.persistence.size | string | `"10Gi"` |  |
 | postgresql.persistence.storageClass | string | `"standard"` |  |
 | postgresql.resources.limits.cpu | int | `1` |  |

--- a/charts/tractusx-connector/README.md
+++ b/charts/tractusx-connector/README.md
@@ -56,7 +56,7 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.13.0-SNAPSHO
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://helm.releases.hashicorp.com | vault(vault) | 0.27.0 |
+| https://helm.releases.hashicorp.com | vault(vault) | 0.28.0 |
 | oci://registry-1.docker.io/cloudpirates | postgresql(postgres) | 0.18.3 |
 
 ## Values

--- a/charts/tractusx-connector/README.md
+++ b/charts/tractusx-connector/README.md
@@ -56,8 +56,8 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.13.0-SNAPSHO
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql(postgresql) | 15.2.1 |
 | https://helm.releases.hashicorp.com | vault(vault) | 0.27.0 |
+| oci://registry-1.docker.io/cloudpirates | postgresql(postgres) | 0.18.3 |
 
 ## Values
 
@@ -284,11 +284,16 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.13.0-SNAPSHO
 | postgresql.auth.database | string | `"edc"` |  |
 | postgresql.auth.password | string | `"password"` |  |
 | postgresql.auth.username | string | `"user"` |  |
-| postgresql.image.repository | string | `"bitnamilegacy/postgresql"` |  |
-| postgresql.image.tag | string | `"16.2.0-debian-12-r10"` |  |
+| postgresql.image.registry | string | `"docker.io"` |  |
+| postgresql.image.repository | string | `"postgres"` |  |
 | postgresql.jdbcUrl | string | `"jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/edc"` |  |
-| postgresql.primary.persistence.enabled | bool | `false` |  |
-| postgresql.readReplicas.persistence.enabled | bool | `false` |  |
+| postgresql.persistence.enabled | bool | `true` |  |
+| postgresql.persistence.size | string | `"10Gi"` |  |
+| postgresql.persistence.storageClass | string | `"standard"` |  |
+| postgresql.resources.limits.cpu | int | `1` |  |
+| postgresql.resources.limits.memory | string | `"1Gi"` |  |
+| postgresql.resources.requests.cpu | string | `"250m"` |  |
+| postgresql.resources.requests.memory | string | `"256Mi"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.imagePullSecrets | list | `[]` | Existing image pull secret bound to the service account to use to [obtain the container image from private registries](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry) |

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -629,7 +629,7 @@ postgresql:
     repository: postgres
   jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/edc"
   persistence:
-    enabled: true
+    enabled: false
     size: 10Gi
     storageClass: standard
   resources:

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -625,15 +625,20 @@ dataplane:
 
 postgresql:
   image:
-    repository: "bitnamilegacy/postgresql"
-    tag: "16.2.0-debian-12-r10"
+    registry: docker.io
+    repository: postgres
   jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/edc"
-  primary:
-    persistence:
-      enabled: false
-  readReplicas:
-    persistence:
-      enabled: false
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClass: standard
+  resources:
+    limits:
+      cpu: 1
+      memory: 1Gi
+    requests:
+      cpu: 250m
+      memory: 256Mi
   auth:
     database: "edc"
     username: "user"

--- a/docs/migration/2026_06-Version_0.12.x_0.13.x.md
+++ b/docs/migration/2026_06-Version_0.12.x_0.13.x.md
@@ -8,7 +8,9 @@ This document is not a comprehensive feature list.
 
 <!-- TOC -->
 * [Migration Guide `0.12.x -> 0.13.x`](#migration-guide-012x---013x)
-    * [1. Federate Catalog removal](#2-federate-catalog-removal)
+  * [1. Federate Catalog removal](#1-federate-catalog-removal)
+  * [2. Deprecated instances](#2-deprecated-instances)
+  * [3. Postgres Version](#3-postgres-version)
 <!-- TOC -->
 
 ## 1. Federate Catalog removal
@@ -38,3 +40,13 @@ Please use the updated configuration parameters instead.
 
 
 [2026_06-Version_0.12.x_0.13.x.md](2026_06-Version_0.12.x_0.13.x.md)
+
+## 3. Postgres Version
+
+The new version provides Postgres version 18.0 as dependency in the helm charts referring to the Cloud Pirates
+helm charts and the official Postgres docker image instead of the formerly used bitnami charts and docker images.
+
+As a consequence, for a Kubernetes setup done with the provided helm charts, there is no possibility to do an automatic
+upgrade with the provided helm charts, as the two images are not supporting that. Instead, during update, an operator
+has to follow the general
+[migration guide](https://github.com/eclipse-tractusx/tutorial-resources/blob/main/migration-guides/GENERIC_POSTGRESQL_MIGRATION_GUIDE.md#:~:text=GENERIC_BITNAMI_TO_CLOUDPIRATES_KEYCLOAK_MIGRATION_GUIDE.md-,GENERIC_POSTGRESQL_MIGRATION_GUIDE,-.md)

--- a/edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml
+++ b/edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml
@@ -80,14 +80,6 @@ dataplane:
       privatekey_alias: "key-1"
     verifier:
       publickey_alias: "key-1"
-postgresql:
-  image:
-    repository: "bitnamilegacy/postgresql"
-    tag: "16.2.0-debian-12-r10"
-  jdbcUrl: jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/edc
-  auth:
-    username: user
-    password: password
 vault:
   hashicorp:
     url: http://{{ .Release.Name }}-vault:8200


### PR DESCRIPTION
## WHAT

Adapt the helm charts to use coud pirates helm charts for postgres deployment

## WHY

Follow overall Tractus-X decisions

Closes #2162