### PR TITLE
fix: Handle older connectors <=0.9.0 for version metadata

### DIFF
--- a/edc-extensions/connector-discovery/connector-discovery-api/src/main/java/org/eclipse/tractusx/edc/discovery/v4alpha/service/BaseConnectorDiscoveryServiceImpl.java
+++ b/edc-extensions/connector-discovery/connector-discovery-api/src/main/java/org/eclipse/tractusx/edc/discovery/v4alpha/service/BaseConnectorDiscoveryServiceImpl.java
@@ -146,22 +146,45 @@ public abstract class BaseConnectorDiscoveryServiceImpl implements ConnectorDisc
                 .build();
 
         return httpClient.executeAsync(wellKnownRequest, emptyList())
-                .thenApply(response -> {
+                .handle((response, throwable) -> {
+                    if (throwable != null) {
+                        var msg = "Counterparty well-known endpoint call has failed with message: %s"
+                                .formatted(throwable.getLocalizedMessage());
+                        monitor.warning(msg);
+                        throw new BadGatewayException(msg);
+                    }
                     try (response) {
-                        if (!response.isSuccessful()) {
-                            var msg = "Counterparty well-known endpoint has failed with status %s and message: %s"
-                                    .formatted(response.code(), response.message());
-                            monitor.warning(msg);
-                            throw new BadGatewayException(msg);
+                        ProtocolVersion protocolVersion;
+                        if (response.isSuccessful()) {
+                            protocolVersion = extractLatestSupportedVersion(parseResponseBody(response));
+                        } else {
+                            protocolVersion = handleSpecialStatusCode(response);
+                            if (protocolVersion == null) {
+                                var msg = "Counterparty well-known endpoint has failed with status %s and message: %s"
+                                        .formatted(response.code(), response.message());
+                                monitor.warning(msg);
+                                throw new BadGatewayException(msg);
+                            }
                         }
 
-                        var protocolVersion = extractLatestSupportedVersion(parseResponseBody(response));
                         var resultObject = createResultObjectFromProtocolVersionData(request, protocolVersion);
                         versionsCache.put(versionEndpoint, new TimestampedValue<>(protocolVersion, cacheValidity));
                         return resultObject;
                     }
                 });
     }
+
+    /**
+     * This method allows to handle certain status codes returned in the response of the version metadata call.
+     * Needed for older connector versions, as they had and access-restricted endpoint which results in a 401.
+     * Intention is, to allow to handle this status code instead of doing an authenticated call, as this is
+     * a temporary situation.
+     *
+     * @param response The response object of the version metadata request
+     * @return Either a default ProtocolVersion object, if the status code is caught or null, if the response does
+     *         not map to a default value
+     */
+    protected abstract ProtocolVersion handleSpecialStatusCode(Response response);
 
     /**
      * The connector discovery basically deals with two potential input root patterns. First input pattern is, that
@@ -182,7 +205,7 @@ public abstract class BaseConnectorDiscoveryServiceImpl implements ConnectorDisc
      * @return A joint path cleaned from unneeded slashes following the pattern 'root/subpath'
      * @throws InvalidRequestException If the created path, i.e., the root parameter is not a correct url.
      */
-    protected String createFullPath(String root, String subpath) {
+    private String createFullPath(String root, String subpath) {
         var input = root;
         if (root.endsWith(DSP_DISCOVERY_PATH)) {
             input = root.substring(0, root.length() - DSP_DISCOVERY_PATH.length() - 1);

--- a/edc-extensions/connector-discovery/connector-discovery-api/src/main/java/org/eclipse/tractusx/edc/discovery/v4alpha/service/DefaultConnectorDiscoveryServiceImpl.java
+++ b/edc-extensions/connector-discovery/connector-discovery-api/src/main/java/org/eclipse/tractusx/edc/discovery/v4alpha/service/DefaultConnectorDiscoveryServiceImpl.java
@@ -21,9 +21,11 @@
 package org.eclipse.tractusx.edc.discovery.v4alpha.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.Response;
 import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants;
+import org.eclipse.edc.protocol.spi.ProtocolVersion;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.tractusx.edc.discovery.v4alpha.spi.CacheConfig;
@@ -39,6 +41,11 @@ public class DefaultConnectorDiscoveryServiceImpl extends BaseConnectorDiscovery
             CacheConfig cacheConfig,
             Monitor monitor) {
         super(httpClient, didResolver, mapper, List.of(Dsp2025Constants.V_2025_1_VERSION), cacheConfig, monitor);
+    }
+
+    @Override
+    protected ProtocolVersion handleSpecialStatusCode(Response response) {
+        return null;
     }
 
     @Override

--- a/edc-extensions/connector-discovery/connector-discovery-api/src/test/java/org/eclipse/tractusx/edc/discovery/v4alpha/DefaultConnectorDiscoveryServiceImplTest.java
+++ b/edc-extensions/connector-discovery/connector-discovery-api/src/test/java/org/eclipse/tractusx/edc/discovery/v4alpha/DefaultConnectorDiscoveryServiceImplTest.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import java.io.IOException;
 import java.time.Clock;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -131,7 +132,7 @@ public class DefaultConnectorDiscoveryServiceImplTest {
     }
 
     @Test
-    void discoverVersionParams_shouldReturnUseCacheDuringSucccess() throws InterruptedException {
+    void discoverVersionParams_shouldReturnUseCacheDuringSuccess() throws InterruptedException {
         var paramsDiscoveryRequest = new ConnectorParamsDiscoveryRequest(TEST_DID, TEST_ADDRESS);
 
         var expectedJson = Json.createObjectBuilder()
@@ -180,7 +181,7 @@ public class DefaultConnectorDiscoveryServiceImplTest {
     }
 
     @Test
-    void discoverVersionParams_shouldReturnException_whenMetadataEndpointHasError() {
+    void discoverVersionParams_shouldReturnException_whenMetadataEndpointNotFound() {
         var paramsDiscoveryRequest = new ConnectorParamsDiscoveryRequest(TEST_DID, TEST_ADDRESS);
 
         when(httpClient.executeAsync(any(), any()))
@@ -192,6 +193,34 @@ public class DefaultConnectorDiscoveryServiceImplTest {
                 .hasCauseInstanceOf(BadGatewayException.class)
                 .hasMessageContaining("Counterparty well-known endpoint has failed with status")
                 .hasMessageContaining("404");
+    }
+
+    @Test
+    void discoverVersionParams_shouldReturnException_whenMetadataEndpointNotAuthenticated() {
+        var paramsDiscoveryRequest = new ConnectorParamsDiscoveryRequest(TEST_DID, TEST_ADDRESS);
+
+        when(httpClient.executeAsync(any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(
+                        dummyResponseBuilder(401, "Unauthorized", "Unauthorized").build()));
+
+        assertThatThrownBy(() -> testee.discoverVersionParams(paramsDiscoveryRequest).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(BadGatewayException.class)
+                .hasMessageContaining("Counterparty well-known endpoint has failed with status")
+                .hasMessageContaining("401");
+    }
+
+    @Test
+    void discoverVersionParams_shouldReturnException_whenHttpClientThrowsException() {
+        var paramsDiscoveryRequest = new ConnectorParamsDiscoveryRequest(TEST_DID, TEST_ADDRESS);
+
+        when(httpClient.executeAsync(any(), any()))
+                .thenReturn(CompletableFuture.failedFuture(new IOException("Failed Call")));
+        assertThatThrownBy(() -> testee.discoverVersionParams(paramsDiscoveryRequest).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(BadGatewayException.class)
+                .hasMessageContaining("Failed Call");
+
     }
 
     @Test

--- a/edc-extensions/connector-discovery/cx-connector-discovery/src/main/java/org/eclipse/tractusx/edc/discovery/cx/service/BpnlAndDsp08ConnectorDiscoveryServiceImpl.java
+++ b/edc-extensions/connector-discovery/cx-connector-discovery/src/main/java/org/eclipse/tractusx/edc/discovery/cx/service/BpnlAndDsp08ConnectorDiscoveryServiceImpl.java
@@ -22,10 +22,12 @@ package org.eclipse.tractusx.edc.discovery.cx.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.JsonArray;
+import okhttp3.Response;
 import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.edc.protocol.dsp.spi.type.Dsp08Constants;
 import org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants;
+import org.eclipse.edc.protocol.spi.ProtocolVersion;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.tractusx.edc.discovery.v4alpha.service.BaseConnectorDiscoveryServiceImpl;
@@ -63,6 +65,18 @@ public class BpnlAndDsp08ConnectorDiscoveryServiceImpl extends BaseConnectorDisc
     public CompletableFuture<JsonArray> discoverConnectors(ConnectorDiscoveryRequest request) {
         return super.discoverConnectors(new ConnectorDiscoveryRequest(
                 mapToDid(request.counterPartyId()), request.knownConnectors()));
+    }
+
+    @Override
+    protected ProtocolVersion handleSpecialStatusCode(Response response) {
+        if (response.code() == 401) {
+            // Connectors of version 0.9.0 and earlier had access-control for the version metadata endpoint
+            // This way, we assume, that a 401 indicates such a case and therefore default the protocol version to be used
+            // Wrong endpoint urls result in a 404, so the assumption here should be valid, if not, no big harm is
+            // done, as the call to a dsp endpoint would simply fail anyway.
+            return new ProtocolVersion("v0.8", "", "");
+        }
+        return null;
     }
 
     @Override

--- a/edc-extensions/connector-discovery/cx-connector-discovery/src/test/java/org/eclipse/tractusx/edc/discovery/cx/BpnlAndDsp08ConnectorDiscoveryServiceImplTest.java
+++ b/edc-extensions/connector-discovery/cx-connector-discovery/src/test/java/org/eclipse/tractusx/edc/discovery/cx/BpnlAndDsp08ConnectorDiscoveryServiceImplTest.java
@@ -33,6 +33,7 @@ import org.eclipse.edc.iam.did.spi.document.Service;
 import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.web.spi.exception.BadGatewayException;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.tractusx.edc.discovery.cx.service.BpnlAndDsp08ConnectorDiscoveryServiceImpl;
 import org.eclipse.tractusx.edc.discovery.v4alpha.spi.CacheConfig;
@@ -158,6 +159,42 @@ class BpnlAndDsp08ConnectorDiscoveryServiceImplTest {
         var response = testee.discoverVersionParams(paramsDiscoveryRequest).join();
 
         assertThat(response).isEqualTo(expectedJson);
+    }
+
+    @Test
+    void discoverVersionParams_shouldReturnDsp08_whenMetadataEndpointIsAccessControlled() {
+        var paramsDiscoveryRequest = new ConnectorParamsDiscoveryRequest(TEST_DID, TEST_ADDRESS);
+
+        when(bdrsClient.resolveBpn(TEST_DID))
+                .thenReturn(TEST_BPNL);
+        when(httpClient.executeAsync(any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(
+                        dummyResponseBuilder(401, "Unauthorized", "Unauthorized").build()));
+
+        var expectedJson = Json.createObjectBuilder()
+                .add(CATALOG_REQUEST_COUNTER_PARTY_ID, TEST_BPNL)
+                .add(CATALOG_REQUEST_PROTOCOL, VERSION_PROTOCOL_OLD)
+                .add(CATALOG_REQUEST_COUNTER_PARTY_ADDRESS, TEST_ADDRESS)
+                .build();
+
+        var response = testee.discoverVersionParams(paramsDiscoveryRequest).join();
+
+        assertThat(response).isEqualTo(expectedJson);
+    }
+
+    @Test
+    void discoverVersionParams_shouldReturnFailure_whenMetadataEndpointReturnsNotFound() {
+        var paramsDiscoveryRequest = new ConnectorParamsDiscoveryRequest(TEST_DID, TEST_ADDRESS);
+
+        when(httpClient.executeAsync(any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(
+                        dummyResponseBuilder(404, "Not found", "Not found").build()));
+
+        assertThatThrownBy(() -> testee.discoverVersionParams(paramsDiscoveryRequest).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(BadGatewayException.class)
+                .hasMessageContaining("Counterparty well-known endpoint has failed with status")
+                .hasMessageContaining("404");
     }
 
     @Test
@@ -338,9 +375,13 @@ class BpnlAndDsp08ConnectorDiscoveryServiceImplTest {
     }
 
     static okhttp3.Response.Builder dummyResponseBuilder(String body) {
+        return dummyResponseBuilder(200, body, "any");
+    }
+
+    static okhttp3.Response.Builder dummyResponseBuilder(int code, String body, String message) {
         return new okhttp3.Response.Builder()
-                .code(200)
-                .message("any")
+                .code(code)
+                .message(message)
                 .body(ResponseBody.create(body, MediaType.get("application/json")))
                 .protocol(Protocol.HTTP_1_1)
                 .request(new Request.Builder().url(TEST_ADDRESS).build());

--- a/edc-tests/e2e/discovery-tests/src/test/java/org/eclipse/tractusx/edc/discovery/e2e/ConnectorParameterDiscoveryTest.java
+++ b/edc-tests/e2e/discovery-tests/src/test/java/org/eclipse/tractusx/edc/discovery/e2e/ConnectorParameterDiscoveryTest.java
@@ -222,13 +222,13 @@ public class ConnectorParameterDiscoveryTest {
     }
 
     @Test
-    void discoveryShouldReturn500_whenProviderEndpointNotReachable() {
+    void discoveryShouldReturn502_whenProviderEndpointNotReachable() {
 
         var requestBody = createRequestBody(PROVIDER_FULL_DSP.getBpn(), "http://non-existing-provider.com");
 
         var response = CONSUMER.discoverDspParameters(requestBody);
 
-        response.statusCode(500)
+        response.statusCode(502)
                 .extract().body().asString();
     }
 


### PR DESCRIPTION
## WHAT

The `.well-known/dspace-version` endpoint was access-controlled in previous versions <= 0.9.0, this workaround fixes that without adding too much complexity, as this is a temporary effect, that will be gone soon enough.  

## WHY

To support detection of connectors <= 0.9.0

## FURTHER NOTES

Closes #2696
