### PR TITLE
feat/multi-tenant-bdrs: Enable multi-tenancy via `participantContextId` and restructure cache mechanism 

### DIFF
--- a/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsCache.java
+++ b/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsCache.java
@@ -1,0 +1,134 @@
+/********************************************************************************
+ * Copyright (c) 2026 Catena-X Automotive Network e.V.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.identity.mapper;
+
+import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsCacheInterface;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+
+public class BdrsCache implements BdrsCacheInterface {
+
+    private final Map<UUID, EnumMap<BDRS_CACHE_TYPE, Map<String, String>>> participants = new ConcurrentHashMap<>();
+
+    /**
+     * Per-participant cache expiry timestamps.
+     */
+    private final Map<UUID, Instant> lastCacheUpdates = new ConcurrentHashMap<>();
+
+    /**
+     * Cache validity period in seconds.
+     */
+    private final int cacheValiditySeconds;
+
+    public BdrsCache(int cacheValiditySeconds) {
+        this.cacheValiditySeconds = cacheValiditySeconds;
+    }
+
+    @Override
+    public boolean isCacheExpired(UUID participantContextId) {
+        var lastUpdate = lastCacheUpdates.get(participantContextId);
+        return lastUpdate == null || lastUpdate.plus(cacheValiditySeconds, ChronoUnit.SECONDS).isBefore(Instant.now());
+    }
+
+    @Override
+    public void markCacheUpdated(UUID participantContextId) {
+        lastCacheUpdates.put(participantContextId, Instant.now());
+    }
+
+    @Override
+    public EnumMap<BDRS_CACHE_TYPE, Map<String, String>> getAllParticipantCaches(UUID participantContextId) {
+        return participants.computeIfAbsent(participantContextId, tenantId -> initializeParticipantCaches());
+    }
+
+    /**
+     * IMPLEMENTATION SPECIFIC!
+     * Creates the two cache directions for a participant.
+     * @return the two empty caches {@code }
+     */
+    private EnumMap<BDRS_CACHE_TYPE, Map<String, String>> initializeParticipantCaches() {
+        // Initialize the cache entry enum map for the participant
+        var caches = new EnumMap<BDRS_CACHE_TYPE, Map<String, String>>(BDRS_CACHE_TYPE.class);
+
+        // Initialize both caches with empty hash maps
+        for (var cacheId : BDRS_CACHE_TYPE.values()) {
+            caches.put(cacheId, new HashMap<>());
+        }
+        return caches;
+    }
+
+    @Override
+    public void purgeCache(UUID participantContextId, BDRS_CACHE_TYPE cacheId) {
+        getAllParticipantCaches(participantContextId).get(cacheId).clear();
+    }
+
+    @Override
+    public void purgeAllParticipantCaches(UUID participantContextId) {
+        var participantContext = participants.get(participantContextId);
+        if (participantContext != null) {
+            for (var caches : BDRS_CACHE_TYPE.values()) {
+                participantContext.get(caches).clear();
+            }
+        }
+    }
+
+
+    @Override
+    public boolean purgeParticipantCaches(UUID participantContextId) {
+        return participants.remove(participantContextId) != null;
+    }
+
+    @Override
+    public boolean hasParticipantCaches(UUID participantContextId) {
+        return participants.containsKey(participantContextId);
+    }
+
+
+    @Override
+    public String get(UUID participantContextId, BDRS_CACHE_TYPE cacheId, String key) {
+        return getAllParticipantCaches(participantContextId).get(cacheId).get(key);
+    }
+
+    @Override
+    public void put(UUID participantContextId, BDRS_CACHE_TYPE cacheId, String key, String value) {
+        getAllParticipantCaches(participantContextId).get(cacheId).put(key, value);
+    }
+
+    @Override
+    public boolean purge(UUID participantContextId, BDRS_CACHE_TYPE cacheId, String key) {
+        return getAllParticipantCaches(participantContextId).get(cacheId).remove(key) != null;
+    }
+
+    @Override
+    public Map<String, String> getCache(UUID participantContextId, BDRS_CACHE_TYPE cacheId) {
+        return getAllParticipantCaches(participantContextId).get(cacheId);
+    }
+
+    @Override
+    public void setCache(UUID participantContextId, BDRS_CACHE_TYPE cacheId, Map<String, String> cacheData) {
+        getAllParticipantCaches(participantContextId).put(cacheId, new HashMap<>(cacheData));
+    }
+}

--- a/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientImpl.java
+++ b/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientImpl.java
@@ -34,9 +34,6 @@ import org.eclipse.tractusx.edc.TxIatpConstants;
 import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -49,17 +46,19 @@ import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUER;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.JWT_ID;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SUBJECT;
+import static org.eclipse.tractusx.edc.spi.identity.mapper.BdrsCacheInterface.BDRS_CACHE_TYPE;
 
 /**
- * Holds a local cache of BPN-to-DID mapping entries.
+ * Holds a local, participant-aware cache of BPN-to-DID mapping entries.
  * <p>
- * The local cache expires after a configurable time, at which point {@link BdrsClientImpl#resolveDid(String)}} requests will hit the server again.
+ * Each participant (tenant) gets its own cache partition managed by a {@link BdrsCache}.
+ * The cache expires after a configurable time per participant, at which point
+ * the next resolution request will hit the BDRS server again.
  */
 class BdrsClientImpl implements BdrsClient {
     private static final TypeReference<Map<String, String>> MAP_REF = new TypeReference<>() {
     };
     private final String serverUrl;
-    private final int cacheValidity;
     private final EdcHttpClient httpClient;
     private final Monitor monitor;
     private final ObjectMapper mapper;
@@ -69,9 +68,11 @@ class BdrsClientImpl implements BdrsClient {
     private final Supplier<String> ownCredentialServiceUrl;
     private final CredentialServiceClient credentialServiceClient;
     private final ParticipantContextSupplier participantContextSupplier;
-    private Map<String, String> cacheBpnDid = new HashMap<>();
-    private Map<String, String> cacheDidBpn = new HashMap<>();
-    private Instant lastCacheUpdate;
+
+    /**
+     * Participant-aware cache holding both BPN→DID and DID→BPN directions.
+     */
+    private final BdrsCache cache;
 
     BdrsClientImpl(String baseUrl,
                    int cacheValidity,
@@ -81,9 +82,9 @@ class BdrsClientImpl implements BdrsClient {
                    Monitor monitor,
                    ObjectMapper mapper,
                    SecureTokenService secureTokenService,
-                   CredentialServiceClient credentialServiceClient, ParticipantContextSupplier participantContextSupplier) {
+                   CredentialServiceClient credentialServiceClient,
+                   ParticipantContextSupplier participantContextSupplier) {
         this.serverUrl = baseUrl;
-        this.cacheValidity = cacheValidity;
         this.httpClient = httpClient;
         this.monitor = monitor.withPrefix(getClass().getSimpleName());
         this.mapper = mapper;
@@ -92,14 +93,15 @@ class BdrsClientImpl implements BdrsClient {
         this.ownCredentialServiceUrl = ownCredentialServiceUrl;
         this.credentialServiceClient = credentialServiceClient;
         this.participantContextSupplier = participantContextSupplier;
+        this.cache = new BdrsCache(cacheValidity);
     }
 
     @Override
-    public String resolveDid(String bpn) {
+    public String resolveDid(UUID participantContextId, String bpn) {
         lock.readLock().lock();
         try {
-            if (!isCacheExpired()) {
-                return cacheBpnDid.get(bpn);
+            if (!cache.isCacheExpired(participantContextId)) {
+                return cache.get(participantContextId, BDRS_CACHE_TYPE.BPN_TO_DID, bpn);
             }
         } finally {
             lock.readLock().unlock();
@@ -107,21 +109,21 @@ class BdrsClientImpl implements BdrsClient {
 
         lock.writeLock().lock();
         try {
-            if (isCacheExpired()) {
-                updateCache().orElseThrow(f -> new EdcException(f.getFailureDetail()));
+            if (cache.isCacheExpired(participantContextId)) {
+                updateCache(participantContextId).orElseThrow(f -> new EdcException(f.getFailureDetail()));
             }
-            return cacheBpnDid.get(bpn);
+            return cache.get(participantContextId, BDRS_CACHE_TYPE.BPN_TO_DID, bpn);
         } finally {
             lock.writeLock().unlock();
         }
     }
 
     @Override
-    public String resolveBpn(String did) {
+    public String resolveBpn(UUID participantContextId, String did) {
         lock.readLock().lock();
         try {
-            if (!isCacheExpired()) {
-                return cacheDidBpn.get(did);
+            if (!cache.isCacheExpired(participantContextId)) {
+                return cache.get(participantContextId, BDRS_CACHE_TYPE.DID_TO_BPN, did);
             }
         } finally {
             lock.readLock().unlock();
@@ -129,20 +131,16 @@ class BdrsClientImpl implements BdrsClient {
 
         lock.writeLock().lock();
         try {
-            if (isCacheExpired()) {
-                updateCache().orElseThrow(f -> new EdcException(f.getFailureDetail()));
+            if (cache.isCacheExpired(participantContextId)) {
+                updateCache(participantContextId).orElseThrow(f -> new EdcException(f.getFailureDetail()));
             }
-            return cacheDidBpn.get(did);
+            return cache.get(participantContextId, BDRS_CACHE_TYPE.DID_TO_BPN, did);
         } finally {
             lock.writeLock().unlock();
         }
     }
 
-    private boolean isCacheExpired() {
-        return lastCacheUpdate == null || lastCacheUpdate.plus(cacheValidity, ChronoUnit.SECONDS).isBefore(Instant.now());
-    }
-
-    private Result<Void> updateCache() {
+    private Result<Void> updateCache(UUID participantContextId) {
         var membershipCredToken = createMembershipPresentation();
         if (membershipCredToken.failed()) {
             return membershipCredToken.mapFailure();
@@ -159,15 +157,23 @@ class BdrsClientImpl implements BdrsClient {
                 var body = response.body().byteStream();
                 try (var gz = new GZIPInputStream(body)) {
                     var bytes = gz.readAllBytes();
-                    cacheBpnDid = mapper.readValue(bytes, MAP_REF);
-                    cacheDidBpn = cacheBpnDid.entrySet()
+                    Map<String, String> bpnToDidMapping = mapper.readValue(bytes, MAP_REF);
+
+                    // Store BPN→DID direction
+                    cache.setCache(participantContextId, BDRS_CACHE_TYPE.BPN_TO_DID, bpnToDidMapping);
+
+                    // Store inverted DID→BPN direction
+                    var didToBpnMapping = bpnToDidMapping.entrySet()
                             .stream()
-                            .collect(Collectors.toMap(
-                                    Map.Entry::getValue,
-                                    Map.Entry::getKey
-                            ));
-                    lastCacheUpdate = Instant.now();
+                            .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+                    cache.setCache(participantContextId, BDRS_CACHE_TYPE.DID_TO_BPN, didToBpnMapping);
+
+                    cache.markCacheUpdated(participantContextId);
                     return Result.success();
+                } catch (Exception e) {
+                    var msg = "Failed parsing the BDRS response into the local cache: code: %d, message: %s".formatted(response.code(), response.message());
+                    monitor.severe(msg);
+                    return Result.failure(msg);
                 }
             } else {
                 var msg = "Could not obtain data from BDRS server: code: %d, message: %s".formatted(response.code(), response.message());
@@ -175,7 +181,7 @@ class BdrsClientImpl implements BdrsClient {
                 return Result.failure(msg);
             }
         } catch (IOException e) {
-            var msg = "Error fetching BDRS data";
+            var msg = "Error fetching BDRS data: exception: %s".formatted(e.toString());
             monitor.severe(msg, e);
             return Result.failure(msg);
         }

--- a/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientImpl.java
+++ b/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientImpl.java
@@ -159,10 +159,10 @@ class BdrsClientImpl implements BdrsClient {
                     var bytes = gz.readAllBytes();
                     Map<String, String> bpnToDidMapping = mapper.readValue(bytes, MAP_REF);
 
-                    // Store BPN→DID direction
+                    // Store BPN -> DID cache
                     cache.setCache(participantContextId, BDRS_CACHE_TYPE.BPN_TO_DID, bpnToDidMapping);
 
-                    // Store inverted DID→BPN direction
+                    // Store inverted DID -> BPN cache
                     var didToBpnMapping = bpnToDidMapping.entrySet()
                             .stream()
                             .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));

--- a/spi/bdrs-client-spi/src/main/java/org/eclipse/tractusx/edc/spi/identity/mapper/BdrsCacheInterface.java
+++ b/spi/bdrs-client-spi/src/main/java/org/eclipse/tractusx/edc/spi/identity/mapper/BdrsCacheInterface.java
@@ -1,0 +1,168 @@
+/********************************************************************************
+ * Copyright (c) 2026 Catena-X Automotive Network e.V.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.edc.spi.identity.mapper;
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ *
+ * This is the BDRS cache implementation context aware (based on the participantContext logic from upstream).
+ * Also, it has an enabled selector, so that both cache directions (BPN_TO_DID and DID_TO_BPN) can be stored in the same cache instance.
+ *
+ * Example:
+ * <pre>{@code
+ *   var cache = new BdrsCache();
+ *   UUID tenant = UUID.randomUUID();
+ *
+ *   cache.put(tenant, BDRS_CACHE.BPN_TO_DID, "BPNL00000000VV12", "did:web:alice");
+ *   cache.put(tenant, BDRS_CACHE.DID_TO_BPN, "did:web:alice", "BPNL00000000VV12");
+ *
+ *   String did = cache.get(tenant, BDRS_CACHE.BPN_TO_DID, "BPNL00000000VV12");   // "did:web:alice"
+ *   String bpn = cache.get(tenant, BDRS_CACHE.DID_TO_BPN, "did:web:alice"); // "BPNL00000000VV12"
+ * }</pre>
+ *
+ * Additionally all the cache can be retrieved, replaced or cleared per direction and participant:
+ * Example:
+ * <pre>{@code
+ *  var cache = new BdrsCache();
+ *  UUID tenant = UUID.randomUUID();
+ *
+ *  cache.setCache(tenant, BDRS_CACHE.BPN_TO_DID, Map.of("BPNL00000000VV12", "did:web:alice", "BPNL00000000AT21", "did:web:bob"));
+ *
+ *  Map<String, String> bpnToDidCache = cache.getCache(tenant, BDRS_CACHE.BPN_TO_DID); // {"BPNL00000000VV12": "did:web:alice", "BPNL00000000AT21": "did:web:bob"}
+ *
+ * }</pre>
+ */
+@ExtensionPoint
+public interface BdrsCacheInterface {
+
+    /**
+     * This is are the selectors for the two cache partitions which is maintained for each participant.
+     */
+    enum BDRS_CACHE_TYPE {
+        BPN_TO_DID,
+        DID_TO_BPN
+    }
+
+    /**
+     * Returns the cache partition for the given participant, initializing the cache if not already present.
+     */
+    EnumMap<BDRS_CACHE_TYPE, Map<String, String>> getAllParticipantCaches(UUID participantContextId);
+
+    /**
+     * Purge all cached data in one direction for a participant.
+     *
+     * @param participantContextId the tenant scope
+     * @param cacheId which direction (BPN_TO_DID, or DID_TO_BPN)
+     */
+    void purgeCache(UUID participantContextId, BDRS_CACHE_TYPE cacheId);
+
+    /**
+     * Purge both directions for a participant, full reset of this participant's cache.
+     *
+     * @param participantContextId the tenant scope
+     */
+     void purgeAllParticipantCaches(UUID participantContextId);
+
+    /**
+     * Purge the participant from the cache.
+     *
+     * @param participantContextId the tenant scope
+     * @return {@code true} if the participant was present
+     */
+    boolean purgeParticipantCaches(UUID participantContextId);
+
+    /**
+     * Check whether a participant has any caches available.
+     *
+     * @param participantContextId the tenant scope
+     * @return {@code true} if the participant is registered in the cache
+     */
+    boolean hasParticipantCaches(UUID participantContextId);
+
+    /**
+     * Check whether the cache for a participant has expired.
+     *
+     * @param participantContextId the tenant scope
+     * @return {@code true} if the cache is expired or has never been populated
+     */
+    boolean isCacheExpired(UUID participantContextId);
+
+    /**
+     * Mark the cache for a participant as recently updated
+     *
+     * @param participantContextId the tenant scope
+     */
+    void markCacheUpdated(UUID participantContextId);
+
+    /**
+     * Get a single value.
+     *
+     * @param participantContextId the tenant scope
+     * @param cacheId which direction (BPN_TO_DID, or DID_TO_BPN)
+     * @param key the lookup key (bpn or did depending on direction)
+     * @return the mapped value, or {@code null}
+     */
+    String get(UUID participantContextId, BDRS_CACHE_TYPE cacheId, String key);
+
+    /**
+     * Store a single entry.
+     *
+     * @param participantContextId the tenant scope
+     * @param cacheId which direction (BPN_TO_DID, or DID_TO_BPN)
+     * @param key the lookup key (bpn or did depending on direction)
+     * @param value the mapped value (did or bpn depending on direction)
+     */
+    void put(UUID participantContextId, BDRS_CACHE_TYPE cacheId, String key, String value);
+
+    /**
+     * Purge a single entry.
+     *
+     * @param participantContextId the tenant scope
+     * @param cacheId which direction (BPN_TO_DID, or DID_TO_BPN)
+     * @param key the lookup key (bpn or did depending on direction)
+     * @return {@code true} if the key was present
+     */
+    boolean purge(UUID participantContextId, BDRS_CACHE_TYPE cacheId, String key);
+
+    /**
+     * Get the full cache for one direction of a participant.
+     *
+     * @param participantContextId the tenant scope
+     * @param cacheId which direction (BPN_TO_DID, or DID_TO_BPN)
+     * @return the cache map
+     */
+     Map<String, String> getCache(UUID participantContextId, BDRS_CACHE_TYPE cacheId);
+
+    /**
+     * Replace the full map for one direction of a participant.
+     *
+     * @param participantContextId the tenant scope
+     * @param cacheId which direction (BPN_TO_DID, or DID_TO_BPN)
+     * @param cacheData the new cache entries
+     */
+    void setCache(UUID participantContextId, BDRS_CACHE_TYPE cacheId, Map<String, String> cacheData);
+}
+
+

--- a/spi/bdrs-client-spi/src/main/java/org/eclipse/tractusx/edc/spi/identity/mapper/BdrsClient.java
+++ b/spi/bdrs-client-spi/src/main/java/org/eclipse/tractusx/edc/spi/identity/mapper/BdrsClient.java
@@ -22,25 +22,87 @@ package org.eclipse.tractusx.edc.spi.identity.mapper;
 
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 
+import java.util.Map;
+import java.util.UUID;
+
 /**
  * Interface for resolving BPNs to DIDs
+ * a participantId parameter so that the resolution is scoped to a specific tenant. If the
+ * BDRS server returns different mappings depending on the caller's credentials, the
+ * resolution must be participant-aware.
  */
 @ExtensionPoint
 public interface BdrsClient {
 
     /**
-     * Resolve the input BPN to a DID
+     * Resolve the input BPN to a DID context aware
      *
+     * @param participantContextId @type UUID the parameter needed for multi-tenant context mapping
      * @param bpn The participantID (BPN)
      * @return The resolved DID if found, null otherwise
      */
-    String resolveDid(String bpn);
+    String resolveDid(UUID participantContextId, String bpn);
 
     /**
-     * Resolve the input DID to a BPN
+     * Resolve the input DID to a BPN context aware
      *
+     * @param participantContextId @type UUID the parameter needed for multi-tenant context mapping
      * @param did The participantID (DID)
      * @return The resolved BPN if found, null otherwise
      */
-    String resolveBpn(String did);
+    String resolveBpn(UUID participantContextId, String did);
+
+
+    /**
+     * Set cached entry context aware
+     *
+     * @param participantContextId @type UUID the parameter needed for multi-tenant context mapping
+     * @param bpn The participantID (BPN)
+     * @param did The participantID (DID)
+     * @return The cache HashMap if found
+     */
+    Boolean setCacheEntry(UUID participantContextId, String bpn, String did);
+
+    /**
+     * Get cached entry context aware
+     *
+     * @param participantContextId @type UUID the parameter needed for multi-tenant context mapping
+     * @param bpn The participantID (BPN)
+     * @return The cache HashMap if found
+     */
+    String getCacheEntry(UUID participantContextId, String bpn);
+
+    /**
+     * Purge cache entry context aware
+     *
+     * @param participantContextId @type UUID the parameter needed for multi-tenant context mapping
+     * @return True if purged, False (Exception) otherwise
+     */
+    Boolean purgeCacheEntry(UUID participantContextId, String bpn);
+
+    /**
+     * Get cache context aware
+     *
+     * @param participantContextId @type UUID the parameter needed for multi-tenant context mapping
+     * @return True if updated, False (Exception) otherwise
+     */
+    Map<String, String> getCache(UUID participantContextId);
+
+    /**
+     * Set cache context aware
+     *
+     * @param participantContextId @type UUID the parameter needed for multi-tenant context mapping
+     * @param cache the cache to be introduced at the participantContextId entry.
+     * @return True if updated, False (Exception) otherwise
+     */
+    Boolean setCache(UUID participantContextId, Map<String, String> cache);
+
+    /**
+     * Purge cache context aware
+     *
+     * @param participantContextId @type UUID the parameter needed for multi-tenant context mapping
+     * @return True if purged, False (Exception) otherwise
+     */
+    Boolean purgeCache(UUID participantContextId);
+
 }

--- a/spi/bdrs-client-spi/src/main/java/org/eclipse/tractusx/edc/spi/identity/mapper/BdrsClient.java
+++ b/spi/bdrs-client-spi/src/main/java/org/eclipse/tractusx/edc/spi/identity/mapper/BdrsClient.java
@@ -22,14 +22,12 @@ package org.eclipse.tractusx.edc.spi.identity.mapper;
 
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 
-import java.util.Map;
 import java.util.UUID;
 
 /**
- * Interface for resolving BPNs to DIDs
- * a participantId parameter so that the resolution is scoped to a specific tenant. If the
- * BDRS server returns different mappings depending on the caller's credentials, the
- * resolution must be participant-aware.
+ * Interface for resolving BPNs to DIDs.
+ * Every resolution is scoped to a specific tenant via a participantContextId,
+ * so that different participants can have independent cache partitions.
  */
 @ExtensionPoint
 public interface BdrsClient {
@@ -51,58 +49,5 @@ public interface BdrsClient {
      * @return The resolved BPN if found, null otherwise
      */
     String resolveBpn(UUID participantContextId, String did);
-
-
-    /**
-     * Set cached entry context aware
-     *
-     * @param participantContextId @type UUID the parameter needed for multi-tenant context mapping
-     * @param bpn The participantID (BPN)
-     * @param did The participantID (DID)
-     * @return The cache HashMap if found
-     */
-    Boolean setCacheEntry(UUID participantContextId, String bpn, String did);
-
-    /**
-     * Get cached entry context aware
-     *
-     * @param participantContextId @type UUID the parameter needed for multi-tenant context mapping
-     * @param bpn The participantID (BPN)
-     * @return The cache HashMap if found
-     */
-    String getCacheEntry(UUID participantContextId, String bpn);
-
-    /**
-     * Purge cache entry context aware
-     *
-     * @param participantContextId @type UUID the parameter needed for multi-tenant context mapping
-     * @return True if purged, False (Exception) otherwise
-     */
-    Boolean purgeCacheEntry(UUID participantContextId, String bpn);
-
-    /**
-     * Get cache context aware
-     *
-     * @param participantContextId @type UUID the parameter needed for multi-tenant context mapping
-     * @return True if updated, False (Exception) otherwise
-     */
-    Map<String, String> getCache(UUID participantContextId);
-
-    /**
-     * Set cache context aware
-     *
-     * @param participantContextId @type UUID the parameter needed for multi-tenant context mapping
-     * @param cache the cache to be introduced at the participantContextId entry.
-     * @return True if updated, False (Exception) otherwise
-     */
-    Boolean setCache(UUID participantContextId, Map<String, String> cache);
-
-    /**
-     * Purge cache context aware
-     *
-     * @param participantContextId @type UUID the parameter needed for multi-tenant context mapping
-     * @return True if purged, False (Exception) otherwise
-     */
-    Boolean purgeCache(UUID participantContextId);
 
 }


### PR DESCRIPTION
> [!CAUTION]
> UNIT TESTs not yet implemented. I wanted to get some feedback so I can continue with the implementation until end .

## WHAT

- Restructured the cache mechanism to a class, so it can have it own constructuctor and manage the different participants caches independently.
- Refactored the BRDS client to support the new cache mechanism.
- Enhanced error handling from BDRS client implementation. So if there is an exception it will print.

## WHY

The BDRS cache was not yet participant context aware.

I also believed that the way we manage the BDRS cache can be improved and we should have a class which manages this cache for us, having methods to execute the CRUD + supporting us on the maintenance.

## FURTHER NOTES

I have programmed it myself this time, the interfaces, implementation class and architecture was done my me.

Copilot (Claude OPUS) was used for support only on the documentation, and to find which references are bring broken by the refactor and it will be used to create unit tests.

### Questions that I have still (may require ADR):

- In order to continue with "backward compatibility" shall we enable a "default" participant id, which can be used if the methods are called without a participantContextId?

Closes #2695 
