### PR TITLE
Extend policy logs

### DIFF
--- a/edc-extensions/cx-policy-legacy/src/main/java/org/eclipse/tractusx/edc/policy/cx/legacy/CxLegacyPolicyExtension.java
+++ b/edc-extensions/cx-policy-legacy/src/main/java/org/eclipse/tractusx/edc/policy/cx/legacy/CxLegacyPolicyExtension.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.policy.engine.spi.RuleBindingRegistry;
 import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.tractusx.edc.policy.cx.legacy.contractreference.ContractReferenceConstraintFunction;
@@ -65,15 +66,18 @@ public class CxLegacyPolicyExtension implements ServiceExtension {
     @Inject
     private RuleBindingRegistry bindingRegistry;
 
-    public static void registerFunctions(PolicyEngine engine) {
-        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, new DismantlerCredentialConstraintFunction<>());
-        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, new DismantlerCredentialConstraintFunction<>());
+    @Inject
+    private Monitor monitor;
 
-        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, new FrameworkAgreementConstraintFunction<>());
-        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, new FrameworkAgreementConstraintFunction<>());
+    public static void registerFunctions(PolicyEngine engine, Monitor monitor) {
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, new DismantlerCredentialConstraintFunction<>(monitor));
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, new DismantlerCredentialConstraintFunction<>(monitor));
 
-        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, new MembershipCredentialConstraintFunction<>());
-        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, new MembershipCredentialConstraintFunction<>());
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, new FrameworkAgreementConstraintFunction<>(monitor));
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, new FrameworkAgreementConstraintFunction<>(monitor));
+
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, new MembershipCredentialConstraintFunction<>(monitor));
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, new MembershipCredentialConstraintFunction<>(monitor));
 
         engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, CX_POLICY_NS + USAGE_PURPOSE, new UsagePurposeConstraintFunction<>());
         engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, CX_POLICY_NS + USAGE_PURPOSE, new UsagePurposeConstraintFunction<>());
@@ -108,7 +112,7 @@ public class CxLegacyPolicyExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        registerFunctions(policyEngine);
+        registerFunctions(policyEngine, monitor);
         registerBindings(bindingRegistry);
     }
 }

--- a/edc-extensions/cx-policy-legacy/src/main/java/org/eclipse/tractusx/edc/policy/cx/legacy/common/AbstractDynamicCredentialConstraintFunction.java
+++ b/edc-extensions/cx-policy-legacy/src/main/java/org/eclipse/tractusx/edc/policy/cx/legacy/common/AbstractDynamicCredentialConstraintFunction.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.policy.engine.spi.DynamicAtomicConstraintRuleFunction;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 
 import java.util.Collection;
@@ -42,10 +43,17 @@ public abstract class AbstractDynamicCredentialConstraintFunction<C extends Part
     public static final String ACTIVE = "active";
     public static final String CREDENTIAL_LITERAL = "Credential";
     protected static final Collection<Operator> EQUALITY_OPERATORS = List.of(Operator.EQ, Operator.NEQ);
+    private final Monitor monitor;
+
+    protected AbstractDynamicCredentialConstraintFunction(Monitor monitor) {
+        this.monitor = monitor.withPrefix(getClass().getSimpleName());
+    }
 
     protected boolean checkOperator(Operator actual, PolicyContext context, Collection<Operator> expectedOperators) {
         if (!expectedOperators.contains(actual)) {
-            context.reportProblem("Invalid operator: this constraint only allows the following operators: %s, but received '%s'.".formatted(EQUALITY_OPERATORS, actual));
+            var msg = "Invalid operator: this constraint only allows the following operators: %s, but received '%s'.".formatted(EQUALITY_OPERATORS, actual);
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
         return true;

--- a/edc-extensions/cx-policy-legacy/src/main/java/org/eclipse/tractusx/edc/policy/cx/legacy/dismantler/DismantlerCredentialConstraintFunction.java
+++ b/edc-extensions/cx-policy-legacy/src/main/java/org/eclipse/tractusx/edc/policy/cx/legacy/dismantler/DismantlerCredentialConstraintFunction.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.tractusx.edc.core.utils.credentials.CredentialTypePredicate;
 import org.eclipse.tractusx.edc.policy.cx.legacy.common.AbstractDynamicCredentialConstraintFunction;
 import org.jetbrains.annotations.NotNull;
@@ -57,6 +58,12 @@ public class DismantlerCredentialConstraintFunction<C extends ParticipantAgentPo
     // allows to encode multiple values in a single string in the right-operand. Policies don't handle list-type right-operands well.
     public static final String RIGHT_OPERAND_LIST_SEPARATOR = ",";
     private static final String ALLOWED_ACTIVITIES_LITERAL = "activityType";
+    private final Monitor monitor;
+
+    public DismantlerCredentialConstraintFunction(Monitor monitor) {
+        super(monitor);
+        this.monitor = monitor.withPrefix(getClass().getSimpleName());
+    }
 
     @Override
     public boolean evaluate(Object leftOperand, Operator operator, Object rightOperand, Permission permission, C context) {
@@ -67,6 +74,7 @@ public class DismantlerCredentialConstraintFunction<C extends ParticipantAgentPo
         // check if the participant agent contains the correct data
         var vcListResult = getCredentialList(participantAgent);
         if (vcListResult.failed()) { // couldn't extract credential list from agent
+            monitor.debug(vcListResult.getFailureDetail());
             context.reportProblem(vcListResult.getFailureDetail());
             return false;
         }
@@ -84,7 +92,9 @@ public class DismantlerCredentialConstraintFunction<C extends ParticipantAgentPo
                 return false;
             }
             if (!ACTIVE.equals(rightOperand)) {
-                context.reportProblem("Right-operand must be equal to '%s', but was '%s'".formatted(ACTIVE, rightOperand));
+                var msg = "Right-operand must be equal to '%s', but was '%s'".formatted(ACTIVE, rightOperand);
+                monitor.debug(msg);
+                context.reportProblem(msg);
                 return false;
             }
             if (operator == NEQ) {
@@ -98,7 +108,9 @@ public class DismantlerCredentialConstraintFunction<C extends ParticipantAgentPo
             if (hasInvalidOperand(operator, rightOperand, context)) return false;
             predicate = predicate.and(getCredentialPredicate(ALLOWED_VEHICLE_BRANDS_LITERAL, operator, rightOperand));
         } else {
-            context.reportProblem("Invalid left-operand: must be 'Dismantler[.activityType | .allowedBrands ], but was '%s'".formatted(leftOperand));
+            var msg = "Invalid left-operand: must be 'Dismantler[.activityType | .allowedBrands ], but was '%s'".formatted(leftOperand);
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
 
@@ -148,7 +160,9 @@ public class DismantlerCredentialConstraintFunction<C extends ParticipantAgentPo
         } else if (rightOperand instanceof Iterable<?>) {
             return !checkOperator(operator, context, List.of(EQ, NEQ, IN, IS_ANY_OF, IS_NONE_OF));
         } else {
-            context.reportProblem("Invalid right-operand type: expected String or List, but received: %s".formatted(rightOperand.getClass().getName()));
+            var msg = "Invalid right-operand type: expected String or List, but received: %s".formatted(rightOperand.getClass().getName());
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return true;
         }
     }

--- a/edc-extensions/cx-policy-legacy/src/main/java/org/eclipse/tractusx/edc/policy/cx/legacy/framework/FrameworkAgreementConstraintFunction.java
+++ b/edc-extensions/cx-policy-legacy/src/main/java/org/eclipse/tractusx/edc/policy/cx/legacy/framework/FrameworkAgreementConstraintFunction.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.tractusx.edc.core.utils.credentials.CredentialTypePredicate;
 import org.eclipse.tractusx.edc.policy.cx.legacy.common.AbstractDynamicCredentialConstraintFunction;
@@ -55,6 +56,12 @@ import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
 public class FrameworkAgreementConstraintFunction<C extends ParticipantAgentPolicyContext> extends AbstractDynamicCredentialConstraintFunction<C> {
     public static final String CONTRACT_VERSION_LITERAL = "contractVersion";
     public static final String FRAMEWORK_AGREEMENT_LITERAL = "FrameworkAgreement";
+    private final Monitor monitor;
+
+    public FrameworkAgreementConstraintFunction(Monitor monitor) {
+        super(monitor);
+        this.monitor = monitor.withPrefix(getClass().getSimpleName());
+    }
 
     /**
      * Evaluates the constraint's left-operand and right-operand against a list of {@link VerifiableCredential} objects.
@@ -77,7 +84,9 @@ public class FrameworkAgreementConstraintFunction<C extends ParticipantAgentPoli
 
         // we do not support list-type right-operands
         if (!(leftValue instanceof String) || !(rightValue instanceof String)) {
-            context.reportProblem("Both the right- and left-operand must be of type String but were '%s' and '%s', respectively.".formatted(leftValue.getClass(), rightValue.getClass()));
+            var msg = "Both the right- and left-operand must be of type String but were '%s' and '%s', respectively.".formatted(leftValue.getClass(), rightValue.getClass());
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
 
@@ -91,17 +100,21 @@ public class FrameworkAgreementConstraintFunction<C extends ParticipantAgentPoli
         } else if (leftOperand.startsWith(CX_POLICY_NS + FRAMEWORK_AGREEMENT_LITERAL)) { // new notation
             predicateResult = getFilterPredicate(rightOperand);
         } else { //invalid notation
-            context.reportProblem("Constraint left-operand must start with '%s' but was '%s'.".formatted(FRAMEWORK_AGREEMENT_LITERAL, leftValue));
+            var msg = "Constraint left-operand must start with '%s' but was '%s'.".formatted(FRAMEWORK_AGREEMENT_LITERAL, leftValue);
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
 
         if (predicateResult.failed()) { // couldn't extract subtype/version predicate from constraint
+            monitor.debug(predicateResult.getFailureDetail());
             context.reportProblem(predicateResult.getFailureDetail());
             return false;
         }
 
         var vcListResult = getCredentialList(participantAgent);
         if (vcListResult.failed()) { // couldn't extract credential list from agent
+            monitor.debug(vcListResult.getFailureDetail());
             context.reportProblem(vcListResult.getFailureDetail());
             return false;
         }
@@ -109,7 +122,9 @@ public class FrameworkAgreementConstraintFunction<C extends ParticipantAgentPoli
         var credentials = vcListResult.getContent().stream().filter(rootPredicate).toList();
 
         if (credentials.isEmpty()) {
-            context.reportProblem("No credentials found that match the give Policy constraint: [%s %s %s]".formatted(leftValue.toString(), operator.toString(), rightValue.toString()));
+            var msg = "No credentials found that match the give Policy constraint: [%s %s %s]".formatted(leftValue.toString(), operator.toString(), rightValue.toString());
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
         return true;

--- a/edc-extensions/cx-policy-legacy/src/main/java/org/eclipse/tractusx/edc/policy/cx/legacy/membership/MembershipCredentialConstraintFunction.java
+++ b/edc-extensions/cx-policy-legacy/src/main/java/org/eclipse/tractusx/edc/policy/cx/legacy/membership/MembershipCredentialConstraintFunction.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.tractusx.edc.core.utils.credentials.CredentialTypePredicate;
 import org.eclipse.tractusx.edc.policy.cx.legacy.common.AbstractDynamicCredentialConstraintFunction;
 
@@ -38,15 +39,25 @@ import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
  */
 public class MembershipCredentialConstraintFunction<C extends ParticipantAgentPolicyContext> extends AbstractDynamicCredentialConstraintFunction<C> {
     public static final String MEMBERSHIP_LITERAL = "Membership";
+    private final Monitor monitor;
+
+    public MembershipCredentialConstraintFunction(Monitor monitor) {
+        super(monitor);
+        this.monitor = monitor.withPrefix(getClass().getSimpleName());
+    }
 
     @Override
     public boolean evaluate(Object leftOperand, Operator operator, Object rightOperand, Permission permission, C context) {
         if (!ACTIVE.equals(rightOperand)) {
-            context.reportProblem("Right-operand must be equal to '%s', but was '%s'".formatted(ACTIVE, rightOperand));
+            var msg = "Right-operand must be equal to '%s', but was '%s'".formatted(ACTIVE, rightOperand);
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
         if (!(CX_POLICY_NS + MEMBERSHIP_LITERAL).equalsIgnoreCase(leftOperand.toString())) {
-            context.reportProblem("Invalid left-operand: must be 'Membership', but was '%s'".formatted(leftOperand));
+            var msg = "Invalid left-operand: must be 'Membership', but was '%s'".formatted(leftOperand);
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
         // make sure the ParticipantAgent is there
@@ -54,6 +65,7 @@ public class MembershipCredentialConstraintFunction<C extends ParticipantAgentPo
 
         var credentialResult = getCredentialList(participantAgent);
         if (credentialResult.failed()) {
+            monitor.debug(credentialResult.getFailureDetail());
             context.reportProblem(credentialResult.getFailureDetail());
             return false;
         }

--- a/edc-extensions/cx-policy-legacy/src/test/java/org/eclipse/tractusx/edc/policy/cx/legacy/dismantler/DismantlerCredentialConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy-legacy/src/test/java/org/eclipse/tractusx/edc/policy/cx/legacy/dismantler/DismantlerCredentialConstraintFunctionTest.java
@@ -22,8 +22,10 @@ package org.eclipse.tractusx.edc.policy.cx.legacy.dismantler;
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.tractusx.edc.policy.cx.legacy.CredentialFunctions;
 import org.eclipse.tractusx.edc.policy.cx.legacy.TestParticipantAgentPolicyContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,14 +39,22 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.policy.model.Operator.IN;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class DismantlerCredentialConstraintFunctionTest {
 
     private final ParticipantAgent participantAgent = mock();
-    private final DismantlerCredentialConstraintFunction<ParticipantAgentPolicyContext> function = new DismantlerCredentialConstraintFunction<>();
+    private final Monitor monitor = mock();
+    private DismantlerCredentialConstraintFunction<ParticipantAgentPolicyContext> function;
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
+
+    @BeforeEach
+    void setUp() {
+        when(monitor.withPrefix(anyString())).thenReturn(monitor);
+        function = new DismantlerCredentialConstraintFunction<>(monitor);
+    }
 
     @Test
     void evaluate_leftOperandInvalid() {

--- a/edc-extensions/cx-policy-legacy/src/test/java/org/eclipse/tractusx/edc/policy/cx/legacy/framework/FrameworkAgreementConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy-legacy/src/test/java/org/eclipse/tractusx/edc/policy/cx/legacy/framework/FrameworkAgreementConstraintFunctionTest.java
@@ -24,8 +24,10 @@ import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.tractusx.edc.policy.cx.legacy.CredentialFunctions;
 import org.eclipse.tractusx.edc.policy.cx.legacy.TestParticipantAgentPolicyContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -35,13 +37,21 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class FrameworkAgreementConstraintFunctionTest {
     private final ParticipantAgent participantAgent = mock();
-    private final FrameworkAgreementConstraintFunction<ParticipantAgentPolicyContext> function = new FrameworkAgreementConstraintFunction<>();
+    private final Monitor monitor = mock();
+    private FrameworkAgreementConstraintFunction<ParticipantAgentPolicyContext> function;
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
+
+    @BeforeEach
+    void setUp() {
+        when(monitor.withPrefix(anyString())).thenReturn(monitor);
+        function = new FrameworkAgreementConstraintFunction<>(monitor);
+    }
 
     @Test
     void evaluate_leftOperandInvalid() {

--- a/edc-extensions/cx-policy-legacy/src/test/java/org/eclipse/tractusx/edc/policy/cx/legacy/membership/MembershipCredentialConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy-legacy/src/test/java/org/eclipse/tractusx/edc/policy/cx/legacy/membership/MembershipCredentialConstraintFunctionTest.java
@@ -22,8 +22,10 @@ package org.eclipse.tractusx.edc.policy.cx.legacy.membership;
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.tractusx.edc.policy.cx.legacy.CredentialFunctions;
 import org.eclipse.tractusx.edc.policy.cx.legacy.TestParticipantAgentPolicyContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -31,14 +33,22 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class MembershipCredentialConstraintFunctionTest {
 
     private final ParticipantAgent participantAgent = mock();
-    private final MembershipCredentialConstraintFunction<ParticipantAgentPolicyContext> function = new MembershipCredentialConstraintFunction<>();
+    private final Monitor monitor = mock();
+    private MembershipCredentialConstraintFunction<ParticipantAgentPolicyContext> function;
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
+
+    @BeforeEach
+    void setUp() {
+        when(monitor.withPrefix(anyString())).thenReturn(monitor);
+        function = new MembershipCredentialConstraintFunction<>(monitor);
+    }
 
     @Test
     void evaluate_leftOperandInvalid() {

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/CxPolicyExtension.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/CxPolicyExtension.java
@@ -31,6 +31,7 @@ import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Prohibition;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
@@ -139,6 +140,9 @@ public class CxPolicyExtension implements ServiceExtension {
     @Inject
     JsonObjectValidatorRegistry validatorRegistry;
 
+    @Inject
+    private Monitor monitor;
+
     public void registerFunctions(PolicyEngine engine) {
 
         // Usage Prohibition Validators
@@ -157,31 +161,31 @@ public class CxPolicyExtension implements ServiceExtension {
 
         // Usage Duty Validators
         engine.registerFunction(PolicyMonitorContext.class, Duty.class,
-                withCxPolicyNsPrefix(DATA_PROVISIONING_END_DURATION_DAYS), new DataProvisioningEndDurationDaysConstraintFunction<>());
+                withCxPolicyNsPrefix(DATA_PROVISIONING_END_DURATION_DAYS), new DataProvisioningEndDurationDaysConstraintFunction<>(monitor));
         engine.registerFunction(TransferProcessPolicyContext.class, Duty.class,
-                withCxPolicyNsPrefix(DATA_PROVISIONING_END_DURATION_DAYS), new DataProvisioningEndDurationDaysConstraintFunction<>());
+                withCxPolicyNsPrefix(DATA_PROVISIONING_END_DURATION_DAYS), new DataProvisioningEndDurationDaysConstraintFunction<>(monitor));
         engine.registerFunction(PolicyMonitorContext.class, Duty.class,
-                withCxPolicyNsPrefix(DATA_PROVISIONING_END_DATE), new DataProvisioningEndDateConstraintFunction<>());
+                withCxPolicyNsPrefix(DATA_PROVISIONING_END_DATE), new DataProvisioningEndDateConstraintFunction<>(monitor));
         engine.registerFunction(TransferProcessPolicyContext.class, Duty.class,
-                withCxPolicyNsPrefix(DATA_PROVISIONING_END_DATE), new DataProvisioningEndDateConstraintFunction<>());
+                withCxPolicyNsPrefix(DATA_PROVISIONING_END_DATE), new DataProvisioningEndDateConstraintFunction<>(monitor));
 
         // Access and Usage Permission Validators
-        engine.registerFunction(CatalogPolicyContext.class, Permission.class, new DismantlerCredentialConstraintFunction<>());
-        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, new DismantlerCredentialConstraintFunction<>());
-        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, new DismantlerCredentialConstraintFunction<>());
+        engine.registerFunction(CatalogPolicyContext.class, Permission.class, new DismantlerCredentialConstraintFunction<>(monitor));
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, new DismantlerCredentialConstraintFunction<>(monitor));
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, new DismantlerCredentialConstraintFunction<>(monitor));
 
-        engine.registerFunction(CatalogPolicyContext.class, Permission.class, new FrameworkAgreementConstraintFunction<>());
-        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, new FrameworkAgreementConstraintFunction<>());
-        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, new FrameworkAgreementConstraintFunction<>());
+        engine.registerFunction(CatalogPolicyContext.class, Permission.class, new FrameworkAgreementConstraintFunction<>(monitor));
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, new FrameworkAgreementConstraintFunction<>(monitor));
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, new FrameworkAgreementConstraintFunction<>(monitor));
 
-        engine.registerFunction(CatalogPolicyContext.class, Permission.class, new MembershipCredentialConstraintFunction<>());
-        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, new MembershipCredentialConstraintFunction<>());
-        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, new MembershipCredentialConstraintFunction<>());
+        engine.registerFunction(CatalogPolicyContext.class, Permission.class, new MembershipCredentialConstraintFunction<>(monitor));
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, new MembershipCredentialConstraintFunction<>(monitor));
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, new MembershipCredentialConstraintFunction<>(monitor));
 
         engine.registerFunction(CatalogPolicyContext.class, Permission.class,
-                withCxPolicyNsPrefix(BUSINESS_PARTNER_GROUP), new BusinessPartnerGroupConstraintFunction<>(store, bdrsClient));
+                withCxPolicyNsPrefix(BUSINESS_PARTNER_GROUP), new BusinessPartnerGroupConstraintFunction<>(store, bdrsClient, monitor));
         engine.registerFunction(CatalogPolicyContext.class, Permission.class,
-                withCxPolicyNsPrefix(BUSINESS_PARTNER_NUMBER), new BusinessPartnerNumberConstraintFunction<>(bdrsClient));
+                withCxPolicyNsPrefix(BUSINESS_PARTNER_NUMBER), new BusinessPartnerNumberConstraintFunction<>(bdrsClient, monitor));
 
         // Usage Permission Validators
         engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class,
@@ -207,14 +211,14 @@ public class CxPolicyExtension implements ServiceExtension {
         engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, withCxPolicyNsPrefix(DATA_FREQUENCY), new DataFrequencyConstraintFunction<>());
         engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, withCxPolicyNsPrefix(DATA_FREQUENCY), new DataFrequencyConstraintFunction<>());
 
-        engine.registerFunction(PolicyMonitorContext.class, Permission.class, withCxPolicyNsPrefix(DATA_USAGE_END_DATE), new DataUsageEndDateConstraintFunction<>());
-        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, withCxPolicyNsPrefix(DATA_USAGE_END_DATE), new DataUsageEndDateConstraintFunction<>());
+        engine.registerFunction(PolicyMonitorContext.class, Permission.class, withCxPolicyNsPrefix(DATA_USAGE_END_DATE), new DataUsageEndDateConstraintFunction<>(monitor));
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, withCxPolicyNsPrefix(DATA_USAGE_END_DATE), new DataUsageEndDateConstraintFunction<>(monitor));
 
-        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, withCxPolicyNsPrefix(DATA_USAGE_END_DEFINITION), new DataUsageEndDefinitionConstraintFunction<>());
-        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, withCxPolicyNsPrefix(DATA_USAGE_END_DEFINITION), new DataUsageEndDefinitionConstraintFunction<>());
+        engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class, withCxPolicyNsPrefix(DATA_USAGE_END_DEFINITION), new DataUsageEndDefinitionConstraintFunction<>(monitor));
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, withCxPolicyNsPrefix(DATA_USAGE_END_DEFINITION), new DataUsageEndDefinitionConstraintFunction<>(monitor));
 
-        engine.registerFunction(PolicyMonitorContext.class, Permission.class, withCxPolicyNsPrefix(DATA_USAGE_END_DURATION_DAYS), new DataUsageEndDurationDaysConstraintFunction<>());
-        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, withCxPolicyNsPrefix(DATA_USAGE_END_DURATION_DAYS), new DataUsageEndDurationDaysConstraintFunction<>());
+        engine.registerFunction(PolicyMonitorContext.class, Permission.class, withCxPolicyNsPrefix(DATA_USAGE_END_DURATION_DAYS), new DataUsageEndDurationDaysConstraintFunction<>(monitor));
+        engine.registerFunction(TransferProcessPolicyContext.class, Permission.class, withCxPolicyNsPrefix(DATA_USAGE_END_DURATION_DAYS), new DataUsageEndDurationDaysConstraintFunction<>(monitor));
 
         engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class,
                 withCxPolicyNsPrefix(JURISDICTION_LOCATION), new JurisdictionLocationConstraintFunction<>());

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/businesspartner/BusinessPartnerGroupConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/businesspartner/BusinessPartnerGroupConstraintFunction.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
 import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
 import org.eclipse.tractusx.edc.validation.businesspartner.spi.store.BusinessPartnerStore;
@@ -51,8 +52,9 @@ public class BusinessPartnerGroupConstraintFunction<C extends ParticipantAgentPo
     private static final Map<Operator, Function<BpnGroupHolder, Boolean>> OPERATOR_EVALUATOR_MAP = new HashMap<>();
     private final BusinessPartnerStore store;
     private BdrsClient bdrsClient;
+    private final Monitor monitor;
 
-    public BusinessPartnerGroupConstraintFunction(BusinessPartnerStore store, BdrsClient bdrsClient) {
+    public BusinessPartnerGroupConstraintFunction(BusinessPartnerStore store, BdrsClient bdrsClient, Monitor monitor) {
         super(
                 Set.of(Operator.IS_ANY_OF, Operator.IS_NONE_OF),
                 "[\\s\\S]+",
@@ -60,6 +62,7 @@ public class BusinessPartnerGroupConstraintFunction<C extends ParticipantAgentPo
         );
         this.store = store;
         this.bdrsClient = bdrsClient;
+        this.monitor = monitor.withPrefix(getClass().getSimpleName());
         OPERATOR_EVALUATOR_MAP.put(IS_ANY_OF, this::evaluateIsAnyOf);
         OPERATOR_EVALUATOR_MAP.put(IS_NONE_OF, this::evaluateIsNoneOf);
     }
@@ -70,13 +73,17 @@ public class BusinessPartnerGroupConstraintFunction<C extends ParticipantAgentPo
         // invalid operator
         if (!ALLOWED_OPERATORS.contains(operator)) {
             var ops = ALLOWED_OPERATORS.stream().map(Enum::name).collect(Collectors.joining(", "));
-            context.reportProblem(format("Operator must be one of [%s] but was [%s]", ops, operator.name()));
+            var msg = format("Operator must be one of [%s] but was [%s]", ops, operator.name());
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
 
         var identity = participantAgent.getIdentity();
         if (identity == null) {
-            context.reportProblem("Identity of the participant agent cannot be null");
+            var msg = "Identity of the participant agent cannot be null";
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
 
@@ -89,6 +96,7 @@ public class BusinessPartnerGroupConstraintFunction<C extends ParticipantAgentPo
 
         // BPN not found in database
         if (groups.failed()) {
+            monitor.debug(groups.getFailureDetail());
             context.reportProblem(groups.getFailureDetail());
             return false;
         }
@@ -112,7 +120,9 @@ public class BusinessPartnerGroupConstraintFunction<C extends ParticipantAgentPo
             return ((Collection<?>) rightValue).stream().map(Object::toString).collect(Collectors.toSet());
         }
 
-        context.reportProblem(format("Right operand expected to be either String or a Collection, but was %s", rightValue.getClass()));
+        var msg = format("Right operand expected to be either String or a Collection, but was %s", rightValue.getClass());
+        monitor.debug(msg);
+        context.reportProblem(msg);
         return null;
     }
 

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/businesspartner/BusinessPartnerNumberConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/businesspartner/BusinessPartnerNumberConstraintFunction.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Failure;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
@@ -52,8 +53,9 @@ public class BusinessPartnerNumberConstraintFunction<C extends ParticipantAgentP
     );
 
     private BdrsClient bdrsClient;
+    private final Monitor monitor;
 
-    public BusinessPartnerNumberConstraintFunction(BdrsClient bdrsClient) {
+    public BusinessPartnerNumberConstraintFunction(BdrsClient bdrsClient, Monitor monitor) {
         super(
                 Set.of(Operator.IS_ANY_OF, Operator.IS_NONE_OF),
                 "^BPNL[0-9A-Z]{12}$",
@@ -61,6 +63,7 @@ public class BusinessPartnerNumberConstraintFunction<C extends ParticipantAgentP
         );
 
         this.bdrsClient = bdrsClient;
+        this.monitor = monitor.withPrefix(getClass().getSimpleName());
     }
 
     @Override
@@ -68,14 +71,17 @@ public class BusinessPartnerNumberConstraintFunction<C extends ParticipantAgentP
         var participantAgent = context.participantAgent();
 
         if (!SUPPORTED_OPERATORS.contains(operator)) {
-            var message = "Operator %s is not supported. Supported operators: %s".formatted(operator, SUPPORTED_OPERATORS);
-            context.reportProblem(message);
+            var msg = "Operator %s is not supported. Supported operators: %s".formatted(operator, SUPPORTED_OPERATORS);
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
 
         var identity = participantAgent.getIdentity();
         if (identity == null) {
-            context.reportProblem("Identity of the participant agent cannot be null");
+            var msg = "Identity of the participant agent cannot be null";
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
 
@@ -94,6 +100,7 @@ public class BusinessPartnerNumberConstraintFunction<C extends ParticipantAgentP
 
     private @NotNull Function<Failure, Boolean> reportFailure(PolicyContext context) {
         return f -> {
+            monitor.debug(f.getFailureDetail());
             context.reportProblem(f.getFailureDetail());
             return false;
         };
@@ -113,7 +120,9 @@ public class BusinessPartnerNumberConstraintFunction<C extends ParticipantAgentP
             boolean containsBpn = identity.equals(singleNumber);
             return success(containsBpn);
         }
-        return failure("Invalid right-value: operator '%s' requires a 'List' but got a '%s'"
-                .formatted(operator, Optional.of(rightValue).map(Object::getClass).map(Class::getName).orElse(null)));
+        var msg = "Invalid right-value: operator '%s' requires a 'List' but got a '%s'"
+                .formatted(operator, Optional.of(rightValue).map(Object::getClass).map(Class::getName).orElse(null));
+        monitor.debug(msg);
+        return failure(msg);
     }
 }

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDataEndDateConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDataEndDateConstraintFunction.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.policy.AgreementPolic
 import org.eclipse.edc.policy.engine.spi.AtomicConstraintRuleFunction;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Rule;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 
 import java.time.Instant;
@@ -44,8 +45,13 @@ public abstract class AbstractDataEndDateConstraintFunction<R extends Rule, C ex
     private static final Set<Operator> ALLOWED_OPERATORS = Set.of(
             Operator.EQ
     );
+    private final Monitor monitor;
 
     private static final String DATE_PATTERN = "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|[+-]\\d{2}:\\d{2}))$";
+
+    protected AbstractDataEndDateConstraintFunction(Monitor monitor) {
+        this.monitor = monitor.withPrefix(getClass().getSimpleName());
+    }
 
     @Override
     public boolean evaluate(Operator operator, Object rightOperand, R rule, C context) {
@@ -53,7 +59,9 @@ public abstract class AbstractDataEndDateConstraintFunction<R extends Rule, C ex
             var expiryDate = Instant.parse(rightOperand.toString());
             return !context.now().truncatedTo(ChronoUnit.SECONDS).isAfter(expiryDate);
         } catch (DateTimeParseException e) {
-            context.reportProblem("Invalid right-operand: right operand must match pattern '%s'".formatted(DATE_PATTERN));
+            var msg = "Invalid right-operand: right operand must match pattern '%s'".formatted(DATE_PATTERN);
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
     }

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDataEndDurationDaysConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDataEndDurationDaysConstraintFunction.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.policy.AgreementPolic
 import org.eclipse.edc.policy.engine.spi.AtomicConstraintRuleFunction;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Rule;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 
 import java.time.Instant;
@@ -41,6 +42,11 @@ public abstract class AbstractDataEndDurationDaysConstraintFunction<R extends Ru
     private static final Set<Operator> ALLOWED_OPERATORS = Set.of(
             Operator.EQ
     );
+    private final Monitor monitor;
+
+    protected AbstractDataEndDurationDaysConstraintFunction(Monitor monitor) {
+        this.monitor = monitor.withPrefix(getClass().getSimpleName());
+    }
 
     private Result<Integer> extractRightValue(Object rightOperand) {
         if (rightOperand instanceof Integer) {
@@ -65,7 +71,9 @@ public abstract class AbstractDataEndDurationDaysConstraintFunction<R extends Ru
                         .plus(rightValue, ChronoUnit.DAYS))
                 .map(expiryDate -> context.now().truncatedTo(ChronoUnit.DAYS).isBefore(expiryDate))
                 .orElse(failure -> {
-                    context.reportProblem("Failed to evaluate constraint due to invalid right operand: '%s'. Problems: %s".formatted(rightOperand, failure));
+                    var msg = "Failed to evaluate constraint due to invalid right operand: '%s'. Problems: %s".formatted(rightOperand, failure);
+                    monitor.debug(msg);
+                    context.reportProblem(msg);
                     return false;
                 });
     }

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDynamicCredentialConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDynamicCredentialConstraintFunction.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.policy.engine.spi.DynamicAtomicConstraintRuleFunction;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 
 import java.util.Collection;
@@ -42,10 +43,17 @@ public abstract class AbstractDynamicCredentialConstraintFunction<C extends Part
     public static final String ACTIVE = "active";
     public static final String CREDENTIAL_LITERAL = "Credential";
     protected static final Collection<Operator> EQUALITY_OPERATORS = List.of(Operator.EQ, Operator.NEQ);
+    private final Monitor monitor;
+
+    protected AbstractDynamicCredentialConstraintFunction(Monitor monitor) {
+        this.monitor = monitor.withPrefix(getClass().getSimpleName());
+    }
 
     protected boolean checkOperator(Operator actual, PolicyContext context, Collection<Operator> expectedOperators) {
         if (!expectedOperators.contains(actual)) {
-            context.reportProblem("Invalid operator: this constraint only allows the following operators: %s, but received '%s'.".formatted(EQUALITY_OPERATORS, actual));
+            var msg = "Invalid operator: this constraint only allows the following operators: %s, but received '%s'.".formatted(EQUALITY_OPERATORS, actual);
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
         return true;

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/dataprovisioning/DataProvisioningEndDateConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/dataprovisioning/DataProvisioningEndDateConstraintFunction.java
@@ -21,9 +21,14 @@ package org.eclipse.tractusx.edc.policy.cx.dataprovisioning;
 
 import org.eclipse.edc.connector.controlplane.contract.spi.policy.AgreementPolicyContext;
 import org.eclipse.edc.policy.model.Duty;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.tractusx.edc.policy.cx.common.AbstractDataEndDateConstraintFunction;
 
 
 public class DataProvisioningEndDateConstraintFunction<C extends AgreementPolicyContext> extends AbstractDataEndDateConstraintFunction<Duty, C> {
     public static final String DATA_PROVISIONING_END_DATE = "DataProvisioningEndDate";
+
+    public DataProvisioningEndDateConstraintFunction(Monitor monitor) {
+        super(monitor);
+    }
 }

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/dataprovisioning/DataProvisioningEndDurationDaysConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/dataprovisioning/DataProvisioningEndDurationDaysConstraintFunction.java
@@ -21,9 +21,14 @@ package org.eclipse.tractusx.edc.policy.cx.dataprovisioning;
 
 import org.eclipse.edc.connector.controlplane.contract.spi.policy.AgreementPolicyContext;
 import org.eclipse.edc.policy.model.Duty;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.tractusx.edc.policy.cx.common.AbstractDataEndDurationDaysConstraintFunction;
 
 
 public class DataProvisioningEndDurationDaysConstraintFunction<C extends AgreementPolicyContext> extends AbstractDataEndDurationDaysConstraintFunction<Duty, C> {
     public static final String DATA_PROVISIONING_END_DURATION_DAYS = "DataProvisioningEndDurationDays";
+
+    public DataProvisioningEndDurationDaysConstraintFunction(Monitor monitor) {
+        super(monitor);
+    }
 }

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDateConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDateConstraintFunction.java
@@ -21,9 +21,14 @@ package org.eclipse.tractusx.edc.policy.cx.datausage;
 
 import org.eclipse.edc.connector.controlplane.contract.spi.policy.AgreementPolicyContext;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.tractusx.edc.policy.cx.common.AbstractDataEndDateConstraintFunction;
 
 
 public class DataUsageEndDateConstraintFunction<C extends AgreementPolicyContext> extends AbstractDataEndDateConstraintFunction<Permission, C> {
     public static final String DATA_USAGE_END_DATE = "DataUsageEndDate";
+
+    public DataUsageEndDateConstraintFunction(Monitor monitor) {
+        super(monitor);
+    }
 }

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDefinitionConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDefinitionConstraintFunction.java
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.edc.policy.cx.datausage;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
 
 import java.util.Set;
@@ -33,7 +34,7 @@ import java.util.Set;
 public class DataUsageEndDefinitionConstraintFunction<C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<Permission, C> {
     public static final String DATA_USAGE_END_DEFINITION = "DataUsageEndDefinition";
 
-    public DataUsageEndDefinitionConstraintFunction() {
+    public DataUsageEndDefinitionConstraintFunction(Monitor monitor) {
         super(
                 Set.of(Operator.EQ),
                 Set.of(

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDurationDaysConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDurationDaysConstraintFunction.java
@@ -21,9 +21,14 @@ package org.eclipse.tractusx.edc.policy.cx.datausage;
 
 import org.eclipse.edc.connector.controlplane.contract.spi.policy.AgreementPolicyContext;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.tractusx.edc.policy.cx.common.AbstractDataEndDurationDaysConstraintFunction;
 
 
 public class DataUsageEndDurationDaysConstraintFunction<C extends AgreementPolicyContext> extends AbstractDataEndDurationDaysConstraintFunction<Permission, C> {
     public static final String DATA_USAGE_END_DURATION_DAYS = "DataUsageEndDurationDays";
+
+    public DataUsageEndDurationDaysConstraintFunction(Monitor monitor) {
+        super(monitor);
+    }
 }

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/dismantler/DismantlerCredentialConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/dismantler/DismantlerCredentialConstraintFunction.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.tractusx.edc.core.utils.credentials.CredentialTypePredicate;
 import org.eclipse.tractusx.edc.policy.cx.common.AbstractDynamicCredentialConstraintFunction;
 import org.jetbrains.annotations.NotNull;
@@ -57,6 +58,12 @@ public class DismantlerCredentialConstraintFunction<C extends ParticipantAgentPo
     // allows to encode multiple values in a single string in the right-operand. Policies don't handle list-type right-operands well.
     public static final String RIGHT_OPERAND_LIST_SEPARATOR = ",";
     private static final String ALLOWED_ACTIVITIES_LITERAL = "activityType";
+    private final Monitor monitor;
+
+    public DismantlerCredentialConstraintFunction(Monitor monitor) {
+        super(monitor);
+        this.monitor = monitor.withPrefix(getClass().getSimpleName());
+    }
 
     @Override
     public boolean evaluate(Object leftOperand, Operator operator, Object rightOperand, Permission permission, C context) {
@@ -67,6 +74,7 @@ public class DismantlerCredentialConstraintFunction<C extends ParticipantAgentPo
         // check if the participant agent contains the correct data
         var vcListResult = getCredentialList(participantAgent);
         if (vcListResult.failed()) { // couldn't extract credential list from agent
+            monitor.debug(vcListResult.getFailureDetail());
             context.reportProblem(vcListResult.getFailureDetail());
             return false;
         }
@@ -84,7 +92,9 @@ public class DismantlerCredentialConstraintFunction<C extends ParticipantAgentPo
                 return false;
             }
             if (!ACTIVE.equals(rightOperand)) {
-                context.reportProblem("Right-operand must be equal to '%s', but was '%s'".formatted(ACTIVE, rightOperand));
+                var msg = "Right-operand must be equal to '%s', but was '%s'".formatted(ACTIVE, rightOperand);
+                monitor.debug(msg);
+                context.reportProblem(msg);
                 return false;
             }
             if (operator == NEQ) {
@@ -98,7 +108,9 @@ public class DismantlerCredentialConstraintFunction<C extends ParticipantAgentPo
             if (hasInvalidOperand(operator, rightOperand, context)) return false;
             predicate = predicate.and(getCredentialPredicate(ALLOWED_VEHICLE_BRANDS_LITERAL, operator, rightOperand));
         } else {
-            context.reportProblem("Invalid left-operand: must be 'Dismantler[.activityType | .allowedBrands ], but was '%s'".formatted(leftOperand));
+            var msg = "Invalid left-operand: must be 'Dismantler[.activityType | .allowedBrands ], but was '%s'".formatted(leftOperand);
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
 
@@ -148,7 +160,9 @@ public class DismantlerCredentialConstraintFunction<C extends ParticipantAgentPo
         } else if (rightOperand instanceof Iterable<?>) {
             return !checkOperator(operator, context, List.of(EQ, NEQ, IN, IS_ANY_OF, IS_NONE_OF));
         } else {
-            context.reportProblem("Invalid right-operand type: expected String or List, but received: %s".formatted(rightOperand.getClass().getName()));
+            var msg = "Invalid right-operand type: expected String or List, but received: %s".formatted(rightOperand.getClass().getName());
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return true;
         }
     }

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/framework/FrameworkAgreementConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/framework/FrameworkAgreementConstraintFunction.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.tractusx.edc.core.utils.credentials.CredentialTypePredicate;
 import org.eclipse.tractusx.edc.policy.cx.common.AbstractDynamicCredentialConstraintFunction;
@@ -55,6 +56,12 @@ import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_2025_09_N
 public class FrameworkAgreementConstraintFunction<C extends ParticipantAgentPolicyContext> extends AbstractDynamicCredentialConstraintFunction<C> {
     public static final String CONTRACT_VERSION_LITERAL = "contractVersion";
     public static final String FRAMEWORK_AGREEMENT_LITERAL = "FrameworkAgreement";
+    private final Monitor monitor;
+
+    public FrameworkAgreementConstraintFunction(Monitor monitor) {
+        super(monitor);
+        this.monitor = monitor.withPrefix(getClass().getSimpleName());
+    }
 
     /**
      * Evaluates the constraint's left-operand and right-operand against a list of {@link VerifiableCredential} objects.
@@ -77,7 +84,9 @@ public class FrameworkAgreementConstraintFunction<C extends ParticipantAgentPoli
 
         // we do not support list-type right-operands
         if (!(leftValue instanceof String) || !(rightValue instanceof String)) {
-            context.reportProblem("Both the right- and left-operand must be of type String but were '%s' and '%s', respectively.".formatted(leftValue.getClass(), rightValue.getClass()));
+            var msg = "Both the right- and left-operand must be of type String but were '%s' and '%s', respectively.".formatted(leftValue.getClass(), rightValue.getClass());
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
 
@@ -91,17 +100,21 @@ public class FrameworkAgreementConstraintFunction<C extends ParticipantAgentPoli
         } else if (leftOperand.startsWith(CX_POLICY_2025_09_NS + FRAMEWORK_AGREEMENT_LITERAL)) { // new notation
             predicateResult = getFilterPredicate(rightOperand);
         } else { //invalid notation
-            context.reportProblem("Constraint left-operand must start with '%s' but was '%s'.".formatted(FRAMEWORK_AGREEMENT_LITERAL, leftValue));
+            var msg = "Constraint left-operand must start with '%s' but was '%s'.".formatted(FRAMEWORK_AGREEMENT_LITERAL, leftValue);
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
 
         if (predicateResult.failed()) { // couldn't extract subtype/version predicate from constraint
+            monitor.debug(predicateResult.getFailureDetail());
             context.reportProblem(predicateResult.getFailureDetail());
             return false;
         }
 
         var vcListResult = getCredentialList(participantAgent);
         if (vcListResult.failed()) { // couldn't extract credential list from agent
+            monitor.debug(vcListResult.getFailureDetail());
             context.reportProblem(vcListResult.getFailureDetail());
             return false;
         }
@@ -109,7 +122,9 @@ public class FrameworkAgreementConstraintFunction<C extends ParticipantAgentPoli
         var credentials = vcListResult.getContent().stream().filter(rootPredicate).toList();
 
         if (credentials.isEmpty()) {
-            context.reportProblem("No credentials found that match the give Policy constraint: [%s %s %s]".formatted(leftValue.toString(), operator.toString(), rightValue.toString()));
+            var msg = "No credentials found that match the give Policy constraint: [%s %s %s]".formatted(leftValue.toString(), operator.toString(), rightValue.toString());
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
         return true;

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/membership/MembershipCredentialConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/membership/MembershipCredentialConstraintFunction.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.tractusx.edc.core.utils.credentials.CredentialTypePredicate;
 import org.eclipse.tractusx.edc.policy.cx.common.AbstractDynamicCredentialConstraintFunction;
@@ -41,15 +42,25 @@ import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_2025_09_N
  */
 public class MembershipCredentialConstraintFunction<C extends ParticipantAgentPolicyContext> extends AbstractDynamicCredentialConstraintFunction<C> {
     public static final String MEMBERSHIP_LITERAL = "Membership";
+    private final Monitor monitor;
+
+    public MembershipCredentialConstraintFunction(Monitor monitor) {
+        super(monitor);
+        this.monitor = monitor.withPrefix(getClass().getSimpleName());
+    }
 
     @Override
     public boolean evaluate(Object leftOperand, Operator operator, Object rightOperand, Permission permission, C context) {
         if (!ACTIVE.equals(rightOperand)) {
-            context.reportProblem("Right-operand must be equal to '%s', but was '%s'".formatted(ACTIVE, rightOperand));
+            var msg = "Right-operand must be equal to '%s', but was '%s'".formatted(ACTIVE, rightOperand);
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
         if (!(CX_POLICY_2025_09_NS + MEMBERSHIP_LITERAL).equalsIgnoreCase(leftOperand.toString())) {
-            context.reportProblem("Invalid left-operand: must be 'Membership', but was '%s'".formatted(leftOperand));
+            var msg = "Invalid left-operand: must be 'Membership', but was '%s'".formatted(leftOperand);
+            monitor.debug(msg);
+            context.reportProblem(msg);
             return false;
         }
         // make sure the ParticipantAgent is there
@@ -57,6 +68,7 @@ public class MembershipCredentialConstraintFunction<C extends ParticipantAgentPo
 
         var credentialResult = getCredentialList(participantAgent);
         if (credentialResult.failed()) {
+            monitor.debug(credentialResult.getFailureDetail());
             context.reportProblem(credentialResult.getFailureDetail());
             return false;
         }

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/businesspartner/BusinessPartnerGroupConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/businesspartner/BusinessPartnerGroupConstraintFunctionTest.java
@@ -41,7 +41,7 @@ class BusinessPartnerGroupConstraintFunctionTest {
     private final ParticipantAgent participantAgent = mock();
     private final BusinessPartnerStore store = mock();
     private final BdrsClient bdrsClient = mock();
-    private final BusinessPartnerGroupConstraintFunction<ParticipantAgentPolicyContext> function = new BusinessPartnerGroupConstraintFunction<>(store, bdrsClient);
+    private final BusinessPartnerGroupConstraintFunction<ParticipantAgentPolicyContext> function = new BusinessPartnerGroupConstraintFunction<>(store, bdrsClient, mock());
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
 
     @Test

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/businesspartner/BusinessPartnerNumberConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/businesspartner/BusinessPartnerNumberConstraintFunctionTest.java
@@ -38,7 +38,7 @@ class BusinessPartnerNumberConstraintFunctionTest {
 
     private final ParticipantAgent participantAgent = mock();
     private final BdrsClient bdrsClient = mock();
-    private final BusinessPartnerNumberConstraintFunction<ParticipantAgentPolicyContext> function = new BusinessPartnerNumberConstraintFunction<>(bdrsClient);
+    private final BusinessPartnerNumberConstraintFunction<ParticipantAgentPolicyContext> function = new BusinessPartnerNumberConstraintFunction<>(bdrsClient, mock());
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
 
     @Test

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDataEndDateConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDataEndDateConstraintFunctionTest.java
@@ -31,10 +31,11 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class AbstractDataEndDateConstraintFunctionTest {
 
-    private final AbstractDataEndDateConstraintFunction<Permission, AgreementPolicyContext> function = new AbstractDataEndDateConstraintFunction<>() {};
+    private final AbstractDataEndDateConstraintFunction<Permission, AgreementPolicyContext> function = new AbstractDataEndDateConstraintFunction<>(mock()) {};
     private final AgreementPolicyContext context = new TestAgreementPolicyContext();
 
     private Instant contextNowWithDelta(Integer delta, ChronoUnit unit) {

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDataEndDurationDaysConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/common/AbstractDataEndDurationDaysConstraintFunctionTest.java
@@ -30,9 +30,10 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class AbstractDataEndDurationDaysConstraintFunctionTest {
-    private final AbstractDataEndDurationDaysConstraintFunction<Permission, AgreementPolicyContext> function = new AbstractDataEndDurationDaysConstraintFunction<>() {};
+    private final AbstractDataEndDurationDaysConstraintFunction<Permission, AgreementPolicyContext> function = new AbstractDataEndDurationDaysConstraintFunction<>(mock()) {};
 
     @Test
     void evaluate_whenPolicyIsValid_thenTrue() {

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/dataprovisioning/DataProvisioningEndDateConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/dataprovisioning/DataProvisioningEndDateConstraintFunctionTest.java
@@ -26,10 +26,11 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.ParameterizedType;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class DataProvisioningEndDateConstraintFunctionTest {
 
-    private final DataProvisioningEndDateConstraintFunction<AgreementPolicyContext> function = new DataProvisioningEndDateConstraintFunction<>();
+    private final DataProvisioningEndDateConstraintFunction<AgreementPolicyContext> function = new DataProvisioningEndDateConstraintFunction<>(mock());
 
     @Test
     void shouldOnlyApplyToDuty() {

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/dataprovisioning/DataProvisioningEndDurationDaysConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/dataprovisioning/DataProvisioningEndDurationDaysConstraintFunctionTest.java
@@ -26,10 +26,11 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.ParameterizedType;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class DataProvisioningEndDurationDaysConstraintFunctionTest {
 
-    private final DataProvisioningEndDurationDaysConstraintFunction<AgreementPolicyContext> function = new DataProvisioningEndDurationDaysConstraintFunction<>();
+    private final DataProvisioningEndDurationDaysConstraintFunction<AgreementPolicyContext> function = new DataProvisioningEndDurationDaysConstraintFunction<>(mock());
 
     @Test
     void shouldOnlyApplyToDuty() {

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDateConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDateConstraintFunctionTest.java
@@ -26,10 +26,11 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.ParameterizedType;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class DataUsageEndDateConstraintFunctionTest {
 
-    private final DataUsageEndDateConstraintFunction<AgreementPolicyContext> function = new DataUsageEndDateConstraintFunction<>();
+    private final DataUsageEndDateConstraintFunction<AgreementPolicyContext> function = new DataUsageEndDateConstraintFunction<>(mock());
 
     @Test
     void shouldOnlyApplyToPermission() {

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDefinitionConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDefinitionConstraintFunctionTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.mock;
 class DataUsageEndDefinitionConstraintFunctionTest {
 
     private final ParticipantAgent participantAgent = mock();
-    private final DataUsageEndDefinitionConstraintFunction<ParticipantAgentPolicyContext> function = new DataUsageEndDefinitionConstraintFunction<>();
+    private final DataUsageEndDefinitionConstraintFunction<ParticipantAgentPolicyContext> function = new DataUsageEndDefinitionConstraintFunction<>(mock());
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
 
     @Test

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDurationDaysConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/datausage/DataUsageEndDurationDaysConstraintFunctionTest.java
@@ -26,10 +26,10 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.ParameterizedType;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class DataUsageEndDurationDaysConstraintFunctionTest {
-
-    private final DataUsageEndDurationDaysConstraintFunction<AgreementPolicyContext> function = new DataUsageEndDurationDaysConstraintFunction<>();
+    private final DataUsageEndDurationDaysConstraintFunction<AgreementPolicyContext> function = new DataUsageEndDurationDaysConstraintFunction<>(mock());
 
     @Test
     void shouldOnlyApplyToPermission() {

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/dismantler/DismantlerCredentialConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/dismantler/DismantlerCredentialConstraintFunctionTest.java
@@ -22,7 +22,9 @@ package org.eclipse.tractusx.edc.policy.cx.dismantler;
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -39,14 +41,22 @@ import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
 import static org.eclipse.tractusx.edc.policy.cx.CredentialFunctions.createDismantlerCredential;
 import static org.eclipse.tractusx.edc.policy.cx.CredentialFunctions.createMembershipCredential;
 import static org.eclipse.tractusx.edc.policy.cx.CredentialFunctions.createPlainDismantlerCredential;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class DismantlerCredentialConstraintFunctionTest {
-
     private final ParticipantAgent participantAgent = mock();
-    private final DismantlerCredentialConstraintFunction<ParticipantAgentPolicyContext> function = new DismantlerCredentialConstraintFunction<>();
+    private final Monitor monitor = mock();
+    private DismantlerCredentialConstraintFunction<ParticipantAgentPolicyContext> function;
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
+
+
+    @BeforeEach
+    void setUp() {
+        when(monitor.withPrefix(anyString())).thenReturn(monitor);
+        function = new DismantlerCredentialConstraintFunction<>(monitor);
+    }
 
     @Test
     void evaluate_leftOperandInvalid() {

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/framework/FrameworkAgreementConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/framework/FrameworkAgreementConstraintFunctionTest.java
@@ -24,7 +24,9 @@ import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -37,13 +39,22 @@ import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_2025_09_N
 import static org.eclipse.tractusx.edc.policy.cx.CredentialFunctions.createCredential;
 import static org.eclipse.tractusx.edc.policy.cx.CredentialFunctions.createDataExchangeGovernanceCredential;
 import static org.eclipse.tractusx.edc.policy.cx.CredentialFunctions.createPlainDataExchangeGovernanceCredential;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class FrameworkAgreementConstraintFunctionTest {
     private final ParticipantAgent participantAgent = mock();
-    private final FrameworkAgreementConstraintFunction<ParticipantAgentPolicyContext> function = new FrameworkAgreementConstraintFunction<>();
+    private final Monitor monitor = mock();
+    private FrameworkAgreementConstraintFunction<ParticipantAgentPolicyContext> function;
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
+
+
+    @BeforeEach
+    void setUp() {
+        when(monitor.withPrefix(anyString())).thenReturn(monitor);
+        function = new FrameworkAgreementConstraintFunction<>(monitor);
+    }
 
     @Test
     void evaluate_leftOperandInvalid() {

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/membership/MembershipCredentialConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/membership/MembershipCredentialConstraintFunctionTest.java
@@ -22,7 +22,9 @@ package org.eclipse.tractusx.edc.policy.cx.membership;
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -32,14 +34,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_2025_09_NS;
 import static org.eclipse.tractusx.edc.policy.cx.CredentialFunctions.createDataExchangeGovernanceCredential;
 import static org.eclipse.tractusx.edc.policy.cx.CredentialFunctions.createMembershipCredential;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class MembershipCredentialConstraintFunctionTest {
-
     private final ParticipantAgent participantAgent = mock();
-    private final MembershipCredentialConstraintFunction<ParticipantAgentPolicyContext> function = new MembershipCredentialConstraintFunction<>();
+    private final Monitor monitor = mock();
+    private MembershipCredentialConstraintFunction<ParticipantAgentPolicyContext> function;
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
+
+
+    @BeforeEach
+    void setUp() {
+        when(monitor.withPrefix(anyString())).thenReturn(monitor);
+        function = new MembershipCredentialConstraintFunction<>(monitor);
+    }
 
     @Test
     void evaluate_leftOperandInvalid() {


### PR DESCRIPTION
## WHAT

This PR logs all evaluation failures for policies.

## WHY

To simplify the identification of a problem's root causes.


Closes #2729
