### PR TITLE
feat: resolve BPN from MembershipCredential in BusinessPartnerNumberConstraintFunction

### DIFF
--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/CxPolicyExtension.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/CxPolicyExtension.java
@@ -181,7 +181,7 @@ public class CxPolicyExtension implements ServiceExtension {
         engine.registerFunction(CatalogPolicyContext.class, Permission.class,
                 withCxPolicyNsPrefix(BUSINESS_PARTNER_GROUP), new BusinessPartnerGroupConstraintFunction<>(store, bdrsClient));
         engine.registerFunction(CatalogPolicyContext.class, Permission.class,
-                withCxPolicyNsPrefix(BUSINESS_PARTNER_NUMBER), new BusinessPartnerNumberConstraintFunction<>(bdrsClient));
+                withCxPolicyNsPrefix(BUSINESS_PARTNER_NUMBER), new BusinessPartnerNumberConstraintFunction<>());
 
         // Usage Permission Validators
         engine.registerFunction(ContractNegotiationPolicyContext.class, Permission.class,

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/businesspartner/BusinessPartnerNumberConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/businesspartner/BusinessPartnerNumberConstraintFunction.java
@@ -19,14 +19,15 @@
 
 package org.eclipse.tractusx.edc.policy.cx.businesspartner;
 
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.spi.result.Failure;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.tractusx.edc.core.utils.credentials.CredentialTypePredicate;
 import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
-import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -38,29 +39,30 @@ import java.util.function.Function;
 
 import static org.eclipse.edc.spi.result.Result.failure;
 import static org.eclipse.edc.spi.result.Result.success;
-import static org.eclipse.tractusx.edc.spi.identity.mapper.BdrsConstants.DID_PREFIX;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_CREDENTIAL_NS;
+import static org.eclipse.tractusx.edc.policy.cx.common.AbstractDynamicCredentialConstraintFunction.CREDENTIAL_LITERAL;
+import static org.eclipse.tractusx.edc.policy.cx.common.AbstractDynamicCredentialConstraintFunction.VC_CLAIM;
 
 /**
  * This is a constraint function that evaluates the BusinessPartnerNumber of a participant agent.
+ * The BPN is extracted from the {@code bpn} claim of the participant's BpnCredential.
  */
 public class BusinessPartnerNumberConstraintFunction<C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<Permission, C> {
     public static final String BUSINESS_PARTNER_NUMBER = "BusinessPartnerNumber";
+    private static final String BPN_CREDENTIAL_TYPE = "Bpn";
+    private static final String BPN_CLAIM = "bpn";
 
     private static final List<Operator> SUPPORTED_OPERATORS = Arrays.asList(
             Operator.IS_ANY_OF,
             Operator.IS_NONE_OF
     );
 
-    private BdrsClient bdrsClient;
-
-    public BusinessPartnerNumberConstraintFunction(BdrsClient bdrsClient) {
+    public BusinessPartnerNumberConstraintFunction() {
         super(
                 Set.of(Operator.IS_ANY_OF, Operator.IS_NONE_OF),
                 "^BPNL[0-9A-Z]{12}$",
                 true
         );
-
-        this.bdrsClient = bdrsClient;
     }
 
     @Override
@@ -68,19 +70,32 @@ public class BusinessPartnerNumberConstraintFunction<C extends ParticipantAgentP
         var participantAgent = context.participantAgent();
 
         if (!SUPPORTED_OPERATORS.contains(operator)) {
-            var message = "Operator %s is not supported. Supported operators: %s".formatted(operator, SUPPORTED_OPERATORS);
-            context.reportProblem(message);
+            context.reportProblem("Operator %s is not supported. Supported operators: %s".formatted(operator, SUPPORTED_OPERATORS));
             return false;
         }
 
-        var identity = participantAgent.getIdentity();
+        var vcListClaim = participantAgent.getClaims().get(VC_CLAIM);
+        if (!(vcListClaim instanceof List<?> vcList) || vcList.isEmpty()) {
+            context.reportProblem("ParticipantAgent did not contain a valid '%s' claim.".formatted(VC_CLAIM));
+            return false;
+        }
+
+        var bpnPredicate = new CredentialTypePredicate(CX_CREDENTIAL_NS, BPN_CREDENTIAL_TYPE + CREDENTIAL_LITERAL);
+        var identity = vcList.stream()
+                .filter(VerifiableCredential.class::isInstance)
+                .map(VerifiableCredential.class::cast)
+                .filter(bpnPredicate)
+                .flatMap(vc -> vc.getCredentialSubject().stream())
+                .flatMap(subject -> subject.getClaims().entrySet().stream())
+                .filter(e -> e.getKey().endsWith(BPN_CLAIM))
+                .map(Map.Entry::getValue)
+                .map(String.class::cast)
+                .findFirst()
+                .orElse(null);
+
         if (identity == null) {
-            context.reportProblem("Identity of the participant agent cannot be null");
+            context.reportProblem("Could not extract '%s' from BpnCredential".formatted(BPN_CLAIM));
             return false;
-        }
-
-        if (identity.startsWith(DID_PREFIX)) {
-            identity = bdrsClient.resolveBpn(identity);
         }
 
         return switch (operator) {
@@ -106,12 +121,11 @@ public class BusinessPartnerNumberConstraintFunction<C extends ParticipantAgentP
                     .map(entry -> ((Map<?, ?>) entry).get("@value"))
                     .filter(value -> value instanceof Map<?, ?>)
                     .map(value -> ((Map<?, ?>) value).get("string"))
-                    .anyMatch(bpn -> identity.equals(bpn));
+                    .anyMatch(identity::equals);
 
             return success(containsBpn);
         } else if (rightValue instanceof String singleNumber) {
-            boolean containsBpn = identity.equals(singleNumber);
-            return success(containsBpn);
+            return success(identity.equals(singleNumber));
         }
         return failure("Invalid right-value: operator '%s' requires a 'List' but got a '%s'"
                 .formatted(operator, Optional.of(rightValue).map(Object::getClass).map(Class::getName).orElse(null)));

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/businesspartner/BusinessPartnerNumberConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/businesspartner/BusinessPartnerNumberConstraintFunctionTest.java
@@ -20,44 +20,67 @@
 package org.eclipse.tractusx.edc.policy.cx.businesspartner;
 
 import jakarta.json.Json;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
-import org.eclipse.tractusx.edc.spi.identity.mapper.BdrsClient;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_CREDENTIAL_NS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class BusinessPartnerNumberConstraintFunctionTest {
 
+    private static final String TEST_BPN = "BPNL00000000001A";
+
     private final ParticipantAgent participantAgent = mock();
-    private final BdrsClient bdrsClient = mock();
-    private final BusinessPartnerNumberConstraintFunction<ParticipantAgentPolicyContext> function = new BusinessPartnerNumberConstraintFunction<>(bdrsClient);
+    private final BusinessPartnerNumberConstraintFunction<ParticipantAgentPolicyContext> function = new BusinessPartnerNumberConstraintFunction<>();
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
 
     @Test
     void evaluate() {
-        var identity = "BPNL00000000001A";
-        var bpn1 = Map.of("string", identity);
+        var bpn1 = Map.of("string", TEST_BPN);
         var rightValue = List.of(Map.of("@value", bpn1));
-        when(participantAgent.getIdentity()).thenReturn(identity);
+        when(participantAgent.getClaims()).thenReturn(Map.of("vc", bpnVcList(TEST_BPN)));
         assertThat(function.evaluate(Operator.IS_ANY_OF, rightValue, null, context)).isTrue();
     }
 
     @Test
-    void evaluate_withDid() {
-        var bpn1 = Map.of("string", "BPNL00000000001A");
+    void evaluate_whenIsNoneOf_andBpnNotInList() {
+        var bpn1 = Map.of("string", "BPNL00000000002B");
         var rightValue = List.of(Map.of("@value", bpn1));
-        var identity = "did:example:some-identity";
-        when(participantAgent.getIdentity()).thenReturn(identity);
-        when(bdrsClient.resolveBpn(identity)).thenReturn("BPNL00000000001A");
-        assertThat(function.evaluate(Operator.IS_ANY_OF, rightValue, null, context)).isTrue();
+        when(participantAgent.getClaims()).thenReturn(Map.of("vc", bpnVcList(TEST_BPN)));
+        assertThat(function.evaluate(Operator.IS_NONE_OF, rightValue, null, context)).isTrue();
+    }
+
+    @Test
+    void evaluate_whenIsNoneOf_andBpnInList_returnsFalse() {
+        var bpn1 = Map.of("string", TEST_BPN);
+        var rightValue = List.of(Map.of("@value", bpn1));
+        when(participantAgent.getClaims()).thenReturn(Map.of("vc", bpnVcList(TEST_BPN)));
+        assertThat(function.evaluate(Operator.IS_NONE_OF, rightValue, null, context)).isFalse();
+    }
+
+    @Test
+    void evaluate_whenNoVcClaim_returnsFalse() {
+        when(participantAgent.getClaims()).thenReturn(Map.of());
+        var rightValue = List.of(Map.of("@value", Map.of("string", TEST_BPN)));
+        assertThat(function.evaluate(Operator.IS_ANY_OF, rightValue, null, context)).isFalse();
+        assertThat(context.getProblems()).isNotEmpty();
+    }
+
+    @Test
+    void evaluate_whenNoBpnCredential_returnsFalse() {
+        when(participantAgent.getClaims()).thenReturn(Map.of("vc", List.of()));
+        var rightValue = List.of(Map.of("@value", Map.of("string", TEST_BPN)));
+        assertThat(function.evaluate(Operator.IS_ANY_OF, rightValue, null, context)).isFalse();
+        assertThat(context.getProblems()).isNotEmpty();
     }
 
     @Test
@@ -122,5 +145,18 @@ class BusinessPartnerNumberConstraintFunctionTest {
         var result = function.validate(Operator.IS_ANY_OF, rightValue, null);
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureDetail()).contains("Invalid right-operand: ");
+    }
+
+    private List<VerifiableCredential> bpnVcList(String bpn) {
+        return List.of(VerifiableCredential.Builder.newInstance()
+                .types(List.of(CX_CREDENTIAL_NS + "VerifiableCredential", CX_CREDENTIAL_NS + "BpnCredential"))
+                .id("test-vc-id")
+                .issuer(new org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer("did:web:issuer", Map.of()))
+                .issuanceDate(java.time.Instant.now())
+                .credentialSubject(org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialSubject.Builder.newInstance()
+                        .id("subject-id")
+                        .claim(CX_CREDENTIAL_NS + "bpn", bpn)
+                        .build())
+                .build());
     }
 }

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/MockVcIdentityService.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/MockVcIdentityService.java
@@ -85,7 +85,7 @@ public class MockVcIdentityService implements IdentityService {
         var claimToken = claimTokenResult.getContent();
         var bpnlConsumer = claimToken.getStringClaim(BUSINESS_PARTNER_NUMBER_CLAIM);
         var didConsumer = claimToken.getStringClaim(ISSUER);
-        var credentials = List.of(membershipCredential(bpnlConsumer, didConsumer), dataExchangeGovernanceCredential(bpnlConsumer, didConsumer));
+        var credentials = List.of(membershipCredential(bpnlConsumer, didConsumer), bpnCredential(bpnlConsumer, didConsumer), dataExchangeGovernanceCredential(bpnlConsumer, didConsumer));
 
         var claimTokenWithVc = ClaimToken.Builder.newInstance()
                 .claim(VC_CLAIM, credentials)
@@ -143,6 +143,20 @@ public class MockVcIdentityService implements IdentityService {
                 .credentialSubject(CredentialSubject.Builder.newInstance()
                         .id(didConsumer)
                         .claim("holderIdentifier", bpnlConsumer)
+                        .build())
+                .issuer(new Issuer("issuer", Map.of()))
+                .issuanceDate(Instant.now())
+                .build();
+    }
+
+    private VerifiableCredential bpnCredential(String bpnlConsumer, String didConsumer) {
+        return VerifiableCredential.Builder.newInstance()
+                .type("VerifiableCredential")
+                .type("BpnCredential")
+                .credentialSubject(CredentialSubject.Builder.newInstance()
+                        .id(didConsumer)
+                        .claim("holderIdentifier", bpnlConsumer)
+                        .claim("bpn", bpnlConsumer)
                         .build())
                 .issuer(new Issuer("issuer", Map.of()))
                 .issuanceDate(Instant.now())

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/DataspaceIssuer.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/DataspaceIssuer.java
@@ -88,6 +88,7 @@ public class DataspaceIssuer extends IdentityParticipant {
                 () -> CredentialSubject.Builder.newInstance()
                         .id(did)
                         .claim("holderIdentifier", bpn)
+                        .claim("bpn", bpn)
                         .build(),
                 membershipRawVc(did, bpn)
         );
@@ -162,8 +163,27 @@ public class DataspaceIssuer extends IdentityParticipant {
         return List.of(
                 issueMembershipCredential(did, bpn),
                 issueDismantlerCredential(did, bpn),
-                issueFrameworkCredential(did, bpn, "BpnCredential"),
+                issueBpnCredential(did, bpn),
                 issueFrameworkCredential(did, bpn, "DataExchangeGovernanceCredential"));
+    }
+
+    VerifiableCredentialResource issueBpnCredential(String did, String bpn) {
+        var subject = Json.createObjectBuilder()
+                .add("type", "BpnCredential")
+                .add("holderIdentifier", bpn)
+                .add("bpn", bpn)
+                .add("id", did)
+                .build();
+
+        return issueCredential(
+                did, bpn, "BpnCredential",
+                () -> CredentialSubject.Builder.newInstance()
+                        .id(did)
+                        .claim("holderIdentifier", bpn)
+                        .claim("bpn", bpn)
+                        .build(),
+                createVcBuilder("BpnCredential", subject)
+        );
     }
 
     private VerifiableCredentialResource issueCredential(String did, String bpn, String type, Supplier<CredentialSubject> credentialSubjectSupplier, JsonObjectBuilder vcBuilder) {
@@ -192,8 +212,8 @@ public class DataspaceIssuer extends IdentityParticipant {
                         .add("https://w3id.org/catenax/credentials")
                         .add("https://w3id.org/vc/status-list/2021/v1"))
                 .add("type", Json.createArrayBuilder()
-                        .add("VerifiableCredential")
-                        .add(type))
+                        .add(type)
+                        .add("VerifiableCredential"))
                 .add("credentialSubject", subjectSupplier)
                 .add("issuer", didUrl())
                 .add("issuanceDate", Instant.now().toString());

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/DcpParticipant.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/DcpParticipant.java
@@ -113,12 +113,7 @@ public class DcpParticipant extends TractusxDcpParticipantBase {
     }
 
     private List<VerifiableCredentialResource> issueCredentials(DataspaceIssuer issuer) {
-        return List.of(
-                issuer.issueMembershipCredential(getDid(), getBpn()),
-                issuer.issueDismantlerCredential(getDid(), getBpn()),
-                issuer.issueFrameworkCredential(getDid(), getBpn(), "BpnCredential"),
-                issuer.issueFrameworkCredential(getDid(), getBpn(), "DataExchangeGovernanceCredential")
-        );
+        return issuer.issueCredentials(getDid(), getBpn());
     }
 
     public KeyDescriptor createKeyDescriptor() {


### PR DESCRIPTION
## Summary

- Removes the dependency on `BdrsClient` for BPN resolution in `BusinessPartnerNumberConstraintFunction`
- The BPN is now extracted directly from the `holderIdentifier` property of the participant's `MembershipCredential` (VC claim), eliminating the external BDRS lookup
- Updates `CxPolicyExtension` to construct `BusinessPartnerNumberConstraintFunction` without the `BdrsClient` argument

Closes #2462