### PR TITLE
feat: Clean up of identifier in helm charts

### DIFF
--- a/charts/tractusx-connector-memory/README.md
+++ b/charts/tractusx-connector-memory/README.md
@@ -59,7 +59,6 @@ helm install my-release tractusx-edc/tractusx-connector-memory --version 0.13.0-
 | dcp.cache.enabled | bool | `true` | Whether the Verifiable Presentation cache is enabled |
 | dcp.cache.validity | int | `86400` | Validity of the Verifiable Presentation cache in seconds |
 | dcp.didService.selfRegistration.enabled | bool | `false` | Whether Service Self Registration is enabled |
-| dcp.id | string | `"did:web:changeme"` | Decentralized IDentifier (DID) of the connector |
 | dcp.sts.div.url | string | `nil` | URL where connectors can request SI tokens |
 | dcp.sts.oauth.client.id | string | `nil` | Client ID for requesting OAuth2 access token for DIV access |
 | dcp.sts.oauth.client.secret_alias | string | `nil` | Alias under which the client secret is stored in the vault for requesting OAuth2 access token for DIV access |
@@ -70,8 +69,9 @@ helm install my-release tractusx-edc/tractusx-connector-memory --version 0.13.0-
 | log4j2.config | string | `"Appenders:\n  Console:\n    name: CONSOLE\n    JsonTemplateLayout:\n      eventTemplate: |-\n        {\n          \"timestamp\": {\n            \"$resolver\": \"timestamp\",\n            \"pattern\": {\n              \"format\": \"yyyy-MM-dd'T'HH:mm:ss.SSSSSSS\",\n              \"timeZone\": \"UTC\"\n            }\n          },\n          \"level\": {\n            \"$resolver\": \"level\",\n            \"field\": \"severity\",\n            \"severity\": {\n              \"field\": \"keyword\"\n            }\n          },\n          \"message\": {\n            \"$resolver\": \"message\"\n          }\n        }\nLoggers:\n  Root:\n    level: \"OFF\"\n  Logger:\n    name: org.eclipse.edc.monitor.logger\n    level: DEBUG\n    AppenderRef:\n      ref: CONSOLE"` | Log4j2 configuration for json log formatting. |
 | log4j2.enableJsonLogs | bool | `true` | Whether to enable the json log config in log4j2.config |
 | nameOverride | string | `""` |  |
+| participant.bpnl | string | `"BPNLCHANGEME"` | BPNL Number |
 | participant.contextId | string | `"UUID CHANGEME"` | Participant Context Id - Newly introduced id for a connector instance (needed for multitenancy) |
-| participant.id | string | `"BPNLCHANGEME"` | BPN Number |
+| participant.id | string | `"did:web:changeme"` | Participant Id, resp. the Decentralized IDentifier (DID) of the connector |
 | runtime.affinity | object | `{}` | [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) to configure which nodes the pods can be scheduled on |
 | runtime.autoscaling.enabled | bool | `false` | Enables [horizontal pod autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
 | runtime.autoscaling.maxReplicas | int | `100` | Maximum replicas if resource consumption exceeds resource threshholds |

--- a/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
+++ b/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
@@ -146,13 +146,13 @@ spec:
             ## ID CONFIGURATION ##
             ########################
             - name: EDC_PARTICIPANT_ID
-              value: {{ .Values.dcp.id | required ".Values.dcp.id is required" | quote }}
+              value: {{ .Values.participant.id | required ".Values.participant.id is required" | quote }}
             - name: "EDC_IAM_ISSUER_ID"
-              value: {{ .Values.dcp.id | required ".Values.dcp.id is required" | quote }}
+              value: {{ .Values.participant.id | required ".Values.participant.id is required" | quote }}
             - name: "EDC_PARTICIPANT_CONTEXT_ID"
               value: {{ .Values.participant.contextId | required ".Values.participant.contextId is required" | quote }}
             - name: "TRACTUSX_EDC_PARTICIPANT_BPN"
-              value: {{ .Values.participant.id | required ".Values.participant.id is required" | quote }}
+              value: {{ .Values.participant.bpnl | required ".Values.participant.bpnl is required" | quote }}
 
             ###########################
             ## LOGGING CONFIGURATION ##

--- a/charts/tractusx-connector-memory/values.yaml
+++ b/charts/tractusx-connector-memory/values.yaml
@@ -33,14 +33,14 @@ imagePullSecrets: []
 customLabels: {}
 
 participant:
-  # -- BPN Number
-  id: "BPNLCHANGEME"
+  # -- Participant Id, resp. the Decentralized IDentifier (DID) of the connector
+  id: "did:web:changeme"
+  # -- BPNL Number
+  bpnl: "BPNLCHANGEME"
   # -- Participant Context Id - Newly introduced id for a connector instance (needed for multitenancy)
   contextId: "UUID CHANGEME"
 
 dcp:
-  # -- Decentralized IDentifier (DID) of the connector
-  id: "did:web:changeme"
   # -- Configures the trusted issuers for this runtime. If no supportedTypes are specified, the value defaults to "*" for that issuer
   trustedIssuers: []
   # - id: "did:web:example1.com"

--- a/charts/tractusx-connector/README.md
+++ b/charts/tractusx-connector/README.md
@@ -260,7 +260,6 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.13.0-SNAPSHO
 | dcp.cache.enabled | bool | `true` | Whether the Verifiable Presentation cache is enabled |
 | dcp.cache.validity | int | `86400` | Validity of the Verifiable Presentation cache in seconds |
 | dcp.didService.selfRegistration.enabled | bool | `false` | Whether Service Self Registration is enabled |
-| dcp.id | string | `"did:web:changeme"` | Decentralized IDentifier (DID) of the connector |
 | dcp.sts.div.url | string | `nil` | URL where connectors can request SI tokens |
 | dcp.sts.oauth.client.id | string | `nil` | Client ID for requesting OAuth2 access token for DIV access |
 | dcp.sts.oauth.client.secret_alias | string | `nil` | Alias under which the client secret is stored in the vault for requesting OAuth2 access token for DIV access |
@@ -278,8 +277,9 @@ helm install my-release tractusx-edc/tractusx-connector --version 0.13.0-SNAPSHO
 | networkPolicy.dataplane | object | `{"from":[{"namespaceSelector":{}}]}` | Configuration of the dataplane component |
 | networkPolicy.dataplane.from | list | `[{"namespaceSelector":{}}]` | Specify from rule network policy for dp (defaults to all namespaces) |
 | networkPolicy.enabled | bool | `false` | If `true` network policy will be created to restrict access to control- and dataplane |
+| participant.bpnl | string | `"BPNLCHANGEME"` | BPNL Number |
 | participant.contextId | string | `"UUID CHANGEME"` | Participant Context Id - Newly introduced id for a connector instance (needed for multitenancy) |
-| participant.id | string | `"BPNLCHANGEME"` | BPN Number |
+| participant.id | string | `"did:web:changeme"` | Participant Id, resp. the Decentralized IDentifier (DID) of the connector |
 | postgresql.auth.database | string | `"edc"` |  |
 | postgresql.auth.password | string | `"password"` |  |
 | postgresql.auth.username | string | `"user"` |  |

--- a/charts/tractusx-connector/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-controlplane.yaml
@@ -147,13 +147,13 @@ spec:
             ## ID CONFIGURATION ##
             ########################
             - name: EDC_PARTICIPANT_ID
-              value: {{ .Values.dcp.id | required ".Values.dcp.id is required" | quote }}
+              value: {{ .Values.participant.id | required ".Values.participant.id is required" | quote }}
             - name: "EDC_IAM_ISSUER_ID"
-              value: {{ .Values.dcp.id | required ".Values.dcp.id is required" | quote }}
+              value: {{ .Values.participant.id | required ".Values.participant.id is required" | quote }}
             - name: "EDC_PARTICIPANT_CONTEXT_ID"
               value: {{ .Values.participant.contextId | required ".Values.participant.contextId is required" | quote }}
             - name: "TRACTUSX_EDC_PARTICIPANT_BPN"
-              value: {{ .Values.participant.id | required ".Values.participant.id is required" | quote }}
+              value: {{ .Values.participant.bpnl | required ".Values.participant.bpnl is required" | quote }}
 
             ###########################
             ## LOGGING CONFIGURATION ##

--- a/charts/tractusx-connector/templates/deployment-dataplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-dataplane.yaml
@@ -149,7 +149,7 @@ spec:
             - name: EDC_PARTICIPANT_CONTEXT_ID
               value: {{ .Values.participant.contextId | required ".Values.participant.contextId is required" | quote}}
             - name: "EDC_IAM_ISSUER_ID"
-              value: {{ .Values.dcp.id | required ".Values.dcp.id is required" | quote}}
+              value: {{ .Values.participant.id | required ".Values.participant.id is required" | quote}}
 
             ###########################
             ## LOGGING CONFIGURATION ##

--- a/charts/tractusx-connector/values.yaml
+++ b/charts/tractusx-connector/values.yaml
@@ -40,14 +40,14 @@ imagePullSecrets: []
 customLabels: {}
 
 participant:
-  # -- BPN Number
-  id: "BPNLCHANGEME"
+  # -- Participant Id, resp. the Decentralized IDentifier (DID) of the connector
+  id: "did:web:changeme"
+  # -- BPNL Number
+  bpnl: "BPNLCHANGEME"
   # -- Participant Context Id - Newly introduced id for a connector instance (needed for multitenancy)
   contextId: "UUID CHANGEME"
 
 dcp:
-  # -- Decentralized IDentifier (DID) of the connector
-  id: "did:web:changeme"
   # -- Configures the trusted issuers for this runtime. If no supportedTypes are specified, the value defaults to "*" for that issuer
   trustedIssuers: []
   # - id: "did:web:example1.com"

--- a/edc-tests/deployment/src/main/resources/helm/tractusx-connector-memory-test.yaml
+++ b/edc-tests/deployment/src/main/resources/helm/tractusx-connector-memory-test.yaml
@@ -22,11 +22,10 @@
 ---
 fullnameOverride: tx-inmem
 participant:
-  id: "test-participant"
+  id: "did:web:changeme"
+  bpnl: "test-participant"
   contextId: "test-participant-context"
 dcp:
-  # Decentralized IDentifier
-  id: "did:web:changeme"
   sts:
     div:
       url: "https://somewhere.div.org"

--- a/edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml
+++ b/edc-tests/deployment/src/main/resources/helm/tractusx-connector-test.yaml
@@ -23,11 +23,10 @@ fullnameOverride: tx-prod
 # EDC ControlPlane + DataPlane #
 ################################
 participant:
-  id: "test-participant"
+  id: "did:web:changeme"
+  bpnl: "test-participant"
   contextId: "test-participant-context"
 dcp:
-  # Decentralized IDentifier
-  id: "did:web:changeme"
   sts:
     div:
       url: "https://somewhere.div.org"


### PR DESCRIPTION
## WHAT

The identifier in the values file of the helm charts were not updated during the switch from BPNL to DID as participant id. This has been fixed with this pull request

## WHY

To get rid of an inconsistency. As we are currently doing breaking changes in the helm charts anyway, this is the chance to clean up this issue.

Closes #2721 
