### PR TITLE
chore(deps): Update bugfix version of edc build

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ format.version = "1.1"
 [versions]
 edc = "0.15.1"
 edc-next = "0.16.0"
-edc-build = "1.5.0"
+edc-build = "1.5.2"
 allure = "2.34.0"
 awaitility = "4.3.0"
 aws = "2.42.35"


### PR DESCRIPTION
## WHAT

edc-build 1.5.2 has been released, we use 1.5.0, update to the bugfix

## WHY

There is a reason for the bugfix version

