### PR TITLE
fix: make dependabot ignore SNAPSHOT versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,8 @@ updates:
     ignore:
       - dependency-name: "org.eclipse.dataspacetck.dsp:*"
       - dependency-name: "org.eclipse.dataspacetck.dcp:*"
+      - dependency-name: "*"
+        versions: [ "*SNAPSHOT" ]
 
   # Github Actions
   -


### PR DESCRIPTION
## WHAT

As the title says

## WHY

Because Maven rejects the library with  SNAPSHOT dependencies from publishing

Closes #2774
