### PR TITLE
fix: remove snapshot maven repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,8 +37,6 @@ updates:
     ignore:
       - dependency-name: "org.eclipse.dataspacetck.dsp:*"
       - dependency-name: "org.eclipse.dataspacetck.dcp:*"
-      - dependency-name: "*"
-        versions: [ "*SNAPSHOT" ]
 
   # Github Actions
   -

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,23 +20,16 @@
 
 rootProject.name = "tractusx-edc"
 
-// this is needed to have access to snapshot builds of plugins
 pluginManagement {
     repositories {
         gradlePluginPortal()
         mavenCentral()
-        maven {
-            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
-        }
     }
 }
 
 dependencyResolutionManagement {
     repositories {
         mavenLocal()
-        maven {
-            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
-        }
         mavenCentral()
     }
     versionCatalogs {


### PR DESCRIPTION
## WHAT

Revert changes from [PR](https://github.com/eclipse-tractusx/tractusx-edc/pull/2775) and reimplement by removing maven snapshot repository.

## WHY

Because Maven rejects the library with SNAPSHOT dependencies from publishing

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #2774
