### PR TITLE
fix: remove concurrency for publish-new-snapshot

### DIFF
--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -60,11 +60,6 @@ on:
   # periodic build triggers are defined in run-all-tests.yml, which triggers this workflow
 
 
-concurrency:
-  # cancel older running jobs on the same branch
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 


### PR DESCRIPTION
## WHAT

Remove concurrency for publish-new-snapshot

## WHY

It is conflicting with run-all-tests.yml
