### PR TITLE
feat: remove validation from UsagePurposeConstraintFunction

### DIFF
--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/usage/UsagePurposeConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/usage/UsagePurposeConstraintFunction.java
@@ -20,19 +20,28 @@
 package org.eclipse.tractusx.edc.policy.cx.usage;
 
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
-import org.eclipse.edc.policy.engine.spi.AtomicConstraintRuleFunction;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.tractusx.edc.policy.cx.common.BaseConstraintFunction;
+
+import java.util.Set;
 
 /**
  * This is a placeholder constraint function for UsagePurpose. It always returns true but allows
  * the validation of policies to be strictly enforced.
  */
-public class UsagePurposeConstraintFunction<C extends ParticipantAgentPolicyContext> implements AtomicConstraintRuleFunction<Permission, C> {
+public class UsagePurposeConstraintFunction<C extends ParticipantAgentPolicyContext> extends BaseConstraintFunction<Permission, C> {
     public static final String USAGE_PURPOSE = "UsagePurpose";
 
+    public UsagePurposeConstraintFunction() {
+        super(
+                Set.of(Operator.IS_ANY_OF)
+        );
+    }
+
     @Override
-    public boolean evaluate(Operator operator, Object rightValue, Permission rule, C context) {
-        return true;
+    protected Result<Void> validateRightOperand(Object rightValue) {
+        return Result.success();
     }
 }

--- a/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/usage/UsagePurposeConstraintFunction.java
+++ b/edc-extensions/cx-policy/src/main/java/org/eclipse/tractusx/edc/policy/cx/usage/UsagePurposeConstraintFunction.java
@@ -20,54 +20,19 @@
 package org.eclipse.tractusx.edc.policy.cx.usage;
 
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
+import org.eclipse.edc.policy.engine.spi.AtomicConstraintRuleFunction;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
-import org.eclipse.tractusx.edc.policy.cx.common.ValueValidatingConstraintFunction;
-
-import java.util.Set;
 
 /**
  * This is a placeholder constraint function for UsagePurpose. It always returns true but allows
  * the validation of policies to be strictly enforced.
  */
-public class UsagePurposeConstraintFunction<C extends ParticipantAgentPolicyContext> extends ValueValidatingConstraintFunction<Permission, C> {
+public class UsagePurposeConstraintFunction<C extends ParticipantAgentPolicyContext> implements AtomicConstraintRuleFunction<Permission, C> {
     public static final String USAGE_PURPOSE = "UsagePurpose";
 
-    public UsagePurposeConstraintFunction() {
-        super(
-                Set.of(Operator.IS_ANY_OF),
-                Set.of(
-                        "cx.core.legalRequirementForThirdparty:1",
-                        "cx.core.industrycore:1",
-                        "cx.core.qualityNotifications:1",
-                        "cx.core.digitalTwinRegistry:1",
-                        "cx.pcf.base:1",
-                        "cx.quality.base:1",
-                        "cx.dcm.base:1",
-                        "cx.puris.base:1",
-                        "cx.circular.dpp:1",
-                        "cx.circular.smc:1",
-                        "cx.circular.marketplace:1",
-                        "cx.circular.materialaccounting:1",
-                        "cx.bpdm.gate.upload:1",
-                        "cx.bpdm.gate.download:1",
-                        "cx.bpdm.pool:1",
-                        "cx.bpdm.vas.countryrisk:1",
-                        "cx.bpdm.vas.dataquality.upload:1",
-                        "cx.bpdm.vas.dataquality.download:1",
-                        "cx.bpdm.vas.bdv.upload:1",
-                        "cx.bpdm.vas.bdv.download:1",
-                        "cx.bpdm.vas.fpd.upload:1",
-                        "cx.bpdm.vas.fpd.download:1",
-                        "cx.bpdm.vas.swd.upload:1",
-                        "cx.bpdm.vas.swd.download:1",
-                        "cx.bpdm.vas.nps.upload:1",
-                        "cx.bpdm.vas.nps.download:1",
-                        "cx.ccm.base:1",
-                        "cx.bpdm.poolAll:1",
-                        "cx.logistics.base:1"
-                ),
-                true
-        );
+    @Override
+    public boolean evaluate(Operator operator, Object rightValue, Permission rule, C context) {
+        return true;
     }
 }

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/usage/UsagePurposeConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/usage/UsagePurposeConstraintFunctionTest.java
@@ -36,14 +36,21 @@ class UsagePurposeConstraintFunctionTest {
     private final UsagePurposeConstraintFunction<ParticipantAgentPolicyContext> function = new UsagePurposeConstraintFunction<>();
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
 
+    @ParameterizedTest
+    @EnumSource(value = Operator.class, names = "IS_ANY_OF", mode = EnumSource.Mode.EXCLUDE)
+    void validate_shouldReturnFalse_forAllOperatorsExceptIsAnyOf(Operator operator) {
+        var result = function.validate(operator, "someValue", null);
+        assertThat(result.succeeded()).isFalse();
+    }
+
+    @Test
+    void validate_shouldReturnTrue_forIsAnyOfOperator() {
+        var result = function.validate(Operator.IS_ANY_OF, "someValue", null);
+        assertThat(result.succeeded()).isTrue();
+    }
+
     @Test
     void evaluate_shouldReturnTrue_withAnyRightValue() {
         assertThat(function.evaluate(Operator.IS_ANY_OF, "anyValue", null, context)).isTrue();
-    }
-
-    @ParameterizedTest
-    @EnumSource(Operator.class)
-    void evaluate_shouldReturnTrue_forAllOperators(Operator operator) {
-        assertThat(function.evaluate(operator, "someValue", null, context)).isTrue();
     }
 }

--- a/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/usage/UsagePurposeConstraintFunctionTest.java
+++ b/edc-extensions/cx-policy/src/test/java/org/eclipse/tractusx/edc/policy/cx/usage/UsagePurposeConstraintFunctionTest.java
@@ -19,18 +19,15 @@
 
 package org.eclipse.tractusx.edc.policy.cx.usage;
 
-import jakarta.json.Json;
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.participant.spi.ParticipantAgentPolicyContext;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.tractusx.edc.policy.cx.TestParticipantAgentPolicyContext;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.Map;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
 class UsagePurposeConstraintFunctionTest {
@@ -40,28 +37,13 @@ class UsagePurposeConstraintFunctionTest {
     private final ParticipantAgentPolicyContext context = new TestParticipantAgentPolicyContext(participantAgent);
 
     @Test
-    void evaluate() {
-        assertThat(function.evaluate(Operator.IS_ANY_OF, List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), null, context)).isTrue();
+    void evaluate_shouldReturnTrue_withAnyRightValue() {
+        assertThat(function.evaluate(Operator.IS_ANY_OF, "anyValue", null, context)).isTrue();
     }
 
-    @Test
-    void validate_whenOperatorAndRightOperandAreValid_thenSuccess() {
-        var legalRequirementForThirdparty = Json.createValue("cx.core.legalRequirementForThirdparty:1");
-        var industrycore = Json.createValue("cx.core.industrycore:1");
-        var rightValue = List.of(Map.of("@value", legalRequirementForThirdparty), Map.of("@value", industrycore));
-        var result = function.validate(Operator.IS_ANY_OF, rightValue, null);
-        assertThat(result).isSucceeded();
-    }
-
-    @Test
-    void validate_whenInvalidOperator_thenFailure() {
-        var result = function.validate(Operator.EQ, List.of("cx.core.legalRequirementForThirdparty:1", "cx.core.industrycore:1"), null);
-        assertThat(result).isFailed().detail().contains("Invalid operator");
-    }
-
-    @Test
-    void validate_whenInvalidValue_thenFailure() {
-        var result = function.validate(Operator.IS_ANY_OF, List.of("BPNL00000000001A"), null);
-        assertThat(result).isFailed().detail().contains("Invalid right-operand: ");
+    @ParameterizedTest
+    @EnumSource(Operator.class)
+    void evaluate_shouldReturnTrue_forAllOperators(Operator operator) {
+        assertThat(function.evaluate(operator, "someValue", null, context)).isTrue();
     }
 }


### PR DESCRIPTION
## WHAT

Remove validation from `UsagePurposeContraintFunction`

## WHY

According to the [schema reference](https://github.com/catenax-eV/cx-odrl-profile/blob/33d6271/schema/constraint/usage-purpose-constraint-schema.json), the `UsagePurposeContraint` can be defined at will by the data provider and the data consumer. Specifically, this is defined by the [UsagePurposeIndividualRightOperand](https://github.com/catenax-eV/cx-odrl-profile/blob/33d6271/schema/constraint/usage-purpose-constraint-schema.json#L208).

## FURTHER NOTES

Closes https://github.com/eclipse-tractusx/tractusx-edc/issues/2758