### PR TITLE
fix(helm): add otel configmap to tractusx-connector-memory chart

### DIFF
--- a/charts/tractusx-connector-memory/README.md
+++ b/charts/tractusx-connector-memory/README.md
@@ -141,6 +141,7 @@ helm install my-release tractusx-edc/tractusx-connector-memory --version 0.13.0-
 | runtime.livenessProbe.timeoutSeconds | int | `5` | number of seconds after which the probe times out |
 | runtime.logs.level | string | `"DEBUG"` | Defines the log granularity of the default Console Monitor. |
 | runtime.nodeSelector | object | `{}` | [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to constrain pods to nodes |
+| runtime.opentelemetry | string | `"otel.javaagent.enabled=false\notel.javaagent.debug=false"` | configuration of the [Open Telemetry Agent](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/) to collect and expose metrics |
 | runtime.podAnnotations | object | `{}` | additional annotations for the pod |
 | runtime.podLabels | object | `{}` | additional labels for the pod |
 | runtime.podSecurityContext | object | `{"fsGroup":10001,"runAsGroup":10001,"runAsUser":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | The [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) defines privilege and access control settings for a Pod within the deployment |

--- a/charts/tractusx-connector-memory/templates/configmap-otel.yaml
+++ b/charts/tractusx-connector-memory/templates/configmap-otel.yaml
@@ -1,0 +1,34 @@
+#################################################################################
+  #  Copyright (c) 2023 ZF Friedrichshafen AG
+  #  Copyright (c) 2023 Mercedes-Benz Tech Innovation GmbH
+  #  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+  #  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+  #
+  #  See the NOTICE file(s) distributed with this work for additional
+  #  information regarding copyright ownership.
+  #
+  #  This program and the accompanying materials are made available under the
+  #  terms of the Apache License, Version 2.0 which is available at
+  #  https://www.apache.org/licenses/LICENSE-2.0.
+  #
+  #  Unless required by applicable law or agreed to in writing, software
+  #  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  #  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  #  License for the specific language governing permissions and limitations
+  #  under the License.
+  #
+  #  SPDX-License-Identifier: Apache-2.0
+  #################################################################################
+
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "txdc.fullname" . }}-runtime
+  namespace: {{ .Release.Namespace | default "default" | quote }}
+  labels:
+      {{- include "txdc.runtime.labels" . | nindent 4 }}
+data:
+  opentelemetry.properties: |-
+    {{- .Values.runtime.opentelemetry | nindent 4 }}

--- a/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
+++ b/charts/tractusx-connector-memory/templates/deployment-runtime.yaml
@@ -348,6 +348,9 @@ spec:
               mountPath: /opt/java/openjdk/lib/security/cacerts
               subPath: cacerts
             {{- end }}
+            - name: "configuration"
+              mountPath: "/app/opentelemetry.properties"
+              subPath: "opentelemetry.properties"
             - name: log4j2-config
               mountPath: /app/log4j2.yaml
               subPath: log4j2.yaml
@@ -363,6 +366,12 @@ spec:
           emptyDir:
             sizeLimit: 1Mi
         {{- end }}
+        - name: "configuration"
+          configMap:
+            name: {{ include "txdc.fullname" . }}-runtime
+            items:
+              - key: "opentelemetry.properties"
+                path: "opentelemetry.properties"
         - name: "log4j2-config"
           configMap:
             name: {{ include "txdc.fullname" . }}-log4j2

--- a/charts/tractusx-connector-memory/values.yaml
+++ b/charts/tractusx-connector-memory/values.yaml
@@ -380,6 +380,11 @@ runtime:
     # -- targetAverageUtilization of memory provided to a pod
     targetMemoryUtilizationPercentage: 80
 
+  # -- configuration of the [Open Telemetry Agent](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/) to collect and expose metrics
+  opentelemetry: |-
+    otel.javaagent.enabled=false
+    otel.javaagent.debug=false
+
   # -- [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to constrain pods to nodes
   nodeSelector: {}
   # -- [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to configure preferred nodes


### PR DESCRIPTION
## Summary

- Adds missing `ConfigMap` for `opentelemetry.properties` to the `tractusx-connector-memory` Helm chart
- Mounts the file at `/app/opentelemetry.properties` in the runtime `Deployment`
- Adds `runtime.opentelemetry` to `values.yaml` with otel agent disabled by default

Closes #2814