### PR TITLE
fix: 0.8 tests

### DIFF
--- a/core/json-ld-core/src/main/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtension.java
+++ b/core/json-ld-core/src/main/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtension.java
@@ -23,18 +23,12 @@ package org.eclipse.tractusx.edc.jsonld;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-
-import java.io.File;
-import java.util.Map;
 
 import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp08Constants.DSP_SCOPE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_SCOPE_V_2025_1;
-import static org.eclipse.tractusx.edc.core.utils.FileUtils.getResourceFile;
-import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.EDC_CONTEXT;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_AUTH_NS;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_AUTH_PREFIX;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
@@ -42,20 +36,8 @@ import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_PREFIX;
 
 public class JsonLdExtension implements ServiceExtension {
 
-    public static final String CREDENTIALS_V_1 = "https://www.w3.org/2018/credentials/v1";
-
-    public static final String SECURITY_JWS_V1 = "https://w3id.org/security/suites/jws-2020/v1";
-    public static final String SECURITY_ED25519_V1 = "https://w3id.org/security/suites/ed25519-2020/v1";
-
     public static final String TX_AUTH_CONTEXT = "https://w3id.org/tractusx/auth/v1.0.0";
 
-    private static final String PREFIX = "document" + File.separator;
-    private static final Map<String, String> FILES = Map.of(
-            CREDENTIALS_V_1, PREFIX + "credential-v1.jsonld",
-            SECURITY_JWS_V1, PREFIX + "security-jws-2020.jsonld",
-            SECURITY_ED25519_V1, PREFIX + "security-ed25519-2020.jsonld",
-            TX_AUTH_CONTEXT, PREFIX + "tx-auth-v1.jsonld",
-            EDC_CONTEXT, PREFIX + "edc-v1.jsonld");
     @Inject
     private JsonLd jsonLdService;
 
@@ -71,13 +53,9 @@ public class JsonLdExtension implements ServiceExtension {
 
         jsonLdService.registerNamespace(TX_AUTH_PREFIX, TX_AUTH_NS, MANAGEMENT_SCOPE);
 
-        FILES.entrySet().stream().map(this::mapToFile)
-                .forEach(result -> result.onSuccess(entry -> jsonLdService.registerCachedDocument(entry.getKey(), entry.getValue().toURI()))
-                        .onFailure(failure -> monitor.warning("Failed to register cached json-ld document: " + failure.getFailureDetail())));
-    }
-
-    private Result<Map.Entry<String, File>> mapToFile(Map.Entry<String, String> fileEntry) {
-        return getResourceFile(fileEntry.getValue())
-                .map(file1 -> Map.entry(fileEntry.getKey(), file1));
+        TxCachedDocumentRegistry.getDocuments().forEach(result -> result
+                .onSuccess(c -> jsonLdService.registerCachedDocument(c.url(), c.resource()))
+                .onFailure(failure -> monitor.warning("Failed to register cached json-ld document: " + failure.getFailureDetail()))
+        );
     }
 }

--- a/core/json-ld-core/src/main/java/org/eclipse/tractusx/edc/jsonld/TxCachedDocumentRegistry.java
+++ b/core/json-ld-core/src/main/java/org/eclipse/tractusx/edc/jsonld/TxCachedDocumentRegistry.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Think-it GmbH
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.jsonld;
+
+import org.eclipse.edc.jsonld.spi.JsonLdContext;
+import org.eclipse.edc.spi.result.Result;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.EDC_CONTEXT;
+import static org.eclipse.tractusx.edc.jsonld.JsonLdExtension.TX_AUTH_CONTEXT;
+
+public class TxCachedDocumentRegistry {
+
+    public static final String CREDENTIALS_V_1 = "https://www.w3.org/2018/credentials/v1";
+    public static final String SECURITY_JWS_V1 = "https://w3id.org/security/suites/jws-2020/v1";
+    public static final String SECURITY_ED25519_V1 = "https://w3id.org/security/suites/ed25519-2020/v1";
+
+    public static Stream<Result<JsonLdContext>> getDocuments() {
+        return Map.of(
+                        "credential-v1.jsonld", CREDENTIALS_V_1,
+                        "security-jws-2020.jsonld", SECURITY_JWS_V1,
+                        "security-ed25519-2020.jsonld", SECURITY_ED25519_V1,
+                        "tx-auth-v1.jsonld", TX_AUTH_CONTEXT,
+                        "edc-v1.jsonld", EDC_CONTEXT
+                ).entrySet().stream()
+                .map(entry -> getResourceUri("document/" + entry.getKey())
+                        .map(uri -> new JsonLdContext(uri, entry.getValue())));
+    }
+
+    static Result<URI> getResourceUri(String name) {
+        var uri = TxCachedDocumentRegistry.class.getClassLoader().getResource(name);
+        if (uri == null) {
+            return Result.failure(format("Cannot find resource %s", name));
+        }
+
+        try {
+            return Result.success(uri.toURI());
+        } catch (URISyntaxException e) {
+            return Result.failure(format("Cannot read resource %s: %s", name, e.getMessage()));
+        }
+    }
+}

--- a/core/json-ld-core/src/test/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtensionTest.java
+++ b/core/json-ld-core/src/test/java/org/eclipse/tractusx/edc/jsonld/JsonLdExtensionTest.java
@@ -29,9 +29,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.net.URI;
 
-import static org.eclipse.tractusx.edc.jsonld.JsonLdExtension.CREDENTIALS_V_1;
-import static org.eclipse.tractusx.edc.jsonld.JsonLdExtension.SECURITY_ED25519_V1;
-import static org.eclipse.tractusx.edc.jsonld.JsonLdExtension.SECURITY_JWS_V1;
+import static org.eclipse.tractusx.edc.jsonld.TxCachedDocumentRegistry.CREDENTIALS_V_1;
+import static org.eclipse.tractusx.edc.jsonld.TxCachedDocumentRegistry.SECURITY_ED25519_V1;
+import static org.eclipse.tractusx.edc.jsonld.TxCachedDocumentRegistry.SECURITY_JWS_V1;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;

--- a/core/json-ld-cx/src/main/java/org/eclipse/tractusx/edc/cx/CxCachedDocumentRegistry.java
+++ b/core/json-ld-cx/src/main/java/org/eclipse/tractusx/edc/cx/CxCachedDocumentRegistry.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Think-it GmbH
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.edc.cx;
+
+import org.eclipse.edc.jsonld.spi.JsonLdContext;
+import org.eclipse.edc.spi.result.Result;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static org.eclipse.tractusx.edc.cx.CxJsonLdExtension.CX_ODRL_CONTEXT;
+import static org.eclipse.tractusx.edc.cx.CxJsonLdExtension.CX_POLICY_2025_09_CONTEXT;
+
+public class CxCachedDocumentRegistry {
+
+    public static Stream<Result<JsonLdContext>> getDocuments() {
+        return Map.of(
+                        "cx-policy-v1.jsonld", CX_POLICY_2025_09_CONTEXT,
+                        "cx-odrl.jsonld", CX_ODRL_CONTEXT
+                ).entrySet().stream()
+                .map(entry -> getResourceUri("document/" + entry.getKey())
+                        .map(uri -> new JsonLdContext(uri, entry.getValue())));
+    }
+
+    static Result<URI> getResourceUri(String name) {
+        var uri = CxCachedDocumentRegistry.class.getClassLoader().getResource(name);
+        if (uri == null) {
+            return Result.failure(format("Cannot find resource %s", name));
+        }
+
+        try {
+            return Result.success(uri.toURI());
+        } catch (URISyntaxException e) {
+            return Result.failure(format("Cannot read resource %s: %s", name, e.getMessage()));
+        }
+    }
+}

--- a/core/json-ld-cx/src/main/java/org/eclipse/tractusx/edc/cx/CxJsonLdExtension.java
+++ b/core/json-ld-cx/src/main/java/org/eclipse/tractusx/edc/cx/CxJsonLdExtension.java
@@ -23,17 +23,12 @@ package org.eclipse.tractusx.edc.cx;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-
-import java.io.File;
-import java.util.Map;
 
 import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp08Constants.DSP_SCOPE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_SCOPE_V_2025_1;
-import static org.eclipse.tractusx.edc.core.utils.FileUtils.getResourceFile;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_NS;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.CX_POLICY_PREFIX;
 
@@ -45,10 +40,6 @@ public class CxJsonLdExtension implements ServiceExtension {
     public static final String CX_ODRL_CONTEXT = "https://w3id.org/catenax/2025/9/policy/odrl.jsonld";
     public static final String CX_POLICY_2025_09_CONTEXT = "https://w3id.org/catenax/2025/9/policy/context.jsonld";
 
-    private static final String PREFIX = "document" + File.separator;
-    private static final Map<String, String> FILES = Map.of(
-            CX_POLICY_2025_09_CONTEXT, PREFIX + "cx-policy-v1.jsonld",
-            CX_ODRL_CONTEXT, PREFIX + "cx-odrl.jsonld");
     @Inject
     private JsonLd jsonLdService;
 
@@ -63,13 +54,10 @@ public class CxJsonLdExtension implements ServiceExtension {
 
         jsonLdService.registerContext(CX_POLICY_2025_09_CONTEXT, MANAGEMENT_SCOPE);
 
-        FILES.entrySet().stream().map(this::mapToFile)
-                .forEach(result -> result.onSuccess(entry -> jsonLdService.registerCachedDocument(entry.getKey(), entry.getValue().toURI()))
-                        .onFailure(failure -> monitor.warning("Failed to register cached json-ld document: " + failure.getFailureDetail())));
+        CxCachedDocumentRegistry.getDocuments().forEach(result -> result
+                .onSuccess(c -> jsonLdService.registerCachedDocument(c.url(), c.resource()))
+                .onFailure(failure -> monitor.warning("Failed to register cached json-ld document: " + failure.getFailureDetail()))
+        );
     }
 
-    private Result<Map.Entry<String, File>> mapToFile(Map.Entry<String, String> fileEntry) {
-        return getResourceFile(fileEntry.getValue())
-                .map(file1 -> Map.entry(fileEntry.getKey(), file1));
-    }
 }

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java
@@ -29,6 +29,8 @@ import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.junit.utils.LazySupplier;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.tractusx.edc.cx.CxCachedDocumentRegistry;
+import org.eclipse.tractusx.edc.jsonld.TxCachedDocumentRegistry;
 import org.eclipse.tractusx.edc.tests.ParticipantConsumerDataPlaneApi;
 import org.eclipse.tractusx.edc.tests.ParticipantDataApi;
 import org.eclipse.tractusx.edc.tests.ParticipantEdrApi;
@@ -319,7 +321,7 @@ public abstract class TractusxParticipantBase extends IdentityParticipant {
     // The following functions have been implemented, because they possibilities upstream have been removed
     // They are needed for support of DSP version v0.8
     public void setProtocol(String protocol) {
-        if (DSP_2025.contains(protocol)) {
+        if (DSP_2025.equals(protocol)) {
             this.protocol = new Protocol(DSP_2025, DSP_2025_PATH);
         } else {
             this.protocol = new Protocol(DSP_08, DSP_08_PATH);
@@ -372,6 +374,15 @@ public abstract class TractusxParticipantBase extends IdentityParticipant {
             this.participant.edrs = new ParticipantEdrApi(participant);
             this.participant.data = new ParticipantDataApi();
             this.participant.dataPlane = new ParticipantConsumerDataPlaneApi(this.participant.dataPlaneProxy, Map.of("x-api-key", CONSUMER_PROXY_API_KEY));
+
+            TxCachedDocumentRegistry.getDocuments().forEach(result -> result
+                    .onSuccess(c -> this.participant.jsonLd.registerCachedDocument(c.url(), c.resource()))
+            );
+
+            CxCachedDocumentRegistry.getDocuments().forEach(result -> result
+                    .onSuccess(c -> this.participant.jsonLd.registerCachedDocument(c.url(), c.resource()))
+            );
+
             return participant;
         }
     }


### PR DESCRIPTION
## WHAT

Registers cached jsonld documents also in tests, otherwise they won't work.

## WHY

_Briefly state why the change was necessary._

## FURTHER NOTES
- fixed a subtle bug for which the selected protocol version was always 0.8

Closes # <-- _insert Issue number if one exists_
