### PR TITLE
chore: skip run "publish snapshot" during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
   run-all-tests:
     name: "Run All Tests"
     uses: ./.github/workflows/run-all-tests.yml
+    with:
+      publish: false
   # Gate
   validation:
     name: "Workflow Validation"

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -32,7 +32,19 @@ on:
     paths-ignore:
       - docs/**
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish snapshot"
+        required: false
+        type: boolean
+        default: false
   workflow_call:
+    inputs:
+      publish:
+        description: "Publish snapshot"
+        required: false
+        type: boolean
+        default: false
 
   schedule:
     - cron: 0 3 * * 1 # run on 03:00 UTC every Monday
@@ -78,7 +90,7 @@ jobs:
     needs: [ summary ]
     permissions:
       contents: write
-    if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release/') }}
+    if: ${{ (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) && (github.event_name == 'push' || github.event_name == 'schedule' || inputs.publish == true) }}
     uses: ./.github/workflows/publish-new-snapshot.yaml
     with:
       dated_snapshot: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
## WHAT

Because "Publish Snapshot" runs now after "Run All Tests", we need to skip it during the release.

## WHY

Redundant call of "Publish Snapshot"  workflow

