### PR TITLE
fix: write permission for release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ permissions:
 jobs:
   run-all-tests:
     name: "Run All Tests"
+    permissions:
+      contents: write
     uses: ./.github/workflows/run-all-tests.yml
     with:
       publish: false


### PR DESCRIPTION
## WHAT

Write permission for the release process

## WHY

To make a release possible
