### PR TITLE
Fix: Refresh Token has to use request body as specified in rfc 6749

### DIFF
--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/api/v1/TokenRefreshApi.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/api/v1/TokenRefreshApi.java
@@ -21,12 +21,12 @@ package org.eclipse.tractusx.edc.dataplane.tokenrefresh.api.v1;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -43,8 +43,7 @@ import org.eclipse.tractusx.edc.spi.tokenrefresh.dataplane.model.TokenResponse;
 public interface TokenRefreshApi {
 
     @Operation(description = "Resolves all groups for a particular BPN",
-            parameters = { @Parameter(name = "grant_type", description = "The grant type. Must be \"refresh_token\""),
-                    @Parameter(name = "refresh_token", description = "The refresh token") },
+            requestBody = @RequestBody(description = "Form parameters: grant_type=refresh_token&refresh_token=<the refresh token>"),
             responses = {
                     @ApiResponse(responseCode = "200", description = "The access token and refresh token were updated. Expiry should be " +
                             "interpreted as starting from the time of message reception, allowing for some leeway.",
@@ -54,5 +53,5 @@ public interface TokenRefreshApi {
                     @ApiResponse(responseCode = "400", description = "Request body was malformed, query parameters were missing, etc.",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
             })
-    TokenResponse refreshToken(String grantType, String refreshToken, String bearerToken);
+    TokenResponse refreshToken(String grantType, String refreshToken, String bearerToken, String formParameters);
 }

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/api/v1/TokenRefreshApiController.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/api/v1/TokenRefreshApiController.java
@@ -19,6 +19,7 @@
 
 package org.eclipse.tractusx.edc.dataplane.tokenrefresh.api.v1;
 
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
@@ -32,12 +33,16 @@ import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.tractusx.edc.spi.tokenrefresh.dataplane.DataPlaneTokenRefreshService;
 import org.eclipse.tractusx.edc.spi.tokenrefresh.dataplane.model.TokenResponse;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 
 @Produces({ MediaType.APPLICATION_JSON })
 @Path("/token")
 public class TokenRefreshApiController implements TokenRefreshApi {
-    private static final String REFRESH_TOKEN_GRANT = "refresh_token";
+    private static final String GRANT_TYPE = "grant_type";
+    private static final String REFRESH_TOKEN = "refresh_token";
     private final DataPlaneTokenRefreshService tokenRefreshService;
 
     public TokenRefreshApiController(DataPlaneTokenRefreshService tokenRefreshService) {
@@ -47,20 +52,50 @@ public class TokenRefreshApiController implements TokenRefreshApi {
     @POST
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Override
-    public TokenResponse refreshToken(@QueryParam("grant_type") String grantType,
-                                      @QueryParam("refresh_token") String refreshToken,
-                                      @HeaderParam(AUTHORIZATION) String bearerToken) {
-        if (!REFRESH_TOKEN_GRANT.equals(grantType)) {
-            throw new InvalidRequestException("Grant type MUST be '%s' but was '%s'".formatted(REFRESH_TOKEN_GRANT, grantType));
+    public TokenResponse refreshToken(@QueryParam(GRANT_TYPE) String grantType,
+                                      @QueryParam(REFRESH_TOKEN) String refreshToken,
+                                      @HeaderParam(AUTHORIZATION) String bearerToken,
+                                      @RequestBody() String formParams) {
+        // TODO: This version still supports the deprecated usage of query parameter to provide the
+        // grant_type and refresh_token. This is due to backward compatibility to ensure interoperability
+        // with previous versions. This should be removed in the future, if old connectors are not used
+        // anymore.
+
+        var paramMap = parseFormParameter(formParams);
+        if (!paramMap.containsKey(GRANT_TYPE)) {
+            paramMap.put(GRANT_TYPE, grantType);
         }
-        if (StringUtils.isNullOrBlank(refreshToken)) {
+        if (!paramMap.containsKey(REFRESH_TOKEN)) {
+            paramMap.put(REFRESH_TOKEN, refreshToken);
+        }
+
+        if (!REFRESH_TOKEN.equals(paramMap.get(GRANT_TYPE))) {
+            throw new InvalidRequestException("Grant type MUST be '%s' but was '%s'".formatted(REFRESH_TOKEN, paramMap.get(GRANT_TYPE)));
+        }
+        if (StringUtils.isNullOrBlank(paramMap.get(REFRESH_TOKEN))) {
             throw new InvalidRequestException("Parameter 'refresh_token' cannot be null");
         }
         if (StringUtils.isNullOrBlank(bearerToken)) {
             throw new AuthenticationFailedException("Authorization header missing");
         }
 
-        return tokenRefreshService.refreshToken(refreshToken, bearerToken)
+        return tokenRefreshService.refreshToken(paramMap.get(REFRESH_TOKEN), bearerToken)
                 .orElseThrow(f -> new AuthenticationFailedException(f.getFailureDetail()));
+    }
+
+    private Map<String, String> parseFormParameter(String formParams) {
+        var result = new HashMap<String, String>();
+        if (!StringUtils.isNullOrBlank(formParams)) {
+            var params = formParams.split("&");
+            for (String param : params) {
+                if (!StringUtils.isNullOrBlank(param)) {
+                    var keyValuePair = param.split("=");
+                    if (keyValuePair.length == 2) {
+                        result.put(keyValuePair[0], keyValuePair[1]);
+                    }
+                }
+            }
+        }
+        return result;
     }
 }

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/api/v1/TokenRefreshApiControllerTest.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/api/v1/TokenRefreshApiControllerTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static io.restassured.RestAssured.given;
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static java.lang.String.format;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -48,17 +49,16 @@ class TokenRefreshApiControllerTest extends RestControllerTestBase {
     @Test
     void refresh_noAuthHeader_expect401() {
         baseRequest()
-                .queryParam("grant_type", "refresh_token")
-                .queryParam("refresh_token", "foo-token")
                 /* missing: .header(AUTHORIZATION, "auth-token") */
                 .contentType(ContentType.URLENC)
+                .body("grant_type=refresh_token&refresh_token=foo-token")
                 .then()
                 .statusCode(401);
     }
 
-    @DisplayName("Expect HTTP 200 when the token was successfully refreshed")
+    @DisplayName("Expect HTTP 200 when the token was successfully refreshed and query params used")
     @Test
-    void refresh_expect200() {
+    void refresh_expect200query() {
         when(refreshService.refreshToken(any(), any())).thenReturn(Result.success(new TokenResponse("new-accesstoken", "new-refreshtoken", 3000L, "bearer")));
         baseRequest()
                 .queryParam("grant_type", "refresh_token")
@@ -70,16 +70,28 @@ class TokenRefreshApiControllerTest extends RestControllerTestBase {
                 .body(Matchers.isA(TokenResponse.class));
     }
 
+    @DisplayName("Expect HTTP 200 when the token was successfully refreshed and correct body used")
+    @Test
+    void refresh_expect200body() {
+        when(refreshService.refreshToken(any(), any())).thenReturn(Result.success(new TokenResponse("new-accesstoken", "new-refreshtoken", 3000L, "bearer")));
+        baseRequest()
+                .header(AUTHORIZATION, "auth-token")
+                .contentType(ContentType.URLENC)
+                .body("grant_type=refresh_token&refresh_token=foo-token")
+                .then()
+                .statusCode(200)
+                .body(Matchers.isA(TokenResponse.class));
+    }
+
     @DisplayName("Expect HTTP 400 when an invalid grant type was provided")
     @ParameterizedTest(name = "Invalid grant_type: {0}")
     @ValueSource(strings = { "REFRESH_TOKEN", "refreshToken", "invalid_grant", "client_credentials", "" })
     @NullSource
     void refresh_invalidGrantType_expect400(String grant) {
         baseRequest()
-                .queryParam("grant_type", grant)
-                .queryParam("refresh_token", "foo-token")
                 .header(AUTHORIZATION, "auth-token")
                 .contentType(ContentType.URLENC)
+                .body(format("grant_type=%s&refresh_token=foo-token", grant))
                 .then()
                 .statusCode(400);
     }
@@ -90,10 +102,9 @@ class TokenRefreshApiControllerTest extends RestControllerTestBase {
     @EmptySource
     void refresh_invalidRefreshToken_expect400(String refreshToken) {
         baseRequest()
-                .queryParam("grant_type", "refresh_token")
-                .queryParam("refresh_token", refreshToken)
                 .header(AUTHORIZATION, "auth-token")
                 .contentType(ContentType.URLENC)
+                .body(format("grant_type=refresh_token&refresh_token=%s", refreshToken))
                 .then()
                 .statusCode(400);
     }
@@ -102,16 +113,16 @@ class TokenRefreshApiControllerTest extends RestControllerTestBase {
     @Test
     void refresh_queryParamsMissing() {
         baseRequest()
-                .queryParam("grant_type", "refresh_token")
                 .header(AUTHORIZATION, "auth-token")
                 .contentType(ContentType.URLENC)
+                .body("grant_type=refresh_token")
                 .then()
                 .statusCode(400);
 
         baseRequest()
-                .queryParam("refresh_token", "foo-token")
                 .header(AUTHORIZATION, "auth-token")
                 .contentType(ContentType.URLENC)
+                .body("refresh_token=foo-token")
                 .then()
                 .statusCode(400);
     }
@@ -122,10 +133,9 @@ class TokenRefreshApiControllerTest extends RestControllerTestBase {
         when(refreshService.refreshToken(any(), any())).thenReturn(Result.failure("Invalid auth token"));
 
         baseRequest()
-                .queryParam("grant_type", "refresh_token")
-                .queryParam("refresh_token", "foo-token")
                 .header(AUTHORIZATION, "auth-token")
                 .contentType(ContentType.URLENC)
+                .body("grant_type=refresh_token&refresh_token=foo-token")
                 .then()
                 .statusCode(401)
                 .body(containsString("Invalid auth token"));

--- a/edc-extensions/tokenrefresh-handler/src/main/java/org/eclipse/tractusx/edc/common/tokenrefresh/TokenRefreshHandlerImpl.java
+++ b/edc-extensions/tokenrefresh-handler/src/main/java/org/eclipse/tractusx/edc/common/tokenrefresh/TokenRefreshHandlerImpl.java
@@ -20,9 +20,9 @@
 package org.eclipse.tractusx.edc.common.tokenrefresh;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.FormBody;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
-import okhttp3.RequestBody;
 import org.eclipse.edc.edr.spi.store.EndpointDataReferenceCache;
 import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.iam.decentralizedclaims.spi.SecureTokenService;
@@ -192,17 +192,27 @@ public class TokenRefreshHandlerImpl implements TokenRefreshHandler {
         if (!refreshEndpoint.endsWith("/token")) {
             refreshEndpoint += "/token";
         }
+
+        // TODO: This version still supports the deprecated usage of query parameter to provide the
+        // grant_type and refresh_token. This is due to backward compatibility to ensure interoperability
+        // with previous versions. This should be removed in the future, if old connectors are not used
+        // anymore.
         var url = HttpUrl.parse(refreshEndpoint)
                 .newBuilder()
                 .addQueryParameter("grant_type", "refresh_token")
                 .addQueryParameter("refresh_token", refreshToken)
                 .build();
 
+        var body = new FormBody.Builder()
+                .add("grant_type", "refresh_token")
+                .add("refresh_token", refreshToken)
+                .build();
+
         return success(new Request.Builder()
                 .addHeader("Authorization", bearerToken)
                 .addHeader("Content-Type", "application/x-www-form-urlencoded")
                 .url(url)
-                .post(RequestBody.create(new byte[0]))
+                .post(body)
                 .build());
     }
 

--- a/edc-extensions/tokenrefresh-handler/src/test/java/org/eclipse/tractusx/edc/common/tokenrefresh/TokenRefreshHandlerImplTest.java
+++ b/edc-extensions/tokenrefresh-handler/src/test/java/org/eclipse/tractusx/edc/common/tokenrefresh/TokenRefreshHandlerImplTest.java
@@ -34,6 +34,7 @@ import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import okio.Buffer;
 import org.assertj.core.api.Assertions;
 import org.eclipse.edc.edr.spi.store.EndpointDataReferenceCache;
 import org.eclipse.edc.http.spi.EdcHttpClient;
@@ -128,7 +129,19 @@ class TokenRefreshHandlerImplTest {
                 });
         verify(mockedHttpClient).execute(argThat(r -> {
             var hdr = r.header("Content-Type");
-            return hdr != null && hdr.equalsIgnoreCase("application/x-www-form-urlencoded");
+            var body = r.body();
+            Buffer sink = new Buffer();
+            try {
+                if (body != null) {
+                    body.writeTo(sink);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            return hdr != null &&
+                    hdr.equalsIgnoreCase("application/x-www-form-urlencoded") &&
+                    body != null &&
+                    sink.readUtf8().contains("grant_type=refresh_token&refresh_token=foo-refresh-token");
         }));
     }
 

--- a/edc-tests/e2e/edc-dataplane-tokenrefresh-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/e2e/DataPlaneTokenRefreshEndToEndTest.java
+++ b/edc-tests/e2e/edc-dataplane-tokenrefresh-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/e2e/DataPlaneTokenRefreshEndToEndTest.java
@@ -29,6 +29,7 @@ import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import io.restassured.http.ContentType;
 import org.eclipse.edc.connector.dataplane.spi.DataFlow;
 import org.eclipse.edc.connector.dataplane.spi.edr.EndpointDataReferenceServiceRegistry;
 import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
@@ -49,21 +50,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EmptySource;
-import org.junit.jupiter.params.provider.NullSource;
 
 import java.net.URI;
 import java.text.ParseException;
 import java.util.Map;
 
+import static java.lang.String.format;
 import static org.apache.http.HttpHeaders.AUTHORIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.AUDIENCE_PROPERTY;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_AUTH_NS;
 import static org.hamcrest.Matchers.containsString;
-
 
 @EndToEndTest
 public class DataPlaneTokenRefreshEndToEndTest {
@@ -125,9 +123,9 @@ public class DataPlaneTokenRefreshEndToEndTest {
         var authToken = createAuthToken(accessToken, consumerKey);
 
         var tokenResponse = RUNTIME_CONFIG.basePublicApiRequest()
-                .queryParam("grant_type", "refresh_token")
-                .queryParam("refresh_token", refreshToken)
                 .header(AUTHORIZATION, "Bearer " + authToken)
+                .contentType(ContentType.URLENC)
+                .body(format("grant_type=refresh_token&refresh_token=%s", refreshToken))
                 .post("/token")
                 .then()
                 .log().ifError()
@@ -137,11 +135,9 @@ public class DataPlaneTokenRefreshEndToEndTest {
         assertThat(tokenResponse).isNotNull();
     }
 
-    @DisplayName("Refresh token is null or empty (missing)")
-    @ParameterizedTest
-    @NullSource
-    @EmptySource
-    void refresh_invalidRefreshToken(String invalidRefreshToken) {
+    @DisplayName("Refresh token is empty (missing)")
+    @Test
+    void refresh_invalidRefreshToken() {
         // register generator and secrets
         prepareDataplaneRuntime();
 
@@ -155,9 +151,9 @@ public class DataPlaneTokenRefreshEndToEndTest {
         var authToken = createAuthToken(accessToken, consumerKey);
 
         RUNTIME_CONFIG.basePublicApiRequest()
-                .queryParam("grant_type", "refresh_token")
-                .queryParam("refresh_token", invalidRefreshToken)
                 .header(AUTHORIZATION, "Bearer " + authToken)
+                .contentType(ContentType.URLENC)
+                .body("grant_type=refresh_token&refresh_token=")
                 .post("/token")
                 .then()
                 .log().ifError()
@@ -180,9 +176,9 @@ public class DataPlaneTokenRefreshEndToEndTest {
 
         // auth header is empty
         RUNTIME_CONFIG.basePublicApiRequest()
-                .queryParam("grant_type", "refresh_token")
-                .queryParam("refresh_token", refreshToken)
                 .header(AUTHORIZATION, "")
+                .contentType(ContentType.URLENC)
+                .body(format("grant_type=refresh_token&refresh_token=%s", refreshToken))
                 .post("/token")
                 .then()
                 .log().ifError()
@@ -205,8 +201,8 @@ public class DataPlaneTokenRefreshEndToEndTest {
 
         // auth header is empty
         RUNTIME_CONFIG.basePublicApiRequest()
-                .queryParam("grant_type", "refresh_token")
-                .queryParam("refresh_token", refreshToken)
+                .contentType(ContentType.URLENC)
+                .body(format("grant_type=refresh_token&refresh_token=%s", refreshToken))
                 .post("/token")
                 .then()
                 .log().ifError()
@@ -229,9 +225,9 @@ public class DataPlaneTokenRefreshEndToEndTest {
         var authTokenWithSpoofedKey = createAuthToken(accessToken, spoofedKey);
 
         RUNTIME_CONFIG.basePublicApiRequest()
-                .queryParam("grant_type", "refresh_token")
-                .queryParam("refresh_token", refreshToken)
                 .header(AUTHORIZATION, "Bearer " + authTokenWithSpoofedKey)
+                .contentType(ContentType.URLENC)
+                .body(format("grant_type=refresh_token&refresh_token=%s", refreshToken))
                 .post("/token")
                 .then()
                 .log().ifValidationFails()
@@ -253,9 +249,9 @@ public class DataPlaneTokenRefreshEndToEndTest {
         var accessToken = edr.getStringProperty(EDC_NAMESPACE + "authorization");
 
         RUNTIME_CONFIG.basePublicApiRequest()
-                .queryParam("grant_type", "refresh_token")
-                .queryParam("refresh_token", refreshToken)
                 .header(AUTHORIZATION, "Bearer " + createAuthToken(accessToken, consumerKey))
+                .contentType(ContentType.URLENC)
+                .body(format("grant_type=refresh_token&refresh_token=%s", refreshToken))
                 .post("/token")
                 .then()
                 .log().ifValidationFails()
@@ -286,9 +282,9 @@ public class DataPlaneTokenRefreshEndToEndTest {
         var authToken = createJwt(consumerKey, claims);
 
         RUNTIME_CONFIG.basePublicApiRequest()
-                .queryParam("grant_type", "refresh_token")
-                .queryParam("refresh_token", refreshToken)
                 .header(AUTHORIZATION, "Bearer " + authToken)
+                .contentType(ContentType.URLENC)
+                .body(format("grant_type=refresh_token&refresh_token=%s", refreshToken))
                 .post("/token")
                 .then()
                 .log().ifValidationFails()
@@ -319,9 +315,9 @@ public class DataPlaneTokenRefreshEndToEndTest {
         var authToken = createJwt(consumerKey, claims);
 
         RUNTIME_CONFIG.basePublicApiRequest()
-                .queryParam("grant_type", "refresh_token")
-                .queryParam("refresh_token", refreshToken)
                 .header(AUTHORIZATION, "Bearer " + authToken)
+                .contentType(ContentType.URLENC)
+                .body(format("grant_type=refresh_token&refresh_token=%s", refreshToken))
                 .post("/token")
                 .then()
                 .log().ifValidationFails()
@@ -356,9 +352,9 @@ public class DataPlaneTokenRefreshEndToEndTest {
         var authToken = createJwt(consumerKey, claims);
 
         RUNTIME_CONFIG.basePublicApiRequest()
-                .queryParam("grant_type", "refresh_token")
-                .queryParam("refresh_token", refreshToken)
                 .header(AUTHORIZATION, "Bearer " + authToken)
+                .contentType(ContentType.URLENC)
+                .body(format("grant_type=refresh_token&refresh_token=%s", refreshToken))
                 .post("/token")
                 .then()
                 .log().ifValidationFails()

--- a/edc-tests/e2e/edr-api-tests/src/test/java/org/eclipse/tractusx/edc/tests/edrv2/EdrCacheApiEndToEndTest.java
+++ b/edc-tests/e2e/edr-api-tests/src/test/java/org/eclipse/tractusx/edc/tests/edrv2/EdrCacheApiEndToEndTest.java
@@ -56,7 +56,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.IntStream;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
@@ -117,7 +117,9 @@ public class EdrCacheApiEndToEndTest {
     @DisplayName("Verify HTTP 200 response and body when refreshing succeeds")
     @Test
     void getEdrWithRefresh_success() {
-        mockedRefreshApi.stubFor(post(urlPathEqualTo("/refresh/token")).withRequestBody(absent())
+        mockedRefreshApi.stubFor(post(urlPathEqualTo("/refresh/token"))
+                .withFormParam("grant_type", WireMock.equalTo("refresh_token"))
+                .withFormParam("refresh_token", matching(".+"))
                 .willReturn(ok(tokenResponseBody())));
 
         storeEdr("test-id", true);
@@ -126,8 +128,7 @@ public class EdrCacheApiEndToEndTest {
                 .extract().body().as(JsonObject.class);
         assertThat(edr).isNotNull();
 
-        mockedRefreshApi.verify(1, postRequestedFor(urlPathEqualTo("/refresh/token"))
-                .withQueryParam("grant_type", WireMock.equalTo("refresh_token")));
+        mockedRefreshApi.verify(1, postRequestedFor(urlPathEqualTo("/refresh/token")));
     }
 
     @DisplayName("When multiple requests to refresh, to different edrs, verify all return non expired token")
@@ -137,7 +138,9 @@ public class EdrCacheApiEndToEndTest {
         var accessToken = createJwt(providerSigningKey, claims);
         var refreshToken = createJwt(providerSigningKey, new JWTClaimsSet.Builder().build());
         var tokenResponseBodyString = tokenResponseBody(accessToken, refreshToken);
-        mockedRefreshApi.stubFor(post(urlPathEqualTo("/refresh/token")).withRequestBody(absent())
+        mockedRefreshApi.stubFor(post(urlPathEqualTo("/refresh/token"))
+                .withFormParam("grant_type", WireMock.equalTo("refresh_token"))
+                .withFormParam("refresh_token", matching(".+"))
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)
                         .withFixedDelay(5000)
@@ -184,8 +187,7 @@ public class EdrCacheApiEndToEndTest {
         latch.await();
         assertThat(failed.get()).isFalse();
 
-        mockedRefreshApi.verify(2, postRequestedFor(urlPathEqualTo("/refresh/token"))
-                .withQueryParam("grant_type", WireMock.equalTo("refresh_token")));
+        mockedRefreshApi.verify(2, postRequestedFor(urlPathEqualTo("/refresh/token")));
     }
 
     @DisplayName("Verify the refresh endpoint is not called when token not yet expired")
@@ -197,8 +199,7 @@ public class EdrCacheApiEndToEndTest {
                 .extract().body().as(JsonObject.class);
         assertThat(edr).isNotNull();
 
-        mockedRefreshApi.verify(0, postRequestedFor(urlPathEqualTo("/refresh/token"))
-                .withQueryParam("grant_type", WireMock.equalTo("refresh_token")));
+        mockedRefreshApi.verify(0, postRequestedFor(urlPathEqualTo("/refresh/token")));
     }
 
     @DisplayName("Verify the refresh endpoint is not called when auto_refresh=false")
@@ -211,14 +212,15 @@ public class EdrCacheApiEndToEndTest {
                 .extract().body().as(JsonObject.class);
         assertThat(edr).isNotNull();
 
-        mockedRefreshApi.verify(0, postRequestedFor(urlPathEqualTo("/refresh/token"))
-                .withQueryParam("grant_type", WireMock.equalTo("refresh_token")));
+        mockedRefreshApi.verify(0, postRequestedFor(urlPathEqualTo("/refresh/token")));
     }
 
     @DisplayName("Verify HTTP 403 response when refreshing the token is not allowed")
     @Test
     void getEdrWithRefresh_unauthorized() {
-        mockedRefreshApi.stubFor(post(urlPathEqualTo("/refresh/token")).withRequestBody(absent())
+        mockedRefreshApi.stubFor(post(urlPathEqualTo("/refresh/token"))
+                .withFormParam("grant_type", WireMock.equalTo("refresh_token"))
+                .withFormParam("refresh_token", matching(".+"))
                 .willReturn(WireMock.aResponse()
                         .withStatus(401)
                         .withBody("unauthorized")
@@ -228,13 +230,14 @@ public class EdrCacheApiEndToEndTest {
         CONSUMER.edrs().getEdrWithRefresh("test-id", true)
                 .statusCode(403);
 
-        mockedRefreshApi.verify(1, postRequestedFor(urlPathEqualTo("/refresh/token"))
-                .withQueryParam("grant_type", WireMock.equalTo("refresh_token")));
+        mockedRefreshApi.verify(1, postRequestedFor(urlPathEqualTo("/refresh/token")));
     }
 
     @Test
     void refreshEdr() {
-        mockedRefreshApi.stubFor(post(urlPathEqualTo("/refresh/token")).withRequestBody(absent())
+        mockedRefreshApi.stubFor(post(urlPathEqualTo("/refresh/token"))
+                .withFormParam("grant_type", WireMock.equalTo("refresh_token"))
+                .withFormParam("refresh_token", matching(".+"))
                 .willReturn(ok(tokenResponseBody())));
 
         storeEdr("test-id", true);
@@ -243,8 +246,7 @@ public class EdrCacheApiEndToEndTest {
                 .extract().body().as(JsonObject.class);
         assertThat(edr).isNotNull();
 
-        mockedRefreshApi.verify(1, postRequestedFor(urlPathEqualTo("/refresh/token"))
-                    .withQueryParam("grant_type", WireMock.equalTo("refresh_token")));
+        mockedRefreshApi.verify(1, postRequestedFor(urlPathEqualTo("/refresh/token")));
     }
 
     @Test
@@ -255,7 +257,9 @@ public class EdrCacheApiEndToEndTest {
 
     @Test
     void refreshEdr_whenNotAuthorized() {
-        mockedRefreshApi.stubFor(post(urlPathEqualTo("/refresh/token")).withRequestBody(absent())
+        mockedRefreshApi.stubFor(post(urlPathEqualTo("/refresh/token"))
+                .withFormParam("grant_type", WireMock.equalTo("refresh_token"))
+                .withFormParam("refresh_token", matching(".+"))
                 .willReturn(WireMock.aResponse()
                         .withStatus(401)
                         .withBody("unauthorized")
@@ -265,8 +269,7 @@ public class EdrCacheApiEndToEndTest {
         CONSUMER.edrs().refreshEdr("test-id")
                 .statusCode(403);
 
-        mockedRefreshApi.verify(1, postRequestedFor(urlPathEqualTo("/refresh/token"))
-                .withQueryParam("grant_type", WireMock.equalTo("refresh_token")));
+        mockedRefreshApi.verify(1, postRequestedFor(urlPathEqualTo("/refresh/token")));
     }
 
     private String tokenResponseBody() {


### PR DESCRIPTION
## WHAT

The refresh token endpoint follows RFC 6749, which states, that two properties called `grant_type` and `refresh_token` are transfered as form based parameters in the body of the post request. The current implementation makes use of query parameters instead of a body. The fix adds the body but keeps the query parameter as secondary mechanism to ensure interoperability with existing edc implementations.

## WHY

Several reasons:
- Adherence to the spec (in this case CX-0018) for future use of connectors as primary and at some time only mechanism
- Prepare to overcome non-conformant use of query parameters in a post request
- Bugfix, because it allows to remove the query parameter mechanism for future versions as soon as 0.12.x becomes the minimum used connector versions

Relates to: #2899 