### PR TITLE
chore: Enable dependabot for bugfixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,22 +39,6 @@ updates:
     ignore:
       - dependency-name: "org.eclipse.dataspacetck.dsp:*"
       - dependency-name: "org.eclipse.dataspacetck.dcp:*"
-  -
-    package-ecosystem: "gradle"
-    target-branch: release/0.12.2
-    directory: /
-    labels:
-      - "dependabot"
-      - "dependencies"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 50
-    cooldown:
-      default-days: 7
-    ignore:
-      - dependency-name: "org.eclipse.dataspacetck.dsp:*"
-      - dependency-name: "org.eclipse.dataspacetck.dcp:*"
-      - dependency-name: "org.eclipse.edc:*"
 
   # Github Actions
   -
@@ -75,20 +59,6 @@ updates:
   # Docker
   - package-ecosystem: "docker"
     target-branch: main
-    directories:
-      - "resources"
-      - "edc-extensions/bdrs-client/src/test/resources"
-      - "edc-tests/e2e-fixtures/src/testFixtures/resources"
-    labels:
-      - "dependabot"
-      - "docker"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 50
-    cooldown:
-      default-days: 7
-  - package-ecosystem: "docker"
-    target-branch: release/0.12.2
     directories:
       - "resources"
       - "edc-extensions/bdrs-client/src/test/resources"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,22 @@ updates:
     ignore:
       - dependency-name: "org.eclipse.dataspacetck.dsp:*"
       - dependency-name: "org.eclipse.dataspacetck.dcp:*"
+  -
+    package-ecosystem: "gradle"
+    target-branch: release/0.12.2
+    directory: /
+    labels:
+      - "dependabot"
+      - "dependencies"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 50
+    cooldown:
+      default-days: 7
+    ignore:
+      - dependency-name: "org.eclipse.dataspacetck.dsp:*"
+      - dependency-name: "org.eclipse.dataspacetck.dcp:*"
+      - dependency-name: "org.eclipse.edc:*"
 
   # Github Actions
   -
@@ -59,6 +75,20 @@ updates:
   # Docker
   - package-ecosystem: "docker"
     target-branch: main
+    directories:
+      - "resources"
+      - "edc-extensions/bdrs-client/src/test/resources"
+      - "edc-tests/e2e-fixtures/src/testFixtures/resources"
+    labels:
+      - "dependabot"
+      - "docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 50
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "docker"
+    target-branch: release/0.12.2
     directories:
       - "resources"
       - "edc-extensions/bdrs-client/src/test/resources"

--- a/.github/workflows/dependabot-on-demand.yaml
+++ b/.github/workflows/dependabot-on-demand.yaml
@@ -19,7 +19,7 @@
 
 ---
 name: "Dependabot (on-demand)"
-run-name: "Dependabot (gradle ecosystem) on ${{ inputs.branch }}"
+run-name: "Dependabot ${{ matrix.ecosystem }} (${{ matrix.directory }})"
 
 on:
   workflow_dispatch:
@@ -34,12 +34,20 @@ permissions:
 jobs:
   run:
     runs-on: ubuntu-latest
-    name: "Gradle dependency"
+    name: "Dependabot ${{ matrix.ecosystem }} (${{ matrix.directory }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ecosystem: gradle
+            directory: /
+          - ecosystem: docker
+            directory: resources
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       LOCAL_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ECOSYSTEM: gradle
-      DIRECTORY: /
+      ECOSYSTEM: ${{ matrix.ecosystem }}
+      DIRECTORY: ${{ matrix.directory }}
       BRANCH: ${{ inputs.branch }}
       REPO: ${{ github.repository }}
     steps:

--- a/.github/workflows/dependabot-on-demand.yaml
+++ b/.github/workflows/dependabot-on-demand.yaml
@@ -1,0 +1,50 @@
+#################################################################################
+#  Copyright (c) 2026 Cofinity-X GmbH
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+---
+name: "Dependabot (on-demand)"
+run-name: "Dependabot (gradle ecosystem) on ${{ inputs.branch }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to check (e.g. release/0.10.0)."
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    name: "Gradle dependency"
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      LOCAL_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ECOSYSTEM: gradle
+      DIRECTORY: /
+      BRANCH: ${{ inputs.branch }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Run Dependabot
+        run: |
+          VERSION="$(gh release view --repo dependabot/cli --json tagName -q .tagName)"
+          curl -sSfL "https://github.com/dependabot/cli/releases/download/${VERSION}/dependabot-${VERSION}-linux-amd64.tar.gz" | tar -xz dependabot
+          ./dependabot update "$ECOSYSTEM" "$REPO" --branch "$BRANCH" --directory "$DIRECTORY"


### PR DESCRIPTION
## WHAT

A manual workflow to run dependabot. As the release branches change, the solution allows to run dependabot on a selected branch. It does not create a pull request, but the results can be easily used by Copilot to fix the issues and do a single pull request. This is sufficient and generally applicable to branches.

## WHY

To ensure updates of dependencies in the bugfix

