### PR TITLE
fix: Make token response rfc6749 compliant

### DIFF
--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/api/v1/TokenRefreshApiControllerTest.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-api/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/api/v1/TokenRefreshApiControllerTest.java
@@ -59,7 +59,7 @@ class TokenRefreshApiControllerTest extends RestControllerTestBase {
     @DisplayName("Expect HTTP 200 when the token was successfully refreshed and query params used")
     @Test
     void refresh_expect200query() {
-        when(refreshService.refreshToken(any(), any())).thenReturn(Result.success(new TokenResponse("new-accesstoken", "new-refreshtoken", 3000L, "bearer")));
+        when(refreshService.refreshToken(any(), any())).thenReturn(Result.success(new TokenResponse("new-accesstoken", "new-refreshtoken", null, 3000L, "bearer")));
         baseRequest()
                 .queryParam("grant_type", "refresh_token")
                 .queryParam("refresh_token", "foo-token")
@@ -73,7 +73,7 @@ class TokenRefreshApiControllerTest extends RestControllerTestBase {
     @DisplayName("Expect HTTP 200 when the token was successfully refreshed and correct body used")
     @Test
     void refresh_expect200body() {
-        when(refreshService.refreshToken(any(), any())).thenReturn(Result.success(new TokenResponse("new-accesstoken", "new-refreshtoken", 3000L, "bearer")));
+        when(refreshService.refreshToken(any(), any())).thenReturn(Result.success(new TokenResponse("new-accesstoken", "new-refreshtoken", 3000L, null, "bearer")));
         baseRequest()
                 .header(AUTHORIZATION, "auth-token")
                 .contentType(ContentType.URLENC)

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImpl.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImpl.java
@@ -212,7 +212,7 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
             monitor.severe("Failed to store refreshed access token data: %s".formatted(storeResult.getFailureDetail()));
             return Result.failure(storeResult.getFailureMessages());
         }
-        return Result.success(new TokenResponse(newAccessToken.getContent(), newRefreshToken.getContent(), tokenExpirySeconds, "bearer"));
+        return Result.success(new TokenResponse(newAccessToken.getContent(), newRefreshToken.getContent(), tokenExpirySeconds, tokenExpirySeconds, "bearer"));
     }
 
     @Override

--- a/edc-extensions/tokenrefresh-handler/src/test/java/org/eclipse/tractusx/edc/common/tokenrefresh/TokenRefreshHandlerImplTest.java
+++ b/edc-extensions/tokenrefresh-handler/src/test/java/org/eclipse/tractusx/edc/common/tokenrefresh/TokenRefreshHandlerImplTest.java
@@ -116,7 +116,8 @@ class TokenRefreshHandlerImplTest {
     void refresh_validateCorrectRequest() throws IOException {
         when(edrCache.get(anyString())).thenReturn(StoreResult.success(createEdr().build()));
         when(mockedTokenService.createToken(any(), anyMap(), isNull())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().token("foo-auth-token").build()));
-        var tokenResponse = new TokenResponse("new-access-token", "new-refresh-token", 60 * 5L, "bearer");
+        var expires = 60 * 5L;
+        var tokenResponse = new TokenResponse("new-access-token", "new-refresh-token", expires, expires, "bearer");
         var successResponse = createResponse(tokenResponse, 200, "");
         when(mockedHttpClient.execute(any())).thenReturn(successResponse);
         var res = tokenRefreshHandler.refreshToken("token-id");

--- a/edc-tests/e2e/edr-api-tests/src/test/java/org/eclipse/tractusx/edc/tests/edrv2/EdrCacheApiEndToEndTest.java
+++ b/edc-tests/e2e/edr-api-tests/src/test/java/org/eclipse/tractusx/edc/tests/edrv2/EdrCacheApiEndToEndTest.java
@@ -280,7 +280,7 @@ public class EdrCacheApiEndToEndTest {
     }
 
     private String tokenResponseBody(String accessToken, String refreshToken) {
-        var response = new TokenResponse(accessToken, refreshToken, 300L, "bearer");
+        var response = new TokenResponse(accessToken, refreshToken, null, 300L, "bearer");
         try {
             return mapper.writeValueAsString(response);
         } catch (JsonProcessingException e) {

--- a/spi/tokenrefresh-spi/src/main/java/org/eclipse/tractusx/edc/spi/tokenrefresh/dataplane/model/TokenResponse.java
+++ b/spi/tokenrefresh-spi/src/main/java/org/eclipse/tractusx/edc/spi/tokenrefresh/dataplane/model/TokenResponse.java
@@ -23,6 +23,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record TokenResponse(@JsonProperty("access_token") String accessToken,
                             @JsonProperty("refresh_token") String refreshToken,
-                            @JsonProperty("expires") Long expiresInSeconds,
+                            @JsonProperty("expires") Long expiresInLegacy, // TODO: Still needed because older implementations use this non-spec-compliant value, can be removed when only 0.12.x based connectors are in the field
+                            @JsonProperty("expires_in") Long expiresIn,
                             @JsonProperty("token_type") String tokenType) {
+
+    public Long expiresInSeconds() {
+        // Remove when the expiresInLegacy becomes obsolete, change expiresIn to expiresInSeconds
+        return expiresIn() != null ? expiresIn() : expiresInLegacy();
+    }
 }


### PR DESCRIPTION
## WHAT

RFC 6749 (references in CX-0018) defines the content in a token refresh response to contain a field expires_in, in the current implementation, this field is called expires. The change is in a way, that the response now contains both fields to stay backward compatible.

## WHY

The idea is, that hopefully, older implementations ignore additional fields in the token and make use of the legacy field, whereas the implementation returns the new field as default. I have no other idea on how to change that, as it is the old connector versions that might have an issue, this solution should be save, as it basically can handle both fields to be used.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Relates #2936 // Fix for bugfix release 0.12.2
