### PR TITLE
infra: Use dependabot grouping to reduce PR flood

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,30 @@ updates:
     ignore:
       - dependency-name: "org.eclipse.dataspacetck.dsp:*"
       - dependency-name: "org.eclipse.dataspacetck.dcp:*"
+    groups:
+      edc-core-and-spi:
+        patterns:
+          - "org.eclipse.edc*"
+          - "org.eclipse.tractusx*"
+          - "org.eclipse.dataspace*"
+      test-dependencies:
+        patterns:
+          - "org.junit*"
+          - "org.mockito*"
+          - "org.testcontainers*"
+          - "org.awaitility*"
+          - "org.assertj*"
+      build-tooling:
+        patterns:
+          - "com.diffplug.spotless*"
+          - "org.sonarqube*"
+          - "com.github.ben-manes*"
+          - "org.jreleaser*"
+      logging:
+        patterns:
+          - "org.apache.logging.log4j*"
+          - "ch.qos.logback*"
+          - "org.slf4j*"
 
   # Github Actions
   -
@@ -55,6 +79,10 @@ updates:
     open-pull-requests-limit: 50
     cooldown:
       default-days: 7
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"
 
   # Docker
   - package-ecosystem: "docker"
@@ -71,3 +99,7 @@ updates:
     open-pull-requests-limit: 50
     cooldown:
       default-days: 7
+    groups:
+      docker-base-images:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@
 #  under the License.
 #
 #  SPDX-License-Identifier: Apache-2.0
+#  Assisted-By: GPT-5.3-Codex
 #################################################################################
 
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@
 #  under the License.
 #
 #  SPDX-License-Identifier: Apache-2.0
-#  Assisted-By: GPT-5.3-Codex
+#  Assisted-By: Claude-Opus-4.8
 #################################################################################
 
 
@@ -38,23 +38,24 @@ updates:
     cooldown:
       default-days: 7
     ignore:
-      - dependency-name: "org.eclipse.dataspacetck.dsp:*"
-      - dependency-name: "org.eclipse.dataspacetck.dcp:*"
+      - dependency-name: "org.eclipse.dataspacetck.*"
     groups:
-      edc-core-and-spi:
-        patterns:
-          - "org.eclipse.edc*"
-          - "org.eclipse.tractusx*"
-          - "org.eclipse.dataspace*"
       test-dependencies:
         patterns:
           - "org.junit*"
           - "org.mockito*"
-          - "org.testcontainers*"
-          - "org.awaitility*"
           - "org.assertj*"
+          - "org.awaitility*"
+          - "org.testcontainers*"
+          - "com.github.dasniko:testcontainers-keycloak"
+          - "io.rest-assured*"
+          - "org.wiremock*"
+          - "io.qameta.allure*"
       build-tooling:
         patterns:
+          - "com.bmuschko*"
+          - "com.gradleup*"
+          - "io.swagger*"
           - "com.diffplug.spotless*"
           - "org.sonarqube*"
           - "com.github.ben-manes*"
@@ -62,8 +63,26 @@ updates:
       logging:
         patterns:
           - "org.apache.logging.log4j*"
-          - "ch.qos.logback*"
           - "org.slf4j*"
+          - "ch.qos.logback*"
+          - "io.opentelemetry*"
+      serialization-and-crypto:
+        patterns:
+          - "com.fasterxml.jackson*"
+          - "jakarta.json*"
+          - "jakarta.ws.rs*"
+          - "com.apicatalog*"
+          - "com.networknt*"
+          - "org.bouncycastle*"
+          - "com.nimbusds*"
+      cloud-sdks:
+        patterns:
+          - "software.amazon.awssdk*"
+          - "com.azure*"
+      database:
+        patterns:
+          - "org.postgresql*"
+          - "org.flywaydb*"
 
   # Github Actions
   -

--- a/resources/hashtag.header
+++ b/resources/hashtag.header
@@ -16,5 +16,6 @@
 ^#  under the License\.$
 ^#$
 ^#  SPDX-License-Identifier: Apache\-2\.0$
+^#  Assisted-By:.*$
 ^##+$
 ^$

--- a/resources/java.header
+++ b/resources/java.header
@@ -15,4 +15,5 @@
 ^ \* under the License\.$
 ^ \*$
 ^ \* SPDX-License-Identifier: Apache\-2\.0$
+^ \* Assisted-By:.*$
 ^ \*+/$

--- a/resources/tx-checkstyle-config.xml
+++ b/resources/tx-checkstyle-config.xml
@@ -46,13 +46,13 @@
     <module name="RegexpHeader">
         <property name="fileExtensions" value="java, kts"/>
         <property name="headerFile" value="${config_loc}/java.header"/>
-        <property name="multiLines" value="2"/>
+        <property name="multiLines" value="2, 18"/>
     </module>
 
     <module name="RegexpHeader">
         <property name="fileExtensions" value="yml, yaml, properties, sh, ServiceExtension"/>
         <property name="headerFile" value="${config_loc}/hashtag.header"/>
-        <property name="multiLines" value="1, 3"/>
+        <property name="multiLines" value="1, 3, 19"/>
     </module>
 
     <module name="TreeWalker">


### PR DESCRIPTION
## WHAT

I have added reasonable grouping to dependabot warnings, in addition, as this pr was supported by AI, I added the option to add the Assisted-By field in all headers, as these are required by the Eclipse Foundation

## WHY

To remove the pr flood
