### PR TITLE
feat: update allure action to avoid simple-elf action and fix 2 zizmor foundings

### DIFF
--- a/.github/actions/generate-and-publish-allure-report/action.yml
+++ b/.github/actions/generate-and-publish-allure-report/action.yml
@@ -42,11 +42,10 @@ runs:
         path: allure-results
 
     - name: Build Allure test report
-      uses: simple-elf/allure-report-action@e463a472d3b1d750f9544369d60589ff1964c820 # v1.14
-      with:
-        gh_pages: gh-pages
-        allure_results: allure-results
-        allure_report: ${{ inputs.version }}
+      shell: bash
+      run: |
+        npm install -g allure-commandline
+        allure generate allure-results --clean -o "${{ inputs.version }}"
 
     - name: Publish Allure test report to gh-pages
       uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0

--- a/.github/actions/generate-and-publish-allure-report/action.yml
+++ b/.github/actions/generate-and-publish-allure-report/action.yml
@@ -43,9 +43,11 @@ runs:
 
     - name: Build Allure test report
       shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
       run: |
         npm install -g allure-commandline
-        allure generate allure-results --clean -o "${{ inputs.version }}"
+        allure generate allure-results --clean -o "$VERSION"
 
     - name: Publish Allure test report to gh-pages
       uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -120,7 +120,7 @@ jobs:
       packages: write
       pages: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.2 # zizmor: ignore[artipacked]
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: true
       - name: Create Release branch

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -117,7 +117,7 @@ jobs:
       # generates coverage-report.md
       - name: JaCoCo Code Coverage Report
         id: jacoco_reporter
-        uses: PavanMudigonda/jacoco-reporter@e8b54bfea6a667d1a68624dae8a06ba31670667d # v5.1
+        uses: PavanMudigonda/jacoco-reporter@112997f0c32da82d8bfa4a972b4afe67a15529fe # v5.2.1
         with:
           coverage_results_path: build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           skip_check_run: true


### PR DESCRIPTION
## WHAT

Update allure action to avoid simple-elf action 

## WHY

The Docker image that simple-elf/allure-report-action runs in no longer provides xargs

## FURTHER NOTES

Two Zizmor findings were fixed related to incorrect action pin SHA
