### PR TITLE
fix(helm): remove duplicate catalog env vars in deployment-controlplane

### DIFF
--- a/charts/tractusx-connector/templates/deployment-controlplane.yaml
+++ b/charts/tractusx-connector/templates/deployment-controlplane.yaml
@@ -300,43 +300,6 @@ spec:
               value: {{ .Values.vault.hashicorp.paths.folder | quote }}
             {{- end }}
 
-
-            ###############################
-            ## FEDERATED CATALOG CRAWLER ##
-            ###############################
-            {{- if .Values.controlplane.catalog.crawler.period }}
-            - name: "EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS"
-              value: {{ .Values.controlplane.catalog.crawler.period | quote}}
-            {{- end }}
-
-            {{- if .Values.controlplane.catalog.crawler.initialDelay }}
-            - name: "EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS"
-              value: {{ .Values.controlplane.catalog.crawler.initialDelay | quote }}
-            {{- end }}
-
-            {{- if .Values.controlplane.catalog.crawler.num }}
-            - name: "EDC_CATALOG_CACHE_PARTITION_NUM_CRAWLERS"
-              value: {{ .Values.controlplane.catalog.crawler.num }}
-            {{- end }}
-
-            - name: "EDC_CATALOG_CACHE_EXECUTION_ENABLED"
-              value: {{ .Values.controlplane.catalog.enabled | quote }}
-
-            - name: "TX_EDC_CATALOG_NODE_LIST_FILE"
-              value: {{ .Values.controlplane.catalog.crawler.targetsFile }}
-
-              value: {{ .Values.iatp.id | required ".Values.iatp.id is required" | quote }}
-              value: {{ .Values.iatp.id | required ".Values.iatp.id is required" | quote }}
-            - name: "WEB_HTTP_CATALOG_PORT"
-              value: {{ .Values.controlplane.endpoints.catalog.port | quote }}
-            - name: "WEB_HTTP_CATALOG_PATH"
-              value: {{ .Values.controlplane.endpoints.catalog.path | quote }}
-            - name: "WEB_HTTP_CATALOG_AUTH_TYPE"
-              value: "tokenbased"
-            - name: "WEB_HTTP_CATALOG_AUTH_KEY"
-              value: {{ .Values.controlplane.endpoints.catalog.authKey | required ".Values.controlplane.endpoints.catalog.authKey is required" | quote }}
-
-
             ###############################
             ## FEDERATED CATALOG CRAWLER ##
             ###############################


### PR DESCRIPTION
WHAT

Removes a duplicate 
```yaml
###############################
## FEDERATED CATALOG CRAWLER ##
###############################
```
 in `charts/tractusx-connector/templates/deployment-controlplane.yaml` that caused 
`WEB_HTTP_CATALOG_PORT`, 
`WEB_HTTP_CATALOG_PATH`, 
`WEB_HTTP_CATALOG_AUTH_TYPE`, 
`WEB_HTTP_CATALOG_AUTH_KEY`, 
`EDC_CATALOG_CACHE_EXECUTION_ENABLED`, 
`TX_EDC_CATALOG_NODE_LIST_FILE` 

env vars to be rendered twice in the controlplane deployment.

WHY

helm install fails with server-side apply duplicate key errors when using chart version 0.12.1. The duplication was introduced by commit 1f90328364 which added the FEDERATED CATALOG CRAWLER block a second time, including orphaned value: lines without corresponding - name: entries (leftovers from the removal of TX_EDC_DID_SERVICE_SELF_REGISTRATION_ID).

FURTHER NOTES

The clean second copy of the FEDERATED CATALOG CRAWLER section remains intact. The WEB_HTTP_CATALOG_* env vars in the endpoints section (~line 199) are unaffected. The main branch (0.13.0) does not have this issue -- the catalog env vars were restructured there.

Closes #2994