### PR TITLE
feat: make refresh token recoverable

### DIFF
--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImpl.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImpl.java
@@ -82,6 +82,7 @@ import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.EDR_PROPERTY_REFRES
 public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshService, DataPlaneAccessTokenService {
     public static final String ACCESS_TOKEN_CLAIM = "token";
     public static final String TOKEN_ID_CLAIM = "jti";
+    private static final long SLOW_PHASE_THRESHOLD_MS = 5000;
     private final long tokenExpirySeconds;
     private final List<TokenValidationRule> authenticationTokenValidationRules;
     private final ParticipantContextSupplier participantContextSupplier;
@@ -150,7 +151,8 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
      *     <li>verify the token's signature</li>
      *     <li>assert {@code iss} and {@code sub} claims are identical</li>
      *     <li>assert the the token contains an {@code token} claim, and that the value is identical to the access token we have on record</li>
-     *     <li>assert that the {@code refreshToken} parameter is identical to the refresh token we have on record</li>
+     *     <li>assert that the {@code refreshToken} parameter is identical to the refresh token we have on record, or to
+     *     the one that record superseded</li>
      * </ul>
      *
      * @param refreshToken        The refresh token that was issued in the original/previous token request.
@@ -159,9 +161,11 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
     @Override
     public Result<TokenResponse> refreshToken(String refreshToken, String authenticationToken) {
 
-        authenticationToken = authenticationToken.replace("Bearer", "").trim();
+        var authToken = authenticationToken.replace("Bearer", "").trim();
 
-        var authTokenRes = tokenValidationService.validate(authenticationToken, publicKeyResolver, authenticationTokenValidationRules);
+        var authTokenRes = timed("validate-authentication-token [DID resolution]",
+                () -> tokenValidationService.validate(authToken,
+                        publicKeyResolver, authenticationTokenValidationRules));
         if (authTokenRes.failed()) {
             var msg = "Authentication token validation failed: %s".formatted(authTokenRes.getFailureDetail());
             monitor.debug(msg);
@@ -179,8 +183,10 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
         // 2. extract access token and validate it
         var accessToken = authTokenRes.getContent().getStringClaim("token");
         var refreshTokenValidationRule = new RefreshTokenValidationRule(vault, refreshToken, objectMapper, participantContext);
-        var accessTokenDataResult = tokenValidationService.validate(accessToken, localPublicKeyService, refreshTokenValidationRule)
-                .map(accessTokenClaims -> accessTokenDataStore.getById(accessTokenClaims.getStringClaim(JwtRegisteredClaimNames.JWT_ID)));
+
+        Result<AccessTokenData> accessTokenDataResult = timed("validate-access-token [Vault resolveSecret + store getById]",
+                () -> tokenValidationService.validate(accessToken, localPublicKeyService, refreshTokenValidationRule)
+                        .map(accessTokenClaims -> accessTokenDataStore.getById(accessTokenClaims.getStringClaim(JwtRegisteredClaimNames.JWT_ID))));
 
         if (accessTokenDataResult.failed()) {
             var msg = "Access token validation failed: %s".formatted(accessTokenDataResult.getFailureDetail());
@@ -195,7 +201,11 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
                 .build();
 
         var newAccessToken = createToken(newTokenParams).map(tr -> tr.tokenRepresentation().getToken());
-        var newRefreshToken = createToken(TokenParameters.Builder.newInstance().build()).map(tr -> tr.tokenRepresentation().getToken());
+
+        var replayed = refreshTokenValidationRule.replayedToken();
+        var newRefreshToken = replayed != null
+                ? ServiceResult.success(replayed.refreshToken())
+                : createToken(TokenParameters.Builder.newInstance().build()).map(tr -> tr.tokenRepresentation().getToken());
         if (newAccessToken.failed() || newRefreshToken.failed()) {
             var errors = new ArrayList<>(newAccessToken.getFailureMessages());
             errors.addAll(newRefreshToken.getFailureMessages());
@@ -204,13 +214,19 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
             return Result.failure(msg);
         }
 
-        storeRefreshToken(existingAccessTokenData.id(), new RefreshToken(newRefreshToken.getContent(), tokenExpirySeconds, refreshEndpoint), participantContext);
+        if (replayed != null) {
+            monitor.info("Refresh token for '%s' was already rotated, handing out the current one again.".formatted(existingAccessTokenData.id()));
+            return Result.success(new TokenResponse(newAccessToken.getContent(), newRefreshToken.getContent(), tokenExpirySeconds, tokenExpirySeconds, "bearer"));
+        }
+
+        timed("store-refresh-token [Vault storeSecret]",
+                () -> storeRefreshToken(existingAccessTokenData.id(), new RefreshToken(newRefreshToken.getContent(), tokenExpirySeconds, refreshEndpoint, refreshToken), participantContext));
 
         // the ClaimToken is created based solely on the TokenParameters. The additional information (refresh token...) is persisted separately
         var claimToken = ClaimToken.Builder.newInstance().claims(newTokenParams.getClaims()).build();
         var accessTokenData = new AccessTokenData(existingAccessTokenData.id(), claimToken, existingAccessTokenData.dataAddress(), existingAccessTokenData.additionalProperties());
 
-        var storeResult = accessTokenDataStore.update(accessTokenData);
+        var storeResult = timed("update-access-token [store update]", () -> accessTokenDataStore.update(accessTokenData));
 
         if (storeResult.failed()) {
             monitor.severe("Failed to store refreshed access token data: %s".formatted(storeResult.getFailureDetail()));
@@ -392,6 +408,24 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
             return Result.success(objectMapper.writeValueAsString(object));
         } catch (JsonProcessingException e) {
             return Result.failure(e.getMessage());
+        }
+    }
+
+    /**
+     * Executes the given action and records how long it took. Phases exceeding {@link #SLOW_PHASE_THRESHOLD_MS} are
+     * logged at WARNING so that a slow/stalled external dependency (DID resolution, Vault, database) can be identified
+     * from the logs even when the overall request eventually completes.
+     */
+    private <T> T timed(String phase, Supplier<T> action) {
+        var start = System.nanoTime();
+        try {
+            return action.get();
+        } finally {
+            var elapsedMs = (System.nanoTime() - start) / 1_000_000;
+            var msg = "refreshToken phase '%s' took %d ms".formatted(phase, elapsedMs);
+            if (elapsedMs >= SLOW_PHASE_THRESHOLD_MS) {
+                monitor.debug(msg);
+            }
         }
     }
 

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImpl.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImpl.java
@@ -414,7 +414,7 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
 
     /**
      * Executes the given action and records how long it took. Phases exceeding {@link #SLOW_PHASE_THRESHOLD_MS} are
-     * logged at WARNING so that a slow/stalled external dependency (DID resolution, Vault, database) can be identified
+     * logged at DEBUG so that a slow/stalled external dependency (DID resolution, Vault, database) can be identified
      * from the logs even when the overall request eventually completes.
      */
     private <T> T timed(String phase, Supplier<T> action) {

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImpl.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImpl.java
@@ -133,6 +133,7 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
                 new ClaimIsPresentRule(AUDIENCE), // we don't check the contents, only it is present
                 new ClaimIsPresentRule(ACCESS_TOKEN_CLAIM),
                 new ClaimIsPresentRule(TOKEN_ID_CLAIM),
+                new ExpirationIssuedAtValidationRule(clock, tokenExpiryToleranceSeconds, false),
                 new AuthTokenAudienceRule(accessTokenDataStore));
         this.participantContextSupplier = participantContextSupplier;
         accessTokenAuthorizationRules = List.of(new IssuerEqualsSubjectRule(),

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/RefreshToken.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/RefreshToken.java
@@ -19,6 +19,14 @@
 
 package org.eclipse.tractusx.edc.dataplane.tokenrefresh.core;
 
-public record RefreshToken(String refreshToken, Long expiresIn, String refreshEndpoint) {
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.jetbrains.annotations.Nullable;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RefreshToken(String refreshToken, Long expiresIn, String refreshEndpoint,
+                           @Nullable String previousRefreshToken) {
+
+    public RefreshToken(String refreshToken, Long expiresIn, String refreshEndpoint) {
+        this(refreshToken, expiresIn, refreshEndpoint, null);
+    }
 }

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/rules/RefreshTokenValidationRule.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/rules/RefreshTokenValidationRule.java
@@ -39,12 +39,18 @@ import static org.eclipse.edc.spi.result.Result.success;
 /**
  * Validates that the refresh token information associated with a token's ID ({@code jti}), that is stored in the {@link Vault}
  * matches a refresh token string. The refresh token in question is passed into the CTor.
+ * <p>
+ * The token that the last refresh replaced is accepted as well: a client presenting it never received the response of
+ * that refresh, and retiring it before the client has proven receipt would strand the transfer for good. In that case
+ * {@link #replayedToken()} carries the stored record, so that the current refresh token can be handed out again
+ * instead of rotating a second time. Instances are therefore single-use, one per refresh request.
  */
 public class RefreshTokenValidationRule implements TokenValidationRule {
     private final Vault vault;
     private final String incomingRefreshToken;
     private final ObjectMapper objectMapper;
     private final ParticipantContext participantContext;
+    private RefreshToken replayedToken;
 
     public RefreshTokenValidationRule(Vault vault, String incomingRefreshToken, ObjectMapper objectMapper, ParticipantContext participantContext) {
         this.vault = vault;
@@ -62,9 +68,20 @@ public class RefreshTokenValidationRule implements TokenValidationRule {
             return failure("No refresh token with the ID '%s' was found in the vault.".formatted(tokenId));
         }
         return parse(storedRefreshTokenJson)
-                .compose(rt -> incomingRefreshToken.equals(rt.refreshToken()) ?
-                        success() :
-                        failure("Provided refresh token does not match the stored refresh token."));
+                .compose(rt -> {
+                    if (incomingRefreshToken.equals(rt.refreshToken())) {
+                        return success();
+                    }
+                    if (incomingRefreshToken.equals(rt.previousRefreshToken())) {
+                        replayedToken = rt;
+                        return success();
+                    }
+                    return failure("Provided refresh token does not match the stored refresh token.");
+                });
+    }
+
+    public @Nullable RefreshToken replayedToken() {
+        return replayedToken;
     }
 
     private Result<RefreshToken> parse(String storedRefreshTokenJson) {

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplComponentTest.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplComponentTest.java
@@ -57,7 +57,10 @@ import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 
@@ -86,11 +89,13 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
     private final ParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(
             ParticipantContext.Builder.newInstance().participantContextId("participantContextId").identity("identity").build()
     );
+    private static final long TOKEN_EXPIRY_SECONDS = 300L;
     private DataPlaneTokenRefreshServiceImpl tokenRefreshService;
     private final InMemoryAccessTokenDataStore tokenDataStore = new InMemoryAccessTokenDataStore(CriterionOperatorRegistryImpl.ofDefaults());
     private final Monitor monitor = mock();
     private final InMemoryVault vault = new InMemoryVault(mock(), null);
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final MutableClock clock = new MutableClock(Instant.now());
     private ECKey consumerKey;
     private ECKey providerKey;
 
@@ -101,7 +106,7 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
         consumerKey = new ECKeyGenerator(Curve.P_384).keyID(CONSUMER_DID + "#consumer-key").keyUse(KeyUse.SIGNATURE).generate();
 
         when(monitor.withPrefix(anyString())).thenReturn(monitor);
-        tokenRefreshService = new DataPlaneTokenRefreshServiceImpl(Clock.systemUTC(),
+        tokenRefreshService = new DataPlaneTokenRefreshServiceImpl(clock,
                 new TokenValidationServiceImpl(),
                 didPkResolverMock,
                 localPublicKeyService,
@@ -111,7 +116,7 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
                 monitor,
                 TEST_REFRESH_ENDPOINT,
                 1,
-                300L,
+                TOKEN_EXPIRY_SECONDS,
                 () -> providerKey.getKeyID(),
                 vault,
                 objectMapper, participantContextSupplier);
@@ -177,6 +182,93 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
                 .doesNotContainKey("refreshToken");
     }
 
+    @DisplayName("Verify that a refresh whose response got lost can be repeated with the same refresh token")
+    @Test
+    void refresh_whenResponseWasLost_returnsCurrentRefreshTokenAndFreshAccessToken() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        var refreshToken = edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString();
+
+        // the client never sees this response, e.g. because a proxy in between timed out
+        var lostResponse = tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+        clock.advanceBy(Duration.ofSeconds(10));
+
+        // ...so it retries with the only refresh token it has, and gets the very same pair back
+        var retriedResponse = tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()));
+
+        assertThat(retriedResponse).withFailMessage(retriedResponse::getFailureDetail).isSucceeded()
+                // the refresh token is the one the client failed to receive, not a rotated one
+                .satisfies(tr -> assertThat(tr.refreshToken()).isEqualTo(lostResponse.refreshToken()))
+                // the access token is minted fresh, so the client gets a usable one however late it retries
+                .satisfies(tr -> assertThat(tokenRefreshService.resolve(tr.accessToken())).isSucceeded());
+    }
+
+    @DisplayName("Verify that the token pair handed out on a repeat can be refreshed again")
+    @Test
+    void refresh_afterRepeat_newTokenIsUsable() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        var refreshToken = edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString();
+
+        tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+        var repeated = tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+        var nextResponse = tokenRefreshService.refreshToken(repeated.refreshToken(), createAuthToken(tokenId, repeated.accessToken()));
+
+        assertThat(nextResponse).withFailMessage(nextResponse::getFailureDetail).isSucceeded()
+                .satisfies(tr -> assertThat(tr.refreshToken()).isNotEqualTo(repeated.refreshToken()));
+    }
+
+    @DisplayName("Verify that a rotated refresh token is rejected once the client proved it received the new one")
+    @Test
+    void refresh_whenSupersededTokenWasAcknowledged_shouldFail() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        var firstRefreshToken = edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString();
+        var second = tokenRefreshService.refreshToken(firstRefreshToken, createAuthToken(tokenId, edr.getToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+        // using the second token proves that the client received it, which retires the first one
+        tokenRefreshService.refreshToken(second.refreshToken(), createAuthToken(tokenId, second.accessToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+        assertThat(tokenRefreshService.refreshToken(firstRefreshToken, createAuthToken(tokenId, edr.getToken())))
+                .isFailed()
+                .detail()
+                .isEqualTo("Access token validation failed: Provided refresh token does not match the stored refresh token.");
+    }
+
+    @DisplayName("Verify that a rotated refresh token stays acceptable no matter how long the client takes to retry")
+    @Test
+    void refresh_whenResponseWasLostLongAgo_stillSucceeds() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        var refreshToken = edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString();
+        var lostResponse = tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+        // the client still has not proven receipt, so its only refresh token must remain usable - there is no window
+        // after which it is retired
+        clock.advanceBy(Duration.ofDays(1));
+
+        var retriedResponse = tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()));
+
+        assertThat(retriedResponse).withFailMessage(retriedResponse::getFailureDetail).isSucceeded()
+                .satisfies(tr -> assertThat(tr.refreshToken()).isEqualTo(lostResponse.refreshToken()));
+    }
+
     @DisplayName("Verify that a stolen refresh token cannot be used to refresh an access token")
     @Test
     void refresh_originalTokenWasIssuedToDifferentPrincipal() throws JOSEException {
@@ -197,8 +289,7 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
         signedAuthToken.sign(CryptoConverter.createSigner(consumerKey));
         var tokenResponse = tokenRefreshService.refreshToken(edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString(), signedAuthToken.serialize());
 
-        // todo: once the AuthTokenAudienceRule is re-enabled in the DataPlaneTokenRefreshServiceImpl the following assertion needs to be uncommented
-        // assertThat(tokenResponse).isFailed().detail().isEqualTo("Authentication token validation failed: Principal 'did:web:bob' is not authorized to refresh this token.");
+        assertThat(tokenResponse).isFailed().detail().isEqualTo("Authentication token validation failed: Principal 'did:web:bob' is not authorized to refresh this token.");
     }
 
     @DisplayName("Verify that a spoofed refresh attempt is rejected ")
@@ -328,6 +419,13 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
         assertThat(vault.resolveSecret(tokenId)).isNull();
     }
 
+    private String createAuthToken(String tokenId, String accessToken) throws JOSEException {
+        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES384).keyID(consumerKey.getKeyID()).build();
+        var signedAuthToken = new SignedJWT(jwsHeader, getAuthTokenClaims(tokenId, accessToken).build());
+        signedAuthToken.sign(CryptoConverter.createSigner(consumerKey));
+        return signedAuthToken.serialize();
+    }
+
     private JWTClaimsSet.Builder getAuthTokenClaims(String tokenId, String accessToken) {
         return new JWTClaimsSet.Builder()
                 .jwtID(tokenId)
@@ -359,6 +457,36 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
             return jwt.getJWTClaimsSet().getClaims();
         } catch (ParseException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Clock that only moves when the test tells it to, so that token expiry can be exercised without waiting.
+     */
+    private static class MutableClock extends Clock {
+        private Instant instant;
+
+        MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        void advanceBy(Duration duration) {
+            instant = instant.plus(duration);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
         }
     }
 }

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplComponentTest.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplComponentTest.java
@@ -61,6 +61,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -432,6 +433,8 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
                 .issuer(CONSUMER_DID)
                 .subject(CONSUMER_DID)
                 .audience(PROVIDER_DID)
+                .issueTime(Date.from(clock.instant()))
+                .expirationTime(Date.from(clock.instant().plusSeconds(60)))
                 .claim("token", accessToken);
     }
 

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplComponentTest.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplComponentTest.java
@@ -315,6 +315,50 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
         assertThat(tokenResponse).isFailed().detail().isEqualTo("Authentication token validation failed: JWT signature not valid");
     }
 
+    @DisplayName("Verify that an authentication token without an expiry is rejected")
+    @Test
+    void refresh_whenAuthTokenHasNoExpiry_shouldFail() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        // without an expiry an intercepted refresh request could be replayed indefinitely
+        var claimsSet = new JWTClaimsSet.Builder()
+                .jwtID(tokenId)
+                .issuer(CONSUMER_DID)
+                .subject(CONSUMER_DID)
+                .audience(PROVIDER_DID)
+                .claim("token", edr.getToken())
+                .build();
+
+        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES384).keyID(consumerKey.getKeyID()).build();
+        var signedAuthToken = new SignedJWT(jwsHeader, claimsSet);
+        signedAuthToken.sign(CryptoConverter.createSigner(consumerKey));
+
+        assertThat(tokenRefreshService.refreshToken(edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString(), signedAuthToken.serialize()))
+                .isFailed()
+                .detail()
+                .contains("Required expiration time (exp) claim is missing in token");
+    }
+
+    @DisplayName("Verify that an expired authentication token is rejected")
+    @Test
+    void refresh_whenAuthTokenExpired_shouldFail() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        var authToken = createAuthToken(tokenId, edr.getToken());
+
+        // the authentication token outlives its own validity, e.g. because it was captured and replayed later
+        clock.advanceBy(Duration.ofSeconds(120));
+
+        assertThat(tokenRefreshService.refreshToken(edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString(), authToken))
+                .isFailed()
+                .detail()
+                .contains("Token has expired (exp)");
+    }
+
     @DisplayName("Verify that a refresh attempt fails if no \"token\" claim is present")
     @Test
     void refresh_whenNoAccessTokenClaim() throws JOSEException {

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/rules/RefreshTokenValidationRuleTest.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/rules/RefreshTokenValidationRuleTest.java
@@ -22,10 +22,12 @@ package org.eclipse.tractusx.edc.dataplane.tokenrefresh.core.rules;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.tractusx.edc.dataplane.tokenrefresh.core.RefreshToken;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.tractusx.edc.dataplane.tokenrefresh.core.TestFunctions.createAccessToken;
 import static org.mockito.Mockito.mock;
@@ -35,6 +37,7 @@ class RefreshTokenValidationRuleTest {
 
     private static final String TEST_TOKEN_ID = "test-jti";
     private static final String TEST_REFRESH_TOKEN = "test-refresh-token";
+    private static final String TEST_PREVIOUS_REFRESH_TOKEN = "test-previous-refresh-token";
     private final Vault vault = mock();
     private final String participantContextId = "participantContextId";
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
@@ -77,11 +80,12 @@ class RefreshTokenValidationRuleTest {
     }
 
     @Test
-    void checkRule_refreshTokenDoesNotMatch() {
+    void checkRule_refreshTokenDoesNotMatch_shouldNotFlagReplay() {
         when(vault.resolveSecret(participantContextId, TEST_TOKEN_ID)).thenReturn(
                 """
                         {
-                          "refreshToken": "someRefreshToken"
+                          "refreshToken": "someRefreshToken",
+                          "previousRefreshToken": "someOtherRefreshToken"
                         }
                         """);
 
@@ -89,19 +93,44 @@ class RefreshTokenValidationRuleTest {
                 .isFailed()
                 .detail()
                 .isEqualTo("Provided refresh token does not match the stored refresh token.");
+        assertThat(rule.replayedToken()).isNull();
     }
 
     @Test
-    void checkRule_success() {
+    void checkRule_success_currentTokenMatches_shouldNotFlagReplay() {
         when(vault.resolveSecret(participantContextId, TEST_TOKEN_ID)).thenReturn(
                 """
                         {
-                          "refreshToken": "%s"
+                          "refreshToken": "%s",
+                          "expiresIn": 3600,
+                          "refreshEndpoint": "http://foo.bar/refresh",
+                          "previousRefreshToken": "%s"
                         }
-                        """.formatted(TEST_REFRESH_TOKEN));
+                        """.formatted(TEST_REFRESH_TOKEN, TEST_PREVIOUS_REFRESH_TOKEN));
 
         assertThat(rule.checkRule(createAccessToken(TEST_TOKEN_ID), Map.of()))
                 .isSucceeded();
+        assertThat(rule.replayedToken()).isNull();
+    }
+
+    @Test
+    void checkRule_success_previousTokenMatches_shouldFlagReplay() {
+        when(vault.resolveSecret(participantContextId, TEST_TOKEN_ID)).thenReturn(
+                """
+                        {
+                          "refreshToken": "%s",
+                          "expiresIn": 3600,
+                          "refreshEndpoint": "http://foo.bar/refresh",
+                          "previousRefreshToken": "%s"
+                        }
+                        """.formatted(TEST_REFRESH_TOKEN, TEST_PREVIOUS_REFRESH_TOKEN));
+
+        var replayRule = new RefreshTokenValidationRule(vault, TEST_PREVIOUS_REFRESH_TOKEN, new ObjectMapper(), participantContext);
+
+        assertThat(replayRule.checkRule(createAccessToken(TEST_TOKEN_ID), Map.of()))
+                .isSucceeded();
+        assertThat(replayRule.replayedToken())
+                .isEqualTo(new RefreshToken(TEST_REFRESH_TOKEN, 3600L, "http://foo.bar/refresh", TEST_PREVIOUS_REFRESH_TOKEN));
     }
 
     @Test

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/runtimes/ParticipantRuntimeExtension.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/runtimes/ParticipantRuntimeExtension.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.iam.decentralizedclaims.spi.SecureTokenService;
 import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
 import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
+import org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames;
 import org.eclipse.edc.keys.spi.PrivateKeyResolver;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
@@ -42,6 +43,8 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.security.PrivateKey;
+import java.time.Instant;
+import java.util.Date;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -93,7 +96,10 @@ public class ParticipantRuntimeExtension extends RuntimePerClassExtension implem
                         @Override
                         public TokenParameters.Builder decorate(TokenParameters.Builder tokenParameters) {
                             claims.forEach(tokenParameters::claims);
-                            return tokenParameters;
+                            var now = Instant.now();
+                            return tokenParameters
+                                    .claims(JwtRegisteredClaimNames.ISSUED_AT, Date.from(now))
+                                    .claims(JwtRegisteredClaimNames.EXPIRATION_TIME, Date.from(now.plusSeconds(300)));
                         }
                     };
                     return jwtGenerationService.generate(participantContextId, privateAlias, new KeyIdDecorator(kid), decorator);

--- a/edc-tests/e2e/edc-dataplane-tokenrefresh-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/e2e/DataPlaneTokenRefreshEndToEndTest.java
+++ b/edc-tests/e2e/edc-dataplane-tokenrefresh-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/e2e/DataPlaneTokenRefreshEndToEndTest.java
@@ -315,6 +315,8 @@ public class DataPlaneTokenRefreshEndToEndTest {
                 .subject(CONSUMER_DID)
                 /* missing: .audience("did:web:bob")*/
                 .jwtID(getJwtId(accessToken))
+                .issueTime(Date.from(Instant.now()))
+                .expirationTime(Date.from(Instant.now().plusSeconds(60)))
                 .build();
         var authToken = createJwt(consumerKey, claims);
 
@@ -351,6 +353,8 @@ public class DataPlaneTokenRefreshEndToEndTest {
                 .subject(CONSUMER_DID)
                 .audience("did:web:bob")
                 .jwtID(tokenId)
+                .issueTime(Date.from(Instant.now()))
+                .expirationTime(Date.from(Instant.now().plusSeconds(60)))
                 .build();
 
         var authToken = createJwt(consumerKey, claims);

--- a/edc-tests/e2e/edc-dataplane-tokenrefresh-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/e2e/DataPlaneTokenRefreshEndToEndTest.java
+++ b/edc-tests/e2e/edc-dataplane-tokenrefresh-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/e2e/DataPlaneTokenRefreshEndToEndTest.java
@@ -53,6 +53,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.net.URI;
 import java.text.ParseException;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -278,6 +280,8 @@ public class DataPlaneTokenRefreshEndToEndTest {
                 .subject(CONSUMER_DID)
                 .audience("did:web:bob")
                 .jwtID(getJwtId(accessToken))
+                .issueTime(Date.from(Instant.now()))
+                .expirationTime(Date.from(Instant.now().plusSeconds(60)))
                 .build();
         var authToken = createJwt(consumerKey, claims);
 
@@ -377,6 +381,8 @@ public class DataPlaneTokenRefreshEndToEndTest {
                 .subject(CONSUMER_DID)
                 .audience("did:web:bob")
                 .jwtID(getJwtId(accessToken))
+                .issueTime(Date.from(Instant.now()))
+                .expirationTime(Date.from(Instant.now().plusSeconds(60)))
                 .build();
         return createJwt(signerKey, claims);
     }


### PR DESCRIPTION
## WHAT

Make token refresh recoverable when the refresh response does not reach the consumer

## WHY

The provider rotates the refresh token before the consumer can possibly have received it: the vault entry is overwritten and the previous token is rejected from then on. That is only safe if the response always arrives.  

The provider now retires a refresh token only once the consumer proves it received the replacement, by presenting it. Until then the superseded token is still accepted and returns the current one, so a lost    
  response costs a retry instead of the transfer.

Part of #3002
