### PR TITLE
feat: make refresh token recoverable

### DIFF
--- a/docs/development/decision-records/2026-08-10-refresh-token-retire-on-acknowledgement/README.md
+++ b/docs/development/decision-records/2026-08-10-refresh-token-retire-on-acknowledgement/README.md
@@ -1,0 +1,106 @@
+# Retire Refresh Tokens on Acknowledgement
+
+## Decision
+
+The provider data plane will retire a rotated refresh token only once the consumer has proven that it received the
+replacement. The proof of receipt is the consumer presenting the new refresh token. Until that happens, the token it
+replaced remains acceptable, and presenting it again returns the current refresh token — the one the consumer failed to
+receive — instead of rotating a second time. The access token is issued fresh on both paths.
+
+This is a behavioural change with no configuration surface and no way to opt out. There is nothing worth switching off:
+the old behaviour is the one that breaks transfers on a network timeout, and the new one costs one extra string in the
+vault record. The request and response formats are unchanged, so conforming consumers see no difference either way.
+
+## Rationale
+
+Token refresh as specified in the
+[Tractus-X Refresh Token Grant Profile](https://github.com/eclipse-tractusx/tractusx-profiles/blob/main/tx/refresh/refresh.token.grant.profile.md)
+and implemented per [2024-03-05_token_refresh](../2024-03-05_token_refresh/README.md) rotates the refresh token on every
+successful call. The implementation treated the moment of *issuing* a new token as the moment the old one dies: the
+vault entry was overwritten and the previous token was rejected from then on.
+
+That is only correct if the response always reaches the consumer, which is not a property an HTTP call has. Observed in
+production: a refresh takes longer than a proxy or ingress in front of the public API tolerates, the request is answered
+with HTTP 504, or the consumer cancels and the access log shows 499. The provider has rotated; the consumer still holds
+the old refresh token; it never saw the new one. Every subsequent refresh is answered with HTTP 401 because the token
+presented no longer matches the stored one. The transfer is permanently broken and can only be recovered by
+restarting the transfer process — for a failure mode that is a plain network timeout.
+
+The observation that resolves this is that **the acknowledgement already exists in the protocol**. A consumer that
+presents the new refresh token can only have obtained it from the response it is confirming. No extra message, no
+profile change, and no timer is needed — the provider simply defers retirement until it sees that evidence.
+
+The refresh token is sender-constrained: holding one does not authorise a refresh. Every request must also carry an
+authentication token signed with the key behind the consumer's DID and issued by the participant the EDR was issued to
+(`AuthTokenAudienceRule`), so an intercepted or leaked refresh token is unusable on its own, however often it is
+replayed. Retention changes how long the consumer's own copy stays valid, not who is able to use it.
+
+## Approach
+
+### Retained state
+
+`RefreshToken`, the record persisted in the vault under the access token's ID, gains a single component:
+
+```java
+public record RefreshToken(String refreshToken, Long expiresIn, String refreshEndpoint,
+                           @Nullable String previousRefreshToken) {
+}
+```
+
+`previousRefreshToken` is the token that `refreshToken` replaced. Entries written by earlier versions deserialize to
+`null` there and are treated as having no predecessor, so no migration of existing vault entries is required. The record
+additionally ignores unknown properties, so a further component could be added without breaking records already stored.
+
+The record holds refresh tokens only. The access token is never stored — every call mints a new one, whether it rotates
+the refresh token or serves a repeat, so a consumer retrying late still gets a usable access token.
+
+At most two generations of refresh token are live at any time, and the older one is retired by the very request that
+proves it is no longer needed.
+
+### Refresh flow
+
+`RefreshTokenValidationRule` keeps its place in the access token's validation chain and its single vault read, and is
+widened to accept the superseded token in addition to the current one. Deciding between the two outcomes needs to know
+*which* token matched, which a `Result<Void>` cannot express, so the rule exposes the resolved record through
+`replayedToken()` — non-null only in the superseded case. Instances are already created per refresh request, so this
+stays confined to one request.
+
+`DataPlaneTokenRefreshServiceImpl.refreshToken()` then branches on that single value when deciding what to pair the
+newly issued access token with:
+
+- `replayedToken()` is non-null — the consumer never saw the response that rotated its token, so it is given the current
+  refresh token from the stored record. Nothing is rotated and nothing is written. Rotating here would be worse than
+  useless: the provider cannot tell which of the two tokens the consumer ended up with, so it would strand the consumer
+  for good.
+- otherwise — the presented token is the current one, which is the acknowledgement. A new refresh token is issued and
+  stored, with the presented token recorded as the new `previousRefreshToken`.
+
+A token matching neither is still rejected by the rule, with the message unchanged, so client-visible behaviour and the
+existing end-to-end assertions are unaffected.
+
+## Further considerations
+
+**Security.** The superseded token stays usable for one extra generation, unbounded in time. That widens an existing
+window: a captured *complete* refresh request can be replayed for a generation longer, and without the 401 collision
+that makes such an intrusion visible. The authentication token must therefore carry an `exp` claim and is validated
+against it.
+
+**Standards conformance.** The behaviour stays within [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749). Section 6
+makes both halves of rotation optional — "The authorization server MAY issue a new refresh token […] The authorization
+server MAY revoke the old refresh token after issuing a new refresh token to the client." A new refresh token is issued
+and only the optional revocation is deferred, until the client has demonstrably received it, which is also what that
+sentence's "to the client" describes. Its three MUSTs are unaffected: client authentication is required, the refresh
+token is checked to have been issued to the authenticated client (`AuthTokenAudienceRule` together with the DID
+signature on the authentication token), and the refresh token is validated. Section 10.4 holds as well — both
+generations stay confidential in the vault, both are bound to the same client through the shared `AccessTokenData`, and
+refresh tokens remain unguessable provider-signed JWTs. What is given up is the detection property of
+strict single-use rotation: the first appearance of a superseded token no longer signals a possible compromise, because
+it is indistinguishable from the legitimate retry this decision exists to support.
+
+## NOTICE
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2026 Cofinity-X GmbH
+- Source URL: [https://github.com/eclipse-tractusx/tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc)

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImpl.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImpl.java
@@ -78,6 +78,7 @@ import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.EDR_PROPERTY_REFRES
 public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshService, DataPlaneAccessTokenService {
     public static final String ACCESS_TOKEN_CLAIM = "token";
     public static final String TOKEN_ID_CLAIM = "jti";
+    private static final long SLOW_PHASE_THRESHOLD_MS = 5000;
     private final long tokenExpirySeconds;
     private final List<TokenValidationRule> authenticationTokenValidationRules;
     private final ParticipantContextSupplier participantContextSupplier;
@@ -128,6 +129,7 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
                 new ClaimIsPresentRule(AUDIENCE), // we don't check the contents, only it is present
                 new ClaimIsPresentRule(ACCESS_TOKEN_CLAIM),
                 new ClaimIsPresentRule(TOKEN_ID_CLAIM),
+                new ExpirationIssuedAtValidationRule(clock, tokenExpiryToleranceSeconds, false),
                 new AuthTokenAudienceRule(accessTokenDataStore));
         this.participantContextSupplier = participantContextSupplier;
         accessTokenAuthorizationRules = List.of(new IssuerEqualsSubjectRule(),
@@ -146,7 +148,8 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
      *     <li>verify the token's signature</li>
      *     <li>assert {@code iss} and {@code sub} claims are identical</li>
      *     <li>assert the the token contains an {@code token} claim, and that the value is identical to the access token we have on record</li>
-     *     <li>assert that the {@code refreshToken} parameter is identical to the refresh token we have on record</li>
+     *     <li>assert that the {@code refreshToken} parameter is identical to the refresh token we have on record, or to
+     *     the one that record superseded</li>
      * </ul>
      *
      * @param refreshToken        The refresh token that was issued in the original/previous token request.
@@ -155,9 +158,11 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
     @Override
     public Result<TokenResponse> refreshToken(String refreshToken, String authenticationToken) {
 
-        authenticationToken = authenticationToken.replace("Bearer", "").trim();
+        var authToken = authenticationToken.replace("Bearer", "").trim();
 
-        var authTokenRes = tokenValidationService.validate(authenticationToken, publicKeyResolver, authenticationTokenValidationRules);
+        var authTokenRes = timed("validate-authentication-token [DID resolution]",
+                () -> tokenValidationService.validate(authToken,
+                        publicKeyResolver, authenticationTokenValidationRules));
         if (authTokenRes.failed()) {
             var msg = "Authentication token validation failed: %s".formatted(authTokenRes.getFailureDetail());
             monitor.debug(msg);
@@ -175,8 +180,10 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
         // 2. extract access token and validate it
         var accessToken = authTokenRes.getContent().getStringClaim("token");
         var refreshTokenValidationRule = new RefreshTokenValidationRule(vault, refreshToken, objectMapper, participantContext);
-        var accessTokenDataResult = tokenValidationService.validate(accessToken, localPublicKeyService, refreshTokenValidationRule)
-                .map(accessTokenClaims -> accessTokenDataStore.getById(accessTokenClaims.getStringClaim(JwtRegisteredClaimNames.JWT_ID)));
+
+        Result<AccessTokenData> accessTokenDataResult = timed("validate-access-token [Vault resolveSecret + store getById]",
+                () -> tokenValidationService.validate(accessToken, localPublicKeyService, refreshTokenValidationRule)
+                        .map(accessTokenClaims -> accessTokenDataStore.getById(accessTokenClaims.getStringClaim(JwtRegisteredClaimNames.JWT_ID))));
 
         if (accessTokenDataResult.failed()) {
             var msg = "Access token validation failed: %s".formatted(accessTokenDataResult.getFailureDetail());
@@ -191,7 +198,11 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
                 .build();
 
         var newAccessToken = createToken(newTokenParams).map(tr -> tr.tokenRepresentation().getToken());
-        var newRefreshToken = createToken(TokenParameters.Builder.newInstance().build()).map(tr -> tr.tokenRepresentation().getToken());
+
+        var replayed = refreshTokenValidationRule.replayedToken();
+        var newRefreshToken = replayed != null
+                ? ServiceResult.success(replayed.refreshToken())
+                : createToken(TokenParameters.Builder.newInstance().build()).map(tr -> tr.tokenRepresentation().getToken());
         if (newAccessToken.failed() || newRefreshToken.failed()) {
             var errors = new ArrayList<>(newAccessToken.getFailureMessages());
             errors.addAll(newRefreshToken.getFailureMessages());
@@ -200,13 +211,19 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
             return Result.failure(msg);
         }
 
-        storeRefreshToken(existingAccessTokenData.id(), new RefreshToken(newRefreshToken.getContent(), tokenExpirySeconds, refreshEndpoint), participantContext);
+        if (replayed != null) {
+            monitor.info("Refresh token for '%s' was already rotated, handing out the current one again.".formatted(existingAccessTokenData.id()));
+            return Result.success(new TokenResponse(newAccessToken.getContent(), newRefreshToken.getContent(), tokenExpirySeconds, tokenExpirySeconds, "bearer"));
+        }
+
+        timed("store-refresh-token [Vault storeSecret]",
+                () -> storeRefreshToken(existingAccessTokenData.id(), new RefreshToken(newRefreshToken.getContent(), tokenExpirySeconds, refreshEndpoint, refreshToken), participantContext));
 
         // the ClaimToken is created based solely on the TokenParameters. The additional information (refresh token...) is persisted separately
         var claimToken = ClaimToken.Builder.newInstance().claims(newTokenParams.getClaims()).build();
         var accessTokenData = new AccessTokenData(existingAccessTokenData.id(), claimToken, existingAccessTokenData.dataAddress(), existingAccessTokenData.additionalProperties());
 
-        var storeResult = accessTokenDataStore.update(accessTokenData);
+        var storeResult = timed("update-access-token [store update]", () -> accessTokenDataStore.update(accessTokenData));
 
         if (storeResult.failed()) {
             monitor.severe("Failed to store refreshed access token data: %s".formatted(storeResult.getFailureDetail()));
@@ -377,6 +394,24 @@ public class DataPlaneTokenRefreshServiceImpl implements DataPlaneTokenRefreshSe
             return Result.success(objectMapper.writeValueAsString(object));
         } catch (JsonProcessingException e) {
             return Result.failure(e.getMessage());
+        }
+    }
+
+    /**
+     * Executes the given action and records how long it took. Phases exceeding {@link #SLOW_PHASE_THRESHOLD_MS} are
+     * logged at DEBUG so that a slow/stalled external dependency (DID resolution, Vault, database) can be identified
+     * from the logs even when the overall request eventually completes.
+     */
+    private <T> T timed(String phase, Supplier<T> action) {
+        var start = System.nanoTime();
+        try {
+            return action.get();
+        } finally {
+            var elapsedMs = (System.nanoTime() - start) / 1_000_000;
+            var msg = "refreshToken phase '%s' took %d ms".formatted(phase, elapsedMs);
+            if (elapsedMs >= SLOW_PHASE_THRESHOLD_MS) {
+                monitor.debug(msg);
+            }
         }
     }
 

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/RefreshToken.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/RefreshToken.java
@@ -19,6 +19,14 @@
 
 package org.eclipse.tractusx.edc.dataplane.tokenrefresh.core;
 
-public record RefreshToken(String refreshToken, Long expiresIn, String refreshEndpoint) {
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.jetbrains.annotations.Nullable;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RefreshToken(String refreshToken, Long expiresIn, String refreshEndpoint,
+                           @Nullable String previousRefreshToken) {
+
+    public RefreshToken(String refreshToken, Long expiresIn, String refreshEndpoint) {
+        this(refreshToken, expiresIn, refreshEndpoint, null);
+    }
 }

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/rules/RefreshTokenValidationRule.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/main/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/rules/RefreshTokenValidationRule.java
@@ -39,12 +39,18 @@ import static org.eclipse.edc.spi.result.Result.success;
 /**
  * Validates that the refresh token information associated with a token's ID ({@code jti}), that is stored in the {@link Vault}
  * matches a refresh token string. The refresh token in question is passed into the CTor.
+ * <p>
+ * The token that the last refresh replaced is accepted as well: a client presenting it never received the response of
+ * that refresh, and retiring it before the client has proven receipt would strand the transfer for good. In that case
+ * {@link #replayedToken()} carries the stored record, so that the current refresh token can be handed out again
+ * instead of rotating a second time. Instances are therefore single-use, one per refresh request.
  */
 public class RefreshTokenValidationRule implements TokenValidationRule {
     private final Vault vault;
     private final String incomingRefreshToken;
     private final ObjectMapper objectMapper;
     private final ParticipantContext participantContext;
+    private RefreshToken replayedToken;
 
     public RefreshTokenValidationRule(Vault vault, String incomingRefreshToken, ObjectMapper objectMapper, ParticipantContext participantContext) {
         this.vault = vault;
@@ -62,9 +68,20 @@ public class RefreshTokenValidationRule implements TokenValidationRule {
             return failure("No refresh token with the ID '%s' was found in the vault.".formatted(tokenId));
         }
         return parse(storedRefreshTokenJson)
-                .compose(rt -> incomingRefreshToken.equals(rt.refreshToken()) ?
-                        success() :
-                        failure("Provided refresh token does not match the stored refresh token."));
+                .compose(rt -> {
+                    if (incomingRefreshToken.equals(rt.refreshToken())) {
+                        return success();
+                    }
+                    if (incomingRefreshToken.equals(rt.previousRefreshToken())) {
+                        replayedToken = rt;
+                        return success();
+                    }
+                    return failure("Provided refresh token does not match the stored refresh token.");
+                });
+    }
+
+    public @Nullable RefreshToken replayedToken() {
+        return replayedToken;
     }
 
     private Result<RefreshToken> parse(String storedRefreshTokenJson) {

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplComponentTest.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplComponentTest.java
@@ -312,7 +312,7 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
         signedAuthToken.sign(CryptoConverter.createSigner(consumerKey));
         var tokenResponse = tokenRefreshService.refreshToken(edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString(), signedAuthToken.serialize());
 
-        assertThat(tokenResponse).isFailed().detail().isEqualTo("Authentication token validation failed: JWT signature not valid");
+        assertThat(tokenResponse).isFailed().detail().isEqualTo("Authentication token validation failed: Token verification failed");
     }
 
 

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplComponentTest.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplComponentTest.java
@@ -57,7 +57,11 @@ import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -86,11 +90,13 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
     private final ParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(
             ParticipantContext.Builder.newInstance().participantContextId("participantContextId").identity("identity").build()
     );
+    private static final long TOKEN_EXPIRY_SECONDS = 300L;
     private DataPlaneTokenRefreshServiceImpl tokenRefreshService;
     private final InMemoryAccessTokenDataStore tokenDataStore = new InMemoryAccessTokenDataStore(CriterionOperatorRegistryImpl.ofDefaults());
     private final Monitor monitor = mock();
     private final InMemoryVault vault = new InMemoryVault(mock(), null);
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final MutableClock clock = new MutableClock(Instant.now());
     private ECKey consumerKey;
     private ECKey providerKey;
 
@@ -101,7 +107,7 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
         consumerKey = new ECKeyGenerator(Curve.P_384).keyID(CONSUMER_DID + "#consumer-key").keyUse(KeyUse.SIGNATURE).generate();
 
         when(monitor.withPrefix(anyString())).thenReturn(monitor);
-        tokenRefreshService = new DataPlaneTokenRefreshServiceImpl(Clock.systemUTC(),
+        tokenRefreshService = new DataPlaneTokenRefreshServiceImpl(clock,
                 new TokenValidationServiceImpl(),
                 didPkResolverMock,
                 localPublicKeyService,
@@ -111,7 +117,7 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
                 monitor,
                 TEST_REFRESH_ENDPOINT,
                 1,
-                300L,
+                TOKEN_EXPIRY_SECONDS,
                 () -> providerKey.getKeyID(),
                 vault,
                 objectMapper, participantContextSupplier);
@@ -177,6 +183,93 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
                 .doesNotContainKey("refreshToken");
     }
 
+    @DisplayName("Verify that a refresh whose response got lost can be repeated with the same refresh token")
+    @Test
+    void refresh_whenResponseWasLost_returnsCurrentRefreshTokenAndFreshAccessToken() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        var refreshToken = edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString();
+
+        // the client never sees this response, e.g. because a proxy in between timed out
+        var lostResponse = tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+        clock.advanceBy(Duration.ofSeconds(10));
+
+        // ...so it retries with the only refresh token it has, and gets the very same pair back
+        var retriedResponse = tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()));
+
+        assertThat(retriedResponse).withFailMessage(retriedResponse::getFailureDetail).isSucceeded()
+                // the refresh token is the one the client failed to receive, not a rotated one
+                .satisfies(tr -> assertThat(tr.refreshToken()).isEqualTo(lostResponse.refreshToken()))
+                // the access token is minted fresh, so the client gets a usable one however late it retries
+                .satisfies(tr -> assertThat(tokenRefreshService.resolve(tr.accessToken())).isSucceeded());
+    }
+
+    @DisplayName("Verify that the token pair handed out on a repeat can be refreshed again")
+    @Test
+    void refresh_afterRepeat_newTokenIsUsable() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        var refreshToken = edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString();
+
+        tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+        var repeated = tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+        var nextResponse = tokenRefreshService.refreshToken(repeated.refreshToken(), createAuthToken(tokenId, repeated.accessToken()));
+
+        assertThat(nextResponse).withFailMessage(nextResponse::getFailureDetail).isSucceeded()
+                .satisfies(tr -> assertThat(tr.refreshToken()).isNotEqualTo(repeated.refreshToken()));
+    }
+
+    @DisplayName("Verify that a rotated refresh token is rejected once the client proved it received the new one")
+    @Test
+    void refresh_whenSupersededTokenWasAcknowledged_shouldFail() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        var firstRefreshToken = edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString();
+        var second = tokenRefreshService.refreshToken(firstRefreshToken, createAuthToken(tokenId, edr.getToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+        // using the second token proves that the client received it, which retires the first one
+        tokenRefreshService.refreshToken(second.refreshToken(), createAuthToken(tokenId, second.accessToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+        assertThat(tokenRefreshService.refreshToken(firstRefreshToken, createAuthToken(tokenId, edr.getToken())))
+                .isFailed()
+                .detail()
+                .isEqualTo("Access token validation failed: Provided refresh token does not match the stored refresh token.");
+    }
+
+    @DisplayName("Verify that a rotated refresh token stays acceptable no matter how long the client takes to retry")
+    @Test
+    void refresh_whenResponseWasLostLongAgo_stillSucceeds() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        var refreshToken = edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString();
+        var lostResponse = tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+        // the client still has not proven receipt, so its only refresh token must remain usable - there is no window
+        // after which it is retired
+        clock.advanceBy(Duration.ofDays(1));
+
+        var retriedResponse = tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()));
+
+        assertThat(retriedResponse).withFailMessage(retriedResponse::getFailureDetail).isSucceeded()
+                .satisfies(tr -> assertThat(tr.refreshToken()).isEqualTo(lostResponse.refreshToken()));
+    }
+
     @DisplayName("Verify that a stolen refresh token cannot be used to refresh an access token")
     @Test
     void refresh_originalTokenWasIssuedToDifferentPrincipal() throws JOSEException {
@@ -197,8 +290,7 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
         signedAuthToken.sign(CryptoConverter.createSigner(consumerKey));
         var tokenResponse = tokenRefreshService.refreshToken(edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString(), signedAuthToken.serialize());
 
-        // todo: once the AuthTokenAudienceRule is re-enabled in the DataPlaneTokenRefreshServiceImpl the following assertion needs to be uncommented
-        // assertThat(tokenResponse).isFailed().detail().isEqualTo("Authentication token validation failed: Principal 'did:web:bob' is not authorized to refresh this token.");
+        assertThat(tokenResponse).isFailed().detail().isEqualTo("Authentication token validation failed: Principal 'did:web:bob' is not authorized to refresh this token.");
     }
 
     @DisplayName("Verify that a spoofed refresh attempt is rejected ")
@@ -220,7 +312,51 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
         signedAuthToken.sign(CryptoConverter.createSigner(consumerKey));
         var tokenResponse = tokenRefreshService.refreshToken(edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString(), signedAuthToken.serialize());
 
-        assertThat(tokenResponse).isFailed().detail().isEqualTo("Authentication token validation failed: Token verification failed");
+        assertThat(tokenResponse).isFailed().detail().isEqualTo("Authentication token validation failed: JWT signature not valid");
+    }
+
+    @DisplayName("Verify that an authentication token without an expiry is rejected")
+    @Test
+    void refresh_whenAuthTokenHasNoExpiry_shouldFail() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        // without an expiry an intercepted refresh request could be replayed indefinitely
+        var claimsSet = new JWTClaimsSet.Builder()
+                .jwtID(tokenId)
+                .issuer(CONSUMER_DID)
+                .subject(CONSUMER_DID)
+                .audience(PROVIDER_DID)
+                .claim("token", edr.getToken())
+                .build();
+
+        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES384).keyID(consumerKey.getKeyID()).build();
+        var signedAuthToken = new SignedJWT(jwsHeader, claimsSet);
+        signedAuthToken.sign(CryptoConverter.createSigner(consumerKey));
+
+        assertThat(tokenRefreshService.refreshToken(edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString(), signedAuthToken.serialize()))
+                .isFailed()
+                .detail()
+                .contains("Required expiration time (exp) claim is missing in token");
+    }
+
+    @DisplayName("Verify that an expired authentication token is rejected")
+    @Test
+    void refresh_whenAuthTokenExpired_shouldFail() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        var authToken = createAuthToken(tokenId, edr.getToken());
+
+        // the authentication token outlives its own validity, e.g. because it was captured and replayed later
+        clock.advanceBy(Duration.ofSeconds(120));
+
+        assertThat(tokenRefreshService.refreshToken(edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString(), authToken))
+                .isFailed()
+                .detail()
+                .contains("Token has expired (exp)");
     }
 
     @DisplayName("Verify that a refresh attempt fails if no \"token\" claim is present")
@@ -328,12 +464,21 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
         assertThat(vault.resolveSecret(tokenId)).isNull();
     }
 
+    private String createAuthToken(String tokenId, String accessToken) throws JOSEException {
+        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES384).keyID(consumerKey.getKeyID()).build();
+        var signedAuthToken = new SignedJWT(jwsHeader, getAuthTokenClaims(tokenId, accessToken).build());
+        signedAuthToken.sign(CryptoConverter.createSigner(consumerKey));
+        return signedAuthToken.serialize();
+    }
+
     private JWTClaimsSet.Builder getAuthTokenClaims(String tokenId, String accessToken) {
         return new JWTClaimsSet.Builder()
                 .jwtID(tokenId)
                 .issuer(CONSUMER_DID)
                 .subject(CONSUMER_DID)
                 .audience(PROVIDER_DID)
+                .issueTime(Date.from(clock.instant()))
+                .expirationTime(Date.from(clock.instant().plusSeconds(60)))
                 .claim("token", accessToken);
     }
 
@@ -359,6 +504,36 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
             return jwt.getJWTClaimsSet().getClaims();
         } catch (ParseException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Clock that only moves when the test tells it to, so that token expiry can be exercised without waiting.
+     */
+    private static class MutableClock extends Clock {
+        private Instant instant;
+
+        MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        void advanceBy(Duration duration) {
+            instant = instant.plus(duration);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
         }
     }
 }

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplComponentTest.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplComponentTest.java
@@ -315,49 +315,6 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
         assertThat(tokenResponse).isFailed().detail().isEqualTo("Authentication token validation failed: JWT signature not valid");
     }
 
-    @DisplayName("Verify that an authentication token without an expiry is rejected")
-    @Test
-    void refresh_whenAuthTokenHasNoExpiry_shouldFail() throws JOSEException {
-        var tokenId = "test-token-id";
-        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
-                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
-
-        // without an expiry an intercepted refresh request could be replayed indefinitely
-        var claimsSet = new JWTClaimsSet.Builder()
-                .jwtID(tokenId)
-                .issuer(CONSUMER_DID)
-                .subject(CONSUMER_DID)
-                .audience(PROVIDER_DID)
-                .claim("token", edr.getToken())
-                .build();
-
-        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES384).keyID(consumerKey.getKeyID()).build();
-        var signedAuthToken = new SignedJWT(jwsHeader, claimsSet);
-        signedAuthToken.sign(CryptoConverter.createSigner(consumerKey));
-
-        assertThat(tokenRefreshService.refreshToken(edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString(), signedAuthToken.serialize()))
-                .isFailed()
-                .detail()
-                .contains("Required expiration time (exp) claim is missing in token");
-    }
-
-    @DisplayName("Verify that an expired authentication token is rejected")
-    @Test
-    void refresh_whenAuthTokenExpired_shouldFail() throws JOSEException {
-        var tokenId = "test-token-id";
-        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
-                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
-
-        var authToken = createAuthToken(tokenId, edr.getToken());
-
-        // the authentication token outlives its own validity, e.g. because it was captured and replayed later
-        clock.advanceBy(Duration.ofSeconds(120));
-
-        assertThat(tokenRefreshService.refreshToken(edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString(), authToken))
-                .isFailed()
-                .detail()
-                .contains("Token has expired (exp)");
-    }
 
     @DisplayName("Verify that an authentication token without an expiry is rejected")
     @Test

--- a/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplComponentTest.java
+++ b/edc-extensions/dataplane/dataplane-token-refresh/token-refresh-core/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/core/DataPlaneTokenRefreshServiceImplComponentTest.java
@@ -57,7 +57,11 @@ import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -86,11 +90,13 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
     private final ParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(
             ParticipantContext.Builder.newInstance().participantContextId("participantContextId").identity("identity").build()
     );
+    private static final long TOKEN_EXPIRY_SECONDS = 300L;
     private DataPlaneTokenRefreshServiceImpl tokenRefreshService;
     private final InMemoryAccessTokenDataStore tokenDataStore = new InMemoryAccessTokenDataStore(CriterionOperatorRegistryImpl.ofDefaults());
     private final Monitor monitor = mock();
     private final InMemoryVault vault = new InMemoryVault(mock(), null);
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final MutableClock clock = new MutableClock(Instant.now());
     private ECKey consumerKey;
     private ECKey providerKey;
 
@@ -101,7 +107,7 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
         consumerKey = new ECKeyGenerator(Curve.P_384).keyID(CONSUMER_DID + "#consumer-key").keyUse(KeyUse.SIGNATURE).generate();
 
         when(monitor.withPrefix(anyString())).thenReturn(monitor);
-        tokenRefreshService = new DataPlaneTokenRefreshServiceImpl(Clock.systemUTC(),
+        tokenRefreshService = new DataPlaneTokenRefreshServiceImpl(clock,
                 new TokenValidationServiceImpl(),
                 didPkResolverMock,
                 localPublicKeyService,
@@ -111,7 +117,7 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
                 monitor,
                 TEST_REFRESH_ENDPOINT,
                 1,
-                300L,
+                TOKEN_EXPIRY_SECONDS,
                 () -> providerKey.getKeyID(),
                 vault,
                 objectMapper, participantContextSupplier);
@@ -177,6 +183,93 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
                 .doesNotContainKey("refreshToken");
     }
 
+    @DisplayName("Verify that a refresh whose response got lost can be repeated with the same refresh token")
+    @Test
+    void refresh_whenResponseWasLost_returnsCurrentRefreshTokenAndFreshAccessToken() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        var refreshToken = edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString();
+
+        // the client never sees this response, e.g. because a proxy in between timed out
+        var lostResponse = tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+        clock.advanceBy(Duration.ofSeconds(10));
+
+        // ...so it retries with the only refresh token it has, and gets the very same pair back
+        var retriedResponse = tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()));
+
+        assertThat(retriedResponse).withFailMessage(retriedResponse::getFailureDetail).isSucceeded()
+                // the refresh token is the one the client failed to receive, not a rotated one
+                .satisfies(tr -> assertThat(tr.refreshToken()).isEqualTo(lostResponse.refreshToken()))
+                // the access token is minted fresh, so the client gets a usable one however late it retries
+                .satisfies(tr -> assertThat(tokenRefreshService.resolve(tr.accessToken())).isSucceeded());
+    }
+
+    @DisplayName("Verify that the token pair handed out on a repeat can be refreshed again")
+    @Test
+    void refresh_afterRepeat_newTokenIsUsable() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        var refreshToken = edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString();
+
+        tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+        var repeated = tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+        var nextResponse = tokenRefreshService.refreshToken(repeated.refreshToken(), createAuthToken(tokenId, repeated.accessToken()));
+
+        assertThat(nextResponse).withFailMessage(nextResponse::getFailureDetail).isSucceeded()
+                .satisfies(tr -> assertThat(tr.refreshToken()).isNotEqualTo(repeated.refreshToken()));
+    }
+
+    @DisplayName("Verify that a rotated refresh token is rejected once the client proved it received the new one")
+    @Test
+    void refresh_whenSupersededTokenWasAcknowledged_shouldFail() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        var firstRefreshToken = edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString();
+        var second = tokenRefreshService.refreshToken(firstRefreshToken, createAuthToken(tokenId, edr.getToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+        // using the second token proves that the client received it, which retires the first one
+        tokenRefreshService.refreshToken(second.refreshToken(), createAuthToken(tokenId, second.accessToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+        assertThat(tokenRefreshService.refreshToken(firstRefreshToken, createAuthToken(tokenId, edr.getToken())))
+                .isFailed()
+                .detail()
+                .isEqualTo("Access token validation failed: Provided refresh token does not match the stored refresh token.");
+    }
+
+    @DisplayName("Verify that a rotated refresh token stays acceptable no matter how long the client takes to retry")
+    @Test
+    void refresh_whenResponseWasLostLongAgo_stillSucceeds() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        var refreshToken = edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString();
+        var lostResponse = tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()))
+                .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+        // the client still has not proven receipt, so its only refresh token must remain usable - there is no window
+        // after which it is retired
+        clock.advanceBy(Duration.ofDays(1));
+
+        var retriedResponse = tokenRefreshService.refreshToken(refreshToken, createAuthToken(tokenId, edr.getToken()));
+
+        assertThat(retriedResponse).withFailMessage(retriedResponse::getFailureDetail).isSucceeded()
+                .satisfies(tr -> assertThat(tr.refreshToken()).isEqualTo(lostResponse.refreshToken()));
+    }
+
     @DisplayName("Verify that a stolen refresh token cannot be used to refresh an access token")
     @Test
     void refresh_originalTokenWasIssuedToDifferentPrincipal() throws JOSEException {
@@ -197,8 +290,7 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
         signedAuthToken.sign(CryptoConverter.createSigner(consumerKey));
         var tokenResponse = tokenRefreshService.refreshToken(edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString(), signedAuthToken.serialize());
 
-        // todo: once the AuthTokenAudienceRule is re-enabled in the DataPlaneTokenRefreshServiceImpl the following assertion needs to be uncommented
-        // assertThat(tokenResponse).isFailed().detail().isEqualTo("Authentication token validation failed: Principal 'did:web:bob' is not authorized to refresh this token.");
+        assertThat(tokenResponse).isFailed().detail().isEqualTo("Authentication token validation failed: Principal 'did:web:bob' is not authorized to refresh this token.");
     }
 
     @DisplayName("Verify that a spoofed refresh attempt is rejected ")
@@ -221,6 +313,50 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
         var tokenResponse = tokenRefreshService.refreshToken(edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString(), signedAuthToken.serialize());
 
         assertThat(tokenResponse).isFailed().detail().isEqualTo("Authentication token validation failed: Token verification failed");
+    }
+
+    @DisplayName("Verify that an authentication token without an expiry is rejected")
+    @Test
+    void refresh_whenAuthTokenHasNoExpiry_shouldFail() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        // without an expiry an intercepted refresh request could be replayed indefinitely
+        var claimsSet = new JWTClaimsSet.Builder()
+                .jwtID(tokenId)
+                .issuer(CONSUMER_DID)
+                .subject(CONSUMER_DID)
+                .audience(PROVIDER_DID)
+                .claim("token", edr.getToken())
+                .build();
+
+        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES384).keyID(consumerKey.getKeyID()).build();
+        var signedAuthToken = new SignedJWT(jwsHeader, claimsSet);
+        signedAuthToken.sign(CryptoConverter.createSigner(consumerKey));
+
+        assertThat(tokenRefreshService.refreshToken(edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString(), signedAuthToken.serialize()))
+                .isFailed()
+                .detail()
+                .contains("Required expiration time (exp) claim is missing in token");
+    }
+
+    @DisplayName("Verify that an expired authentication token is rejected")
+    @Test
+    void refresh_whenAuthTokenExpired_shouldFail() throws JOSEException {
+        var tokenId = "test-token-id";
+        var edr = tokenRefreshService.obtainToken(tokenParams(tokenId), DataAddress.Builder.newInstance().type("test-type").build(), Map.of(AUDIENCE_PROPERTY, CONSUMER_DID))
+                .orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+
+        var authToken = createAuthToken(tokenId, edr.getToken());
+
+        // the authentication token outlives its own validity, e.g. because it was captured and replayed later
+        clock.advanceBy(Duration.ofSeconds(120));
+
+        assertThat(tokenRefreshService.refreshToken(edr.getAdditional().get(EDR_PROPERTY_REFRESH_TOKEN).toString(), authToken))
+                .isFailed()
+                .detail()
+                .contains("Token has expired (exp)");
     }
 
     @DisplayName("Verify that a refresh attempt fails if no \"token\" claim is present")
@@ -328,12 +464,21 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
         assertThat(vault.resolveSecret(tokenId)).isNull();
     }
 
+    private String createAuthToken(String tokenId, String accessToken) throws JOSEException {
+        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES384).keyID(consumerKey.getKeyID()).build();
+        var signedAuthToken = new SignedJWT(jwsHeader, getAuthTokenClaims(tokenId, accessToken).build());
+        signedAuthToken.sign(CryptoConverter.createSigner(consumerKey));
+        return signedAuthToken.serialize();
+    }
+
     private JWTClaimsSet.Builder getAuthTokenClaims(String tokenId, String accessToken) {
         return new JWTClaimsSet.Builder()
                 .jwtID(tokenId)
                 .issuer(CONSUMER_DID)
                 .subject(CONSUMER_DID)
                 .audience(PROVIDER_DID)
+                .issueTime(Date.from(clock.instant()))
+                .expirationTime(Date.from(clock.instant().plusSeconds(60)))
                 .claim("token", accessToken);
     }
 
@@ -359,6 +504,36 @@ class DataPlaneTokenRefreshServiceImplComponentTest {
             return jwt.getJWTClaimsSet().getClaims();
         } catch (ParseException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Clock that only moves when the test tells it to, so that token expiry can be exercised without waiting.
+     */
+    private static class MutableClock extends Clock {
+        private Instant instant;
+
+        MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        void advanceBy(Duration duration) {
+            instant = instant.plus(duration);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
         }
     }
 }

--- a/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/runtimes/ParticipantRuntimeExtension.java
+++ b/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/runtimes/ParticipantRuntimeExtension.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.iam.decentralizedclaims.spi.SecureTokenService;
 import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
 import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
+import org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames;
 import org.eclipse.edc.keys.spi.PrivateKeyResolver;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
@@ -42,6 +43,8 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.security.PrivateKey;
+import java.time.Instant;
+import java.util.Date;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -93,7 +96,10 @@ public class ParticipantRuntimeExtension extends RuntimePerClassExtension implem
                         @Override
                         public TokenParameters.Builder decorate(TokenParameters.Builder tokenParameters) {
                             claims.forEach(tokenParameters::claims);
-                            return tokenParameters;
+                            var now = Instant.now();
+                            return tokenParameters
+                                    .claims(JwtRegisteredClaimNames.ISSUED_AT, Date.from(now))
+                                    .claims(JwtRegisteredClaimNames.EXPIRATION_TIME, Date.from(now.plusSeconds(300)));
                         }
                     };
                     return jwtGenerationService.generate(participantContextId, privateAlias, new KeyIdDecorator(kid), decorator);

--- a/edc-tests/e2e/edc-dataplane-tokenrefresh-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/e2e/DataPlaneTokenRefreshEndToEndTest.java
+++ b/edc-tests/e2e/edc-dataplane-tokenrefresh-tests/src/test/java/org/eclipse/tractusx/edc/dataplane/tokenrefresh/e2e/DataPlaneTokenRefreshEndToEndTest.java
@@ -53,6 +53,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.net.URI;
 import java.text.ParseException;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -278,6 +280,8 @@ public class DataPlaneTokenRefreshEndToEndTest {
                 .subject(CONSUMER_DID)
                 .audience("did:web:bob")
                 .jwtID(getJwtId(accessToken))
+                .issueTime(Date.from(Instant.now()))
+                .expirationTime(Date.from(Instant.now().plusSeconds(60)))
                 .build();
         var authToken = createJwt(consumerKey, claims);
 
@@ -311,6 +315,8 @@ public class DataPlaneTokenRefreshEndToEndTest {
                 .subject(CONSUMER_DID)
                 /* missing: .audience("did:web:bob")*/
                 .jwtID(getJwtId(accessToken))
+                .issueTime(Date.from(Instant.now()))
+                .expirationTime(Date.from(Instant.now().plusSeconds(60)))
                 .build();
         var authToken = createJwt(consumerKey, claims);
 
@@ -347,6 +353,8 @@ public class DataPlaneTokenRefreshEndToEndTest {
                 .subject(CONSUMER_DID)
                 .audience("did:web:bob")
                 .jwtID(tokenId)
+                .issueTime(Date.from(Instant.now()))
+                .expirationTime(Date.from(Instant.now().plusSeconds(60)))
                 .build();
 
         var authToken = createJwt(consumerKey, claims);
@@ -377,6 +385,8 @@ public class DataPlaneTokenRefreshEndToEndTest {
                 .subject(CONSUMER_DID)
                 .audience("did:web:bob")
                 .jwtID(getJwtId(accessToken))
+                .issueTime(Date.from(Instant.now()))
+                .expirationTime(Date.from(Instant.now().plusSeconds(60)))
                 .build();
         return createJwt(signerKey, claims);
     }


### PR DESCRIPTION
## WHAT

Make token refresh recoverable when the refresh response does not reach the consumer

## WHY

The provider rotates the refresh token before the consumer can possibly have received it: the vault entry is overwritten and the previous token is rejected from then on. That is only safe if the response always arrives.

The provider now retires a refresh token only once the consumer proves it received the replacement, by presenting it. Until then the superseded token is still accepted and returns the current one, so a lost
response costs a retry instead of the transfer.

Closes #3002
