### PR TITLE
ci: run checkstyleTestFixtures in verify workflow

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -69,7 +69,7 @@ jobs:
       - uses: ./.github/actions/setup-java
       - name: Run Checkstyle
         run: |
-          ./gradlew checkstyleMain checkstyleTest
+          ./gradlew checkstyleMain checkstyleTest checkstyleTestFixtures
 
   verify-javadoc:
     permissions:


### PR DESCRIPTION
## WHAT

- Closes the Checkstyle blind spot for the testFixtures source set: "Run Checkstyle"
  invoked only `checkstyleMain` `checkstyleTest`.


## WHY

- The source set exists repo-wide (added in EDC 0.12.0 via java-test-fixtures) and is
  executed by every local `./gradlew build` through the static check lifecycle — but was
  unreachable in CI, whose hardcoded task list predates it. 
 That results in new clones using `./gradlew build` failing while CI stayed green.

## FURTHER NOTES

An alternative would be to switch this step to `./gradlew check -x test`, which skips test execution
  but covers all source sets. This way future sets can't be forgotten. 
  However, I'm not fully sure and it might produce other anomalies. Maybe a discussion for the future. 

Complements #3046
